### PR TITLE
inventory: surface fleet field in widget and data model

### DIFF
--- a/src/components/widgets/Inventory.tsx
+++ b/src/components/widgets/Inventory.tsx
@@ -28,6 +28,7 @@ interface Device {
     assetTag?: string
     serialNumber?: string
     uuid?: string
+    fleet?: string
   }
   // Modular data from modules
   modules?: {
@@ -43,6 +44,7 @@ interface Device {
       serialNumber?: string
       serial_number?: string
       uuid?: string
+      fleet?: string
     }
   }
 }
@@ -57,7 +59,7 @@ export const InventoryWidget: React.FC<InventoryWidgetProps> = ({ device }) => {
   const inventory = rawInventory ? normalizeKeys(rawInventory) as any : {}
   
   // Check if we have any assignment details for the right column
-  const hasAssignmentDetails = inventory.usage || inventory.catalog || inventory.department || inventory.location
+  const hasAssignmentDetails = inventory.usage || inventory.catalog || inventory.department || inventory.location || inventory.fleet
   
   return (
     <StatBlock 
@@ -125,6 +127,11 @@ export const InventoryWidget: React.FC<InventoryWidgetProps> = ({ device }) => {
               {/* Location */}
               {inventory.location && (
                 <Stat label="Location" value={inventory.location} />
+              )}
+
+              {/* Fleet */}
+              {inventory.fleet && (
+                <Stat label="Fleet" value={inventory.fleet} />
               )}
             </div>
           )}

--- a/src/lib/data-processing/modules/inventory.ts
+++ b/src/lib/data-processing/modules/inventory.ts
@@ -15,6 +15,9 @@ export interface InventoryInfo {
   model?: string
   serialNumber?: string
   description?: string
+  fleet?: string
+  usage?: string
+  catalog?: string
 }
 
 /**
@@ -55,6 +58,9 @@ export function extractInventory(inventoryData: any): InventoryInfo {
   if (inventory.model) inventoryInfo.model = inventory.model
   if (serialNumber) inventoryInfo.serialNumber = serialNumber
   if (inventory.description) inventoryInfo.description = inventory.description
+  if (inventory.fleet) inventoryInfo.fleet = inventory.fleet
+  if (inventory.usage) inventoryInfo.usage = inventory.usage
+  if (inventory.catalog) inventoryInfo.catalog = inventory.catalog
 
     return inventoryInfo
 }


### PR DESCRIPTION
## Summary
- Adds `fleet` (plus `usage` and `catalog`) to the `InventoryInfo` TypeScript interface
- `extractInventory()` now extracts `fleet` from the inventory module data
- `InventoryWidget` shows a "Fleet" stat in the assignment column when the value is present
- `hasAssignmentDetails` guard updated to include `fleet` so the column renders when only fleet is set

## Test plan
- [ ] Open a device detail page for a device with a fleet set — verify "Fleet" row appears in the Inventory widget
- [ ] Open a device without a fleet — verify no "Fleet" row rendered
- [ ] Check installs page fleet filter still works as before