### PR TITLE
feat(security): show firmware password status on Security tab

### DIFF
--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -358,14 +358,14 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                   {/* Code Integrity / Boot Debugging from health attestation if available */}
                   {(security?.healthAttestation || security?.health_attestation) && (
                     <>
-                      <DetailRow 
-                        label="Code Integrity" 
-                        isStatus 
-                        enabled={security?.healthAttestation?.codeIntegrityEnabled || security?.health_attestation?.code_integrity_enabled} 
+                      <DetailRow
+                        label="Code Integrity"
+                        isStatus
+                        enabled={security?.healthAttestation?.codeIntegrityEnabled || security?.health_attestation?.code_integrity_enabled}
                       />
-                      <DetailRow 
-                        label="Boot Debugging" 
-                        isStatus 
+                      <DetailRow
+                        label="Boot Debugging"
+                        isStatus
                         neutral
                         enabled={!(security?.healthAttestation?.bootDebuggingEnabled || security?.health_attestation?.boot_debugging_enabled)}
                         value={(security?.healthAttestation?.bootDebuggingEnabled || security?.health_attestation?.boot_debugging_enabled) ? 'Enabled' : 'Disabled'}
@@ -373,6 +373,53 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                     </>
                   )}
                 </div>
+
+                {/* Firmware Password — SMBIOS for all OEMs, augmented with Lenovo WMI bitmask */}
+                {security?.firmwarePassword && (
+                  <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
+                    <DetailRow
+                      label="Firmware Password"
+                      isStatus
+                      danger
+                      enabled={security.firmwarePassword.statusDisplay === 'Set'}
+                      activeLabel={security.firmwarePassword.statusDisplay || 'Set'}
+                      inactiveLabel={security.firmwarePassword.statusDisplay || 'Not Set'}
+                    />
+                    {security.firmwarePassword.adminPasswordSet !== null && security.firmwarePassword.adminPasswordSet !== undefined && (
+                      <DetailRow
+                        label="Admin / Supervisor"
+                        isStatus
+                        danger
+                        enabled={security.firmwarePassword.adminPasswordSet}
+                        activeLabel="Set"
+                        inactiveLabel="Not Set"
+                      />
+                    )}
+                    {security.firmwarePassword.powerOnPasswordSet !== null && security.firmwarePassword.powerOnPasswordSet !== undefined && (
+                      <DetailRow
+                        label="Power-on Password"
+                        isStatus
+                        neutral
+                        enabled={security.firmwarePassword.powerOnPasswordSet}
+                        activeLabel="Set"
+                        inactiveLabel="Not Set"
+                      />
+                    )}
+                    {security.firmwarePassword.hddPasswordSet !== null && security.firmwarePassword.hddPasswordSet !== undefined && (
+                      <DetailRow
+                        label="HDD Password"
+                        isStatus
+                        neutral
+                        enabled={security.firmwarePassword.hddPasswordSet}
+                        activeLabel="Set"
+                        inactiveLabel="Not Set"
+                      />
+                    )}
+                    {security.firmwarePassword.source && (
+                      <DetailRow label="Source" value={security.firmwarePassword.source} />
+                    )}
+                  </div>
+                )}
               </>
             )}
           </div>

--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -374,16 +374,23 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                   )}
                 </div>
 
-                {/* Firmware Password — SMBIOS for all OEMs, augmented with Lenovo WMI bitmask */}
+                {/* Firmware Password — SMBIOS for all OEMs, augmented with OEM-specific sources
+                    such as Lenovo WMI bitmask, Dell CIM, and HP CMI */}
                 {security?.firmwarePassword && (
                   <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
                     <DetailRow
                       label="Firmware Password"
                       isStatus
-                      danger
-                      enabled={security.firmwarePassword.statusDisplay === 'Set'}
+                      danger={security.firmwarePassword.statusDisplay === 'Not Set'}
+                      enabled={
+                        security.firmwarePassword.statusDisplay === 'Set'
+                          ? true
+                          : security.firmwarePassword.statusDisplay === 'Not Set'
+                            ? false
+                            : undefined
+                      }
                       activeLabel={security.firmwarePassword.statusDisplay || 'Set'}
-                      inactiveLabel={security.firmwarePassword.statusDisplay || 'Not Set'}
+                      inactiveLabel={security.firmwarePassword.statusDisplay || 'Unknown'}
                     />
                     {security.firmwarePassword.adminPasswordSet !== null && security.firmwarePassword.adminPasswordSet !== undefined && (
                       <DetailRow
@@ -399,7 +406,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                       <DetailRow
                         label="Power-on Password"
                         isStatus
-                        neutral
+                        danger
                         enabled={security.firmwarePassword.powerOnPasswordSet}
                         activeLabel="Set"
                         inactiveLabel="Not Set"
@@ -409,7 +416,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                       <DetailRow
                         label="HDD Password"
                         isStatus
-                        neutral
+                        danger
                         enabled={security.firmwarePassword.hddPasswordSet}
                         activeLabel="Set"
                         inactiveLabel="Not Set"


### PR DESCRIPTION
## Summary

Adds a **Firmware Password** subsection to the Windows Tampering card on `/device/[serialNumber]` Security tab, sitting below Secure Boot.

Reads `security.firmwarePassword` (new field populated by the Windows client — see paired PR in `reportmate-client-win`) and renders:

- Overall status — `Set` / `Not Set` / `Not Implemented` / `Unknown` — with `danger` styling when not set.
- Per-protection rows for **Admin / Supervisor**, **Power-on Password**, and **HDD Password**, only shown when the underlying value is non-null. On non-Lenovo systems this means you'll just see the overall SMBIOS-derived status.
- A **Source** row indicating where the data came from (`SMBIOS`, `Lenovo WMI`, `Dell CIM`, or `HP CMI`).

The block is gated on `security?.firmwarePassword` existing, so devices that haven't reported in with the new client just don't render it.

## Test plan

- [ ] Lenovo device with no firmware password — overall row shows "Not Set" in red, Admin/Power-on/HDD rows all show "Not Set", Source: "Lenovo WMI"
- [ ] Lenovo device with Supervisor password set — overall row shows "Set" in green, Admin row "Set"
- [ ] Dell / HP without OEM provider — overall row reflects SMBIOS value, no per-protection breakdown rendered, Source: "SMBIOS"
- [ ] Device that hasn't sent the new field yet — section is omitted entirely (no "Unknown" placeholder noise)