### PR TITLE
applications: rebuild report builder + report view around chip-cloud flow

### DIFF
--- a/app/api/devices/applications/filters/route.ts
+++ b/app/api/devices/applications/filters/route.ts
@@ -188,6 +188,7 @@ export async function GET(request: Request) {
       catalogs: data.catalogs || [],
       locations: data.locations || [],
       rooms: data.rooms || [],
+      areas: data.areas || [],
       fleets: data.fleets || [],
       devicesWithData: data.devicesWithData || 0
     }

--- a/app/api/devices/installs/route.ts
+++ b/app/api/devices/installs/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: Request) {
     const selectedCatalogs = searchParams.getAll('catalogs').map(c => c.toLowerCase());
     const selectedRooms = searchParams.getAll('rooms');
     const selectedFleets = searchParams.getAll('fleets');
+    const selectedAreas = searchParams.getAll('areas');
     const _selectedPlatforms = searchParams.getAll('platforms').map(p => p.toLowerCase());
     
         
@@ -128,16 +129,18 @@ export async function GET(request: Request) {
         const usage = parsedInventory?.usage || '';
         const catalog = parsedInventory?.catalog || '';
         const room = parsedInventory?.location || '';
-        const fleet = parsedInventory?.fleet || parsedInventory?.department || '';
+        const fleet = parsedInventory?.fleet || '';
+        const area = parsedInventory?.area || parsedInventory?.department || '';
         const assetTag = parsedInventory?.assetTag || '';
         const deviceName = parsedInventory?.deviceName || device.deviceName || device.serialNumber || 'Unknown Device';
-        
+
         // Apply inventory filters
         if (selectedUsages.length > 0 && !selectedUsages.includes(usage.toLowerCase())) continue;
         if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(catalog.toLowerCase())) continue;
         if (selectedRooms.length > 0 && !selectedRooms.includes(room)) continue;
         if (selectedFleets.length > 0 && !selectedFleets.includes(fleet)) continue;
-        
+        if (selectedAreas.length > 0 && !selectedAreas.includes(area)) continue;
+
         installRecords.push({
           id: `${device.serialNumber}-${item.id || item.itemName}`,
           deviceId: device.deviceId,
@@ -153,6 +156,8 @@ export async function GET(request: Request) {
           catalog,
           room,
           fleet,
+          area,
+          department: area,
           platform: (() => {
             const p = device.modules?.system?.operatingSystem?.platform || device.modules?.inventory?.platform || device.platform || '';
             if (p === 'Windows NT' || p.toLowerCase().includes('windows')) return 'Windows';

--- a/app/api/modules/identity/route.ts
+++ b/app/api/modules/identity/route.ts
@@ -116,8 +116,19 @@ export async function GET(request: Request) {
             isAdmin: u.isAdmin,
             lastLogon: u.lastLogon
           })),
-          
-          loggedInUsernames: item.loggedInUsernames || []
+
+          loggedInUsernames: item.loggedInUsernames || [],
+
+          // Inventory dimensions for the Selections accordion. FastAPI bulk
+          // endpoint returns these straight from inv.data; pass them through
+          // so the page's filter options aren't empty.
+          usage: item.usage || null,
+          catalog: item.catalog || null,
+          location: item.location || null,
+          room: item.room || null,
+          area: item.area || item.department || null,
+          department: item.department || null,
+          fleet: item.fleet || null,
         };
       }) : [];
       

--- a/app/devices/applications/coverage/page.tsx
+++ b/app/devices/applications/coverage/page.tsx
@@ -1,0 +1,341 @@
+"use client"
+
+export const dynamic = 'force-dynamic'
+
+import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { formatRelativeTime } from "../../../../src/lib/time"
+
+interface DarkDevice {
+  serialNumber: string
+  deviceName: string
+  platform: string | null
+  osName: string | null
+  lastSeen: string | null
+  usage: string | null
+  catalog: string | null
+  location: string | null
+  lastUsageDate: string | null
+  daysSinceUsage: number | null
+  totalHoursEver: number
+  rowCount: number
+  bucket: 'dark' | 'never'
+}
+
+interface CollectionHealth {
+  summary: {
+    totalDevices: number
+    healthy: number
+    stale: number
+    dark: number
+    never: number
+    freshDays: number
+    staleDays: number
+  }
+  byPlatform: Record<string, { healthy: number; stale: number; dark: number; never: number; total: number }>
+  darkDevices: DarkDevice[]
+}
+
+type SortColumn = 'bucket' | 'deviceName' | 'platform' | 'usage' | 'location' | 'lastSeen' | 'lastUsage' | 'daysDark'
+type SortDir = 'asc' | 'desc'
+
+export default function CoveragePage() {
+  const searchParams = useSearchParams()
+  const fromParam = searchParams.get('from')
+  const backHref = fromParam || '/devices/applications?type=usage'
+
+  const [data, setData] = useState<CollectionHealth | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<'all' | 'dark' | 'never'>('all')
+  const [platformFilter, setPlatformFilter] = useState<string>('all')
+  const [sortCol, setSortCol] = useState<SortColumn>('daysDark')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/devices/applications/collection-health?freshDays=7&staleDays=30')
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(d => {
+        if (cancelled) return
+        if (d.error) { setError(d.error); return }
+        setData({ summary: d.summary, byPlatform: d.byPlatform || {}, darkDevices: d.darkDevices || [] })
+      })
+      .catch(e => !cancelled && setError(e.message))
+    return () => { cancelled = true }
+  }, [])
+
+  const platforms = useMemo(() => {
+    if (!data) return []
+    return Object.keys(data.byPlatform).sort()
+  }, [data])
+
+  const rows = useMemo(() => {
+    if (!data) return []
+    let list = data.darkDevices
+    if (filter !== 'all') list = list.filter(d => d.bucket === filter)
+    if (platformFilter !== 'all') list = list.filter(d => (d.platform || 'Unknown') === platformFilter)
+    const dir = sortDir === 'asc' ? 1 : -1
+    return [...list].sort((a, b) => {
+      const cmp = (x: string | number | null, y: string | number | null) => {
+        if (x === null && y === null) return 0
+        if (x === null) return 1
+        if (y === null) return -1
+        if (typeof x === 'number' && typeof y === 'number') return x - y
+        return String(x).localeCompare(String(y))
+      }
+      switch (sortCol) {
+        case 'bucket':      return dir * cmp(a.bucket, b.bucket)
+        case 'deviceName':  return dir * cmp(a.deviceName || a.serialNumber, b.deviceName || b.serialNumber)
+        case 'platform':    return dir * cmp(a.platform, b.platform)
+        case 'usage':       return dir * cmp(a.usage, b.usage)
+        case 'location':    return dir * cmp(a.location, b.location)
+        case 'lastSeen':    return dir * cmp(a.lastSeen, b.lastSeen)
+        case 'lastUsage':   return dir * cmp(a.lastUsageDate, b.lastUsageDate)
+        case 'daysDark':    return dir * cmp(a.daysSinceUsage, b.daysSinceUsage)
+      }
+    })
+  }, [data, filter, platformFilter, sortCol, sortDir])
+
+  const toggleSort = (col: SortColumn) => {
+    if (sortCol === col) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    else { setSortCol(col); setSortDir(col === 'daysDark' ? 'desc' : 'asc') }
+  }
+
+  const exportCsv = () => {
+    if (!data) return
+    const header = ['Status','Serial','Device','Platform','OS','Usage','Catalog','Location','LastSeen','LastUsage','DaysSinceUsage','TotalHoursEver']
+    const escape = (v: unknown) => {
+      const s = v == null ? '' : String(v)
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+    }
+    const lines = [header.join(',')]
+    rows.forEach(r => lines.push([
+      r.bucket, r.serialNumber, r.deviceName, r.platform, r.osName,
+      r.usage, r.catalog, r.location, r.lastSeen, r.lastUsageDate,
+      r.daysSinceUsage, r.totalHoursEver
+    ].map(escape).join(',')))
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `usage-coverage-${new Date().toISOString().slice(0,10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const sortIndicator = (col: SortColumn) => {
+    if (sortCol !== col) return null
+    return (
+      <svg className={`w-3.5 h-3.5 inline-block ml-1 transition-transform ${sortDir === 'desc' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+      </svg>
+    )
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] bg-gray-50 dark:bg-black">
+      <div className="max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">
+
+        {/* Back link */}
+        <div className="mb-4">
+          <Link
+            href={backHref}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1"
+          >
+            ← {fromParam ? 'Back to Usage Report' : 'Applications'}
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-4">
+          <div className="flex items-start justify-between flex-wrap gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Usage Data Coverage</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                Per-device collection health for application usage telemetry. Devices in the <b>dark</b> and <b>never</b> buckets aren&rsquo;t contributing to fleet utilization numbers.
+              </p>
+            </div>
+            {data && (
+              <button
+                onClick={exportCsv}
+                className="px-3 py-1.5 text-sm bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-lg text-gray-900 dark:text-white font-medium"
+              >
+                Export CSV
+              </button>
+            )}
+          </div>
+
+          {/* Summary stats */}
+          {data && (
+            <div className="mt-5 grid grid-cols-2 md:grid-cols-5 gap-3">
+              <SummaryStat label="Total devices" value={data.summary.totalDevices} tone="neutral" />
+              <SummaryStat label={`Healthy (last ${data.summary.freshDays}d)`} value={data.summary.healthy} tone="ok" />
+              <SummaryStat label={`Stale (${data.summary.freshDays}–${data.summary.staleDays}d)`} value={data.summary.stale} tone="warn" />
+              <SummaryStat label={`Dark (>${data.summary.staleDays}d)`} value={data.summary.dark} tone="alert" />
+              <SummaryStat label="Never collected" value={data.summary.never} tone="critical" />
+            </div>
+          )}
+
+          {/* Per-platform breakdown */}
+          {data && Object.keys(data.byPlatform).length > 0 && (
+            <div className="mt-5">
+              <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">By platform</div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {Object.entries(data.byPlatform).sort().map(([plat, c]) => (
+                  <div key={plat} className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 text-sm">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-900 dark:text-white">{plat}</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">{c.total} devices</span>
+                    </div>
+                    <div className="mt-2 flex gap-3 text-xs">
+                      <span className="text-emerald-700 dark:text-emerald-400">✓ {c.healthy}</span>
+                      <span className="text-yellow-700 dark:text-yellow-400">◐ {c.stale}</span>
+                      <span className="text-orange-700 dark:text-orange-400">● {c.dark}</span>
+                      <span className="text-red-700 dark:text-red-400">✗ {c.never}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 px-6 py-4 mb-4 flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2 text-sm">
+            <label className="text-gray-600 dark:text-gray-400">Bucket:</label>
+            <select
+              value={filter}
+              onChange={e => setFilter(e.target.value as 'all' | 'dark' | 'never')}
+              className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            >
+              <option value="all">All non-healthy</option>
+              <option value="dark">Dark only</option>
+              <option value="never">Never only</option>
+            </select>
+          </div>
+          {platforms.length > 0 && (
+            <div className="flex items-center gap-2 text-sm">
+              <label className="text-gray-600 dark:text-gray-400">Platform:</label>
+              <select
+                value={platformFilter}
+                onChange={e => setPlatformFilter(e.target.value)}
+                className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              >
+                <option value="all">All</option>
+                {platforms.map(p => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </div>
+          )}
+          <div className="text-sm text-gray-500 dark:text-gray-400 ml-auto">
+            {data ? `${rows.length} of ${data.darkDevices.length} devices` : ''}
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+          {error && (
+            <div className="p-6 text-center text-red-600 dark:text-red-400 text-sm">{error}</div>
+          )}
+          {!error && !data && (
+            <div className="p-6 text-center text-gray-500 dark:text-gray-400 text-sm">Loading…</div>
+          )}
+          {data && rows.length === 0 && (
+            <div className="p-8 text-center text-gray-500 dark:text-gray-400 text-sm">
+              No devices match the current filter.
+            </div>
+          )}
+          {data && rows.length > 0 && (
+            <div className="overflow-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-900/50 text-gray-700 dark:text-gray-300">
+                  <tr>
+                    <Th col="bucket" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Status</Th>
+                    <Th col="deviceName" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Device</Th>
+                    <Th col="platform" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Platform</Th>
+                    <Th col="usage" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Usage</Th>
+                    <Th col="location" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Location</Th>
+                    <Th col="lastSeen" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Last seen</Th>
+                    <Th col="lastUsage" onClick={toggleSort} active={sortCol} indicator={sortIndicator}>Last usage</Th>
+                    <Th col="daysDark" onClick={toggleSort} active={sortCol} indicator={sortIndicator} align="right">Days dark</Th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {rows.map(dev => (
+                    <tr key={dev.serialNumber} className="hover:bg-gray-50 dark:hover:bg-gray-900/40">
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-semibold uppercase ${
+                          dev.bucket === 'never'
+                            ? 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'
+                            : 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200'
+                        }`}>
+                          {dev.bucket}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link href={`/device/${dev.serialNumber}`} className="font-medium text-blue-600 dark:text-blue-400 hover:underline">
+                          {dev.deviceName || dev.serialNumber}
+                        </Link>
+                        <div className="text-[11px] text-gray-500 dark:text-gray-500 font-mono">{dev.serialNumber}</div>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300">{dev.platform || '—'}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300">{dev.usage || '—'}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300">{dev.location || '—'}</td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300" suppressHydrationWarning>
+                        {dev.lastSeen ? formatRelativeTime(dev.lastSeen) : '—'}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-gray-700 dark:text-gray-300">
+                        {dev.lastUsageDate || 'never'}
+                      </td>
+                      <td className="px-4 py-3 text-right whitespace-nowrap text-gray-700 dark:text-gray-300 font-mono">
+                        {dev.daysSinceUsage !== null ? `${dev.daysSinceUsage}d` : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SummaryStat({ label, value, tone }: { label: string; value: number; tone: 'neutral' | 'ok' | 'warn' | 'alert' | 'critical' }) {
+  const colors = {
+    neutral:  'text-gray-900 dark:text-white',
+    ok:       'text-emerald-700 dark:text-emerald-400',
+    warn:     'text-yellow-700 dark:text-yellow-400',
+    alert:    'text-orange-700 dark:text-orange-400',
+    critical: 'text-red-700 dark:text-red-400',
+  }[tone]
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+      <div className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</div>
+      <div className={`text-2xl font-semibold mt-1 ${colors}`}>{value.toLocaleString()}</div>
+    </div>
+  )
+}
+
+function Th({
+  col, onClick, active, indicator, align = 'left', children,
+}: {
+  col: SortColumn
+  onClick: (c: SortColumn) => void
+  active: SortColumn
+  indicator: (c: SortColumn) => React.ReactNode
+  align?: 'left' | 'right'
+  children: React.ReactNode
+}) {
+  return (
+    <th
+      className={`px-4 py-3 ${align === 'right' ? 'text-right' : 'text-left'} text-xs font-semibold uppercase tracking-wider cursor-pointer select-none hover:bg-blue-100 dark:hover:bg-blue-900/40 ${active === col ? 'bg-blue-50 dark:bg-blue-900/30' : ''}`}
+      onClick={() => onClick(col)}
+    >
+      {children}
+      {indicator(col)}
+    </th>
+  )
+}

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -2115,30 +2115,6 @@ function ApplicationsPageContent() {
                     </div>
                   </div>
 
-                  {/* Area Filter - Only show if areas exist */}
-                  {filterOptions.areas.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {filterOptions.areas.map(area => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-2 py-1 text-xs rounded-full border ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
                   {/* Fleet Filter - Only show if fleets exist */}
                   {filterOptions.fleets.length > 0 && (
                   <div>
@@ -2164,6 +2140,32 @@ function ApplicationsPageContent() {
                   )}
 
                 </div>
+
+                {/* Area Filter - Full width row above Locations */}
+                {filterOptions.areas.length > 0 && (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
+                    </h3>
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {filterOptions.areas.map(area => (
+                      <button
+                        key={area}
+                        onClick={() => toggleArea(area)}
+                        className={`px-2 py-1 text-xs rounded-full border ${
+                          selectedAreas.includes(area)
+                            ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
+                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
+                        }`}
+                      >
+                        {area}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                )}
 
                 {/* Locations Filter Cloud - Full Width */}
                 <div>

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -128,6 +128,7 @@ interface DeviceAggregate {
   catalog: string | null
   location: string | null
   department: string | null
+  area: string | null
   fleet: string | null
   totalSeconds: number
   totalHours: number
@@ -701,16 +702,25 @@ function ApplicationsPageContent() {
   // and usage endpoints accept a server-side platform filter; for versions the
   // client-side filter already scopes the table, so an extra refetch keeps
   // device-set assumptions (which apps belong to which platform) tight.
+  //
+  // Track the platform that produced the currently-loaded report so a flip
+  // during an in-flight request isn't dropped — once the request settles and
+  // `loading` clears, the effect runs again, notices the mismatch, and
+  // re-fetches.
+  const reportPlatformRef = useRef<string | null>(null)
   useEffect(() => {
     if (!hydratedRef.current) return
+    if (!reportType) return
     if (loading) return
+    if (reportPlatformRef.current === platformFilter) return
+    reportPlatformRef.current = platformFilter
     if (reportType === 'usage') {
       handleLoadUtilization()
     } else if (reportType === 'versions') {
       handleLoadVersionsReport()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [platformFilter])
+  }, [platformFilter, loading, reportType])
 
   // Sync state → URL whenever selections, period, reportType, or reportMode
   // change. Skipped during hydration to avoid clobbering the incoming URL.
@@ -1069,6 +1079,11 @@ function ApplicationsPageContent() {
   const handleLoadUtilization = async (daysOverride?: number | React.MouseEvent) => {
     // Handle case where MouseEvent is passed from button onClick
     const effectiveDays = typeof daysOverride === 'number' ? daysOverride : utilizationDays
+    // Capture the platform value at the moment of fetch so the
+    // refetch-on-platform-change effect compares against what THIS fetch
+    // actually queried, not whatever platform the user may have flipped to
+    // mid-flight.
+    const fetchPlatform = platformFilter
     try {
       setLoading(true)
       setError(null)
@@ -1172,6 +1187,11 @@ function ApplicationsPageContent() {
         setError(data.message || 'Usage tracking not yet deployed')
         setUtilizationData(null)
       } else {
+        // Pin the platform the data was fetched for so the refetch-on-platform
+        // effect doesn't see a stale ref and re-trigger immediately after this
+        // load completes. Use the captured fetchPlatform (not current
+        // platformFilter) in case the user flipped while the fetch was in flight.
+        reportPlatformRef.current = fetchPlatform
         setUtilizationData(data)
         setReportType('usage')
         setWidgetsExpanded(true)
@@ -1207,6 +1227,7 @@ function ApplicationsPageContent() {
 
   // Load versions-only report (inventory data with version distribution, no usage analytics)
   const handleLoadVersionsReport = async () => {
+    const fetchPlatform = platformFilter
     try {
       setLoading(true)
       setError(null)
@@ -1252,6 +1273,9 @@ function ApplicationsPageContent() {
       const inventoryData = await inventoryResponse.json()
       
       if (Array.isArray(inventoryData)) {
+        // Pin the platform the data was fetched for so the refetch-on-platform
+        // effect doesn't fire immediately after this load completes.
+        reportPlatformRef.current = fetchPlatform
         setApplications(inventoryData)
         setReportType('versions')
         setSelectionsExpanded(false)
@@ -1557,6 +1581,7 @@ function ApplicationsPageContent() {
     setSelectedCatalogs([])
     setSelectedRooms([])
     setSelectedFleets([])
+    setSelectedAreas([])
     setSelectedVersions([])
     setSearchQuery('')
     // Don't clear applications data - just clear error state
@@ -1574,6 +1599,7 @@ function ApplicationsPageContent() {
     setSelectedLocations([])
     setSelectedRooms([])
     setSelectedFleets([])
+    setSelectedAreas([])
     setSelectedVersions([])
     setSearchQuery('')
     setError(null)
@@ -1732,7 +1758,7 @@ function ApplicationsPageContent() {
     const byLocation = sumBy(d => d.location).slice(0, 10)
     const byCatalog = sumBy(d => d.catalog)
     const byUsage = sumBy(d => d.usage)
-    const byArea = sumBy(d => d.department).slice(0, 10)
+    const byArea = sumBy(d => d.area || d.department).slice(0, 10)
     const byFleet = sumBy(d => d.fleet)
 
     const binDefs = widgetMetric === 'hours'
@@ -2267,7 +2293,7 @@ function ApplicationsPageContent() {
                 onLocationToggle={toggleRoom}
                 onFleetToggle={toggleFleet}
                 onUsageToggle={(u) => toggleUsage(u.toLowerCase())}
-                onClearAll={() => { /* page-specific clear handled elsewhere */ }}
+                onClearAll={clearAllFilters}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
                 locationCounts={locCounts}
@@ -3520,8 +3546,8 @@ function ApplicationsPageContent() {
                             bVal = b.catalog || ''
                             break
                           case 'area':
-                            aVal = a.department || ''
-                            bVal = b.department || ''
+                            aVal = (a as any).area || a.department || ''
+                            bVal = (b as any).area || b.department || ''
                             break
                           case 'location':
                             aVal = a.location || ''

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -36,6 +36,8 @@ interface ApplicationItem {
   location?: string
   room?: string
   fleet?: string
+  department?: string
+  area?: string
   assetTag?: string
   platform?: string
   raw?: any
@@ -160,6 +162,7 @@ interface FilterOptions {
   catalogs: string[]
   rooms: string[]
   fleets: string[]
+  areas: string[]
   locations: string[]
   devicesWithData: number
 }
@@ -410,6 +413,7 @@ function ApplicationsPageContent() {
     catalogs: [],
     rooms: [],
     fleets: [],
+    areas: [],
     locations: [],
     devicesWithData: 0
   })
@@ -467,6 +471,7 @@ function ApplicationsPageContent() {
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
   const [selectedRooms, setSelectedRooms] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedVersions, setSelectedVersions] = useState<string[]>([])
   
   // Track last applied filters to detect changes
@@ -513,6 +518,7 @@ function ApplicationsPageContent() {
       const rooms = getList('rooms')
       if (legacyRoom && !rooms.includes(legacyRoom)) rooms.push(legacyRoom)
       const fleets = getList('fleets')
+      const areas = getList('areas')
       const versions = getList('versions')
 
       const q = sp.get('q') ?? legacySearch
@@ -527,6 +533,7 @@ function ApplicationsPageContent() {
       if (locations.length) setSelectedLocations(locations)
       if (rooms.length) setSelectedRooms(rooms)
       if (fleets.length) setSelectedFleets(fleets)
+      if (areas.length) setSelectedAreas(areas)
       if (versions.length) setSelectedVersions(versions)
       if (period) {
         const n = parseInt(period, 10)
@@ -554,7 +561,7 @@ function ApplicationsPageContent() {
       const hasFilterParams =
         apps.length > 0 || usages.length > 0 || catalogs.length > 0 ||
         locations.length > 0 || rooms.length > 0 || fleets.length > 0 ||
-        versions.length > 0 || !!type || !!mode
+        areas.length > 0 || versions.length > 0 || !!type || !!mode
       if (hasFilterParams) {
         setFiltersExpanded(false)
       }
@@ -602,6 +609,7 @@ function ApplicationsPageContent() {
       if (selectedLocations.length) params.set('locations', selectedLocations.join(','))
       if (selectedRooms.length) params.set('rooms', selectedRooms.join(','))
       if (selectedFleets.length) params.set('fleets', selectedFleets.join(','))
+      if (selectedAreas.length) params.set('areas', selectedAreas.join(','))
       if (selectedVersions.length) params.set('versions', selectedVersions.join(','))
 
       const qs = params.toString()
@@ -627,7 +635,7 @@ function ApplicationsPageContent() {
   }, [
     reportType, reportMode, utilizationDays, searchQuery,
     selectedApplications, selectedUsages, selectedCatalogs,
-    selectedLocations, selectedRooms, selectedFleets, selectedVersions,
+    selectedLocations, selectedRooms, selectedFleets, selectedAreas, selectedVersions,
   ])
 
   // Load ALL applications data on mount with progressive loading
@@ -658,6 +666,7 @@ function ApplicationsPageContent() {
               locations: data.locations || [],
               rooms: data.rooms || [],
               fleets: data.fleets || [],
+              areas: data.areas || [],
               devicesWithData: data.devices?.length || 0
             })
             
@@ -785,8 +794,9 @@ function ApplicationsPageContent() {
         const locations = data.locations || []
         const rooms = data.rooms || []
         const fleets = data.fleets || []
-        
-        
+        const areas = data.areas || []
+
+
         setFilterOptions({
           applicationNames: data.applicationNames || [],
           windowsApplicationNames: data.windowsApplicationNames,
@@ -796,6 +806,7 @@ function ApplicationsPageContent() {
           locations,
           rooms,
           fleets,
+          areas,
           devicesWithData: actualDeviceCount
         })
         
@@ -911,7 +922,8 @@ function ApplicationsPageContent() {
           catalogs: selectedCatalogs,
           locations: selectedLocations,
           rooms: selectedRooms,
-          fleets: selectedFleets
+          fleets: selectedFleets,
+          areas: selectedAreas
         })
         setLastAppliedFilters(currentFilters)
       } else {
@@ -1209,8 +1221,9 @@ function ApplicationsPageContent() {
         app.room?.toLowerCase().includes(room.toLowerCase())
       )
     const matchesFleets = selectedFleets.length === 0 || selectedFleets.includes(app.fleet || '')
-    
-    return matchesSearch && matchesUsages && matchesCatalogs && matchesLocations && matchesRooms && matchesFleets
+    const matchesAreas = selectedAreas.length === 0 || selectedAreas.includes((app.department || '') as string)
+
+    return matchesSearch && matchesUsages && matchesCatalogs && matchesLocations && matchesRooms && matchesFleets && matchesAreas
   })
 
   // Filter applications for display (includes version filter for table)
@@ -1313,8 +1326,14 @@ function ApplicationsPageContent() {
   }
 
   const toggleFleet = (fleet: string) => {
-    setSelectedFleets(prev => 
+    setSelectedFleets(prev =>
       prev.includes(fleet) ? prev.filter(f => f !== fleet) : [...prev, fleet]
+    )
+  }
+
+  const toggleArea = (area: string) => {
+    setSelectedAreas(prev =>
+      prev.includes(area) ? prev.filter(a => a !== area) : [...prev, area]
     )
   }
 
@@ -1625,7 +1644,7 @@ function ApplicationsPageContent() {
                 )}
 
                 {/* Clear All Selections Button - Show when selections are active and NO report loaded */}
-                {(selectedApplications.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0) && 
+                {(selectedApplications.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0) && 
                  !loading && 
                  !reportType && (
                   <button
@@ -1986,9 +2005,9 @@ function ApplicationsPageContent() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                   <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-                    Selections {(selectedApplications.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0) && (
+                    Selections {(selectedApplications.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0) && (
                       <span className="ml-2 text-blue-600 dark:text-blue-400">
-                        ({[selectedApplications, selectedUsages, selectedCatalogs, selectedLocations, selectedRooms, selectedFleets].reduce((sum, arr) => sum + arr.length, 0)} active)
+                        ({[selectedApplications, selectedUsages, selectedCatalogs, selectedLocations, selectedRooms, selectedFleets, selectedAreas].reduce((sum, arr) => sum + arr.length, 0)} active)
                       </span>
                     )}
                   </h3>
@@ -2096,6 +2115,30 @@ function ApplicationsPageContent() {
                     </div>
                   </div>
 
+                  {/* Area Filter - Only show if areas exist */}
+                  {filterOptions.areas.length > 0 && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
+                    </h3>
+                    <div className="flex flex-wrap gap-1">
+                      {filterOptions.areas.map(area => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-2 py-1 text-xs rounded-full border ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
+                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
+                          }`}
+                        >
+                          {area}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  )}
+
                   {/* Fleet Filter - Only show if fleets exist */}
                   {filterOptions.fleets.length > 0 && (
                   <div>
@@ -2109,7 +2152,7 @@ function ApplicationsPageContent() {
                           onClick={() => toggleFleet(fleet)}
                           className={`px-2 py-1 text-xs rounded-full border ${
                             selectedFleets.includes(fleet)
-                              ? 'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-900 dark:text-orange-200 dark:border-orange-600'
+                              ? 'bg-indigo-100 text-indigo-800 border-indigo-300 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-600'
                               : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
                           }`}
                         >

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -421,30 +421,6 @@ function ApplicationsPageContent() {
   const [utilizationSortColumn, setUtilizationSortColumn] = useState<'name' | 'totalHours' | 'launchCount' | 'deviceCount' | 'userCount' | 'lastUsed'>('totalHours')
   const [utilizationSortDirection, setUtilizationSortDirection] = useState<'asc' | 'desc'>('desc')
   
-  // Collection health (audit-readiness): per-device coverage of application
-  // usage data. Surfaces "dark" devices that aren't collecting so the fleet
-  // utilization numbers can be defended.
-  const [collectionHealth, setCollectionHealth] = useState<{
-    summary: { totalDevices: number; healthy: number; stale: number; dark: number; never: number; freshDays: number; staleDays: number }
-    byPlatform: Record<string, { healthy: number; stale: number; dark: number; never: number; total: number }>
-    darkDevices: Array<{
-      serialNumber: string
-      deviceName: string
-      platform: string | null
-      osName: string | null
-      lastSeen: string | null
-      usage: string | null
-      catalog: string | null
-      location: string | null
-      lastUsageDate: string | null
-      daysSinceUsage: number | null
-      totalHoursEver: number
-      rowCount: number
-      bucket: 'dark' | 'never'
-    }>
-  } | null>(null)
-  const [collectionHealthExpanded, setCollectionHealthExpanded] = useState(false)
-
   // Report type: 'usage' for full usage analytics, 'versions' for version distribution only
   const [reportType, setReportType] = useState<'usage' | 'versions' | null>(null)
   
@@ -491,25 +467,6 @@ function ApplicationsPageContent() {
   const [linkCopied, setLinkCopied] = useState(false)
 
   // Hydrate state from URL once on mount. See URL_STATE_CONVENTIONS.md for the
-  // Collection health: fetched once on mount, independent of report state.
-  // Surfaces fleet-wide audit readiness so dark devices show up before the
-  // user runs any report.
-  useEffect(() => {
-    let cancelled = false
-    fetch('/api/devices/applications/collection-health?freshDays=7&staleDays=30')
-      .then(r => r.ok ? r.json() : null)
-      .then(data => {
-        if (cancelled || !data || data.error) return
-        setCollectionHealth({
-          summary: data.summary,
-          byPlatform: data.byPlatform || {},
-          darkDevices: data.darkDevices || [],
-        })
-      })
-      .catch(() => { /* non-fatal */ })
-    return () => { cancelled = true }
-  }, [])
-
   // param contract. Auto-triggers a report load if `type` is in the URL so deep
   // links like ?type=usage&period=30&apps=Houdini render the report directly.
   useEffect(() => {
@@ -1559,110 +1516,6 @@ function ApplicationsPageContent() {
     <div className="h-[calc(100vh-4rem)] bg-gray-50 dark:bg-black flex flex-col overflow-hidden">
       {/* Main Content */}
       <div className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 pb-4 sm:pb-8 pt-4 sm:pt-8 flex flex-col min-h-0">
-        {/* Collection-health banner: surfaces "dark" devices that aren't reporting
-            application usage data, so utilization numbers can be defended. */}
-        {collectionHealth && collectionHealth.summary.totalDevices > 0 && (() => {
-          const s = collectionHealth.summary
-          const darkTotal = s.dark + s.never
-          const pct = s.totalDevices ? Math.round((darkTotal / s.totalDevices) * 100) : 0
-          const severity =
-            darkTotal === 0 ? 'ok' :
-            pct < 5 ? 'low' :
-            pct < 20 ? 'medium' : 'high'
-          const tone = {
-            ok:     'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800 text-emerald-900 dark:text-emerald-100',
-            low:    'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800 text-yellow-900 dark:text-yellow-100',
-            medium: 'bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800 text-orange-900 dark:text-orange-100',
-            high:   'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-900 dark:text-red-100',
-          }[severity]
-          return (
-            <div className={`mb-4 rounded-xl border ${tone}`}>
-              <button
-                type="button"
-                onClick={() => setCollectionHealthExpanded(v => !v)}
-                className="w-full flex flex-wrap items-center justify-between gap-3 px-4 py-3 text-left"
-                aria-expanded={collectionHealthExpanded}
-              >
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
-                  <span className="font-semibold">Usage data coverage</span>
-                  <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 rounded-full bg-emerald-500"></span>
-                    {s.healthy} healthy
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 rounded-full bg-yellow-500"></span>
-                    {s.stale} stale
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 rounded-full bg-orange-500"></span>
-                    {s.dark} dark
-                  </span>
-                  <span className="inline-flex items-center gap-1">
-                    <span className="inline-block w-2 h-2 rounded-full bg-red-500"></span>
-                    {s.never} never
-                  </span>
-                  <span className="text-xs opacity-75">
-                    of {s.totalDevices} devices
-                    {darkTotal > 0 && ` • ${darkTotal} not collecting (${pct}%)`}
-                  </span>
-                </div>
-                {darkTotal > 0 && (
-                  <span className="text-xs font-medium underline">
-                    {collectionHealthExpanded ? 'Hide details' : 'Show details'}
-                  </span>
-                )}
-              </button>
-              {collectionHealthExpanded && darkTotal > 0 && (
-                <div className="border-t border-current/10 max-h-72 overflow-auto">
-                  <table className="w-full text-xs">
-                    <thead className="sticky top-0 bg-inherit">
-                      <tr className="text-left">
-                        <th className="px-4 py-2 font-medium">Status</th>
-                        <th className="px-4 py-2 font-medium">Device</th>
-                        <th className="px-4 py-2 font-medium">Platform</th>
-                        <th className="px-4 py-2 font-medium">Usage</th>
-                        <th className="px-4 py-2 font-medium">Location</th>
-                        <th className="px-4 py-2 font-medium">Last seen</th>
-                        <th className="px-4 py-2 font-medium">Last usage</th>
-                        <th className="px-4 py-2 font-medium text-right">Days dark</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {collectionHealth.darkDevices.map(dev => (
-                        <tr key={dev.serialNumber} className="border-t border-current/10 hover:bg-current/5">
-                          <td className="px-4 py-2 whitespace-nowrap">
-                            <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-semibold uppercase ${
-                              dev.bucket === 'never' ? 'bg-red-200/60 text-red-900 dark:bg-red-900/40 dark:text-red-100' :
-                              'bg-orange-200/60 text-orange-900 dark:bg-orange-900/40 dark:text-orange-100'
-                            }`}>
-                              {dev.bucket}
-                            </span>
-                          </td>
-                          <td className="px-4 py-2">
-                            <Link href={`/device/${dev.serialNumber}`} className="font-medium hover:underline">
-                              {dev.deviceName || dev.serialNumber}
-                            </Link>
-                            <div className="text-[10px] opacity-60 font-mono">{dev.serialNumber}</div>
-                          </td>
-                          <td className="px-4 py-2 whitespace-nowrap">{dev.platform || '—'}</td>
-                          <td className="px-4 py-2 whitespace-nowrap">{dev.usage || '—'}</td>
-                          <td className="px-4 py-2 whitespace-nowrap">{dev.location || '—'}</td>
-                          <td className="px-4 py-2 whitespace-nowrap" suppressHydrationWarning>
-                            {dev.lastSeen ? formatRelativeTime(dev.lastSeen) : '—'}
-                          </td>
-                          <td className="px-4 py-2 whitespace-nowrap">{dev.lastUsageDate || 'never'}</td>
-                          <td className="px-4 py-2 text-right whitespace-nowrap">
-                            {dev.daysSinceUsage !== null ? `${dev.daysSinceUsage}d` : '—'}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </div>
-          )
-        })()}
         <div className="flex-1 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 flex flex-col min-h-0 overflow-hidden">
 
           {/* Header Section */}

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -118,12 +118,26 @@ interface VersionDistribution {
   [appName: string]: AppVersionDistribution
 }
 
+interface DeviceAggregate {
+  serialNumber: string
+  deviceName: string
+  usage: string | null
+  catalog: string | null
+  location: string | null
+  department: string | null
+  fleet: string | null
+  totalSeconds: number
+  totalHours: number
+  launchCount: number
+}
+
 interface UtilizationData {
   status: string
   applications: UtilizationApp[]
   topUsers: TopUser[]
   singleUserApps: SingleUserApp[]
   unusedApps: UnusedApp[]
+  devicesAggregate?: DeviceAggregate[]
   versionDistribution?: VersionDistribution
   summary: UtilizationSummary
   filters: {
@@ -1429,21 +1443,61 @@ function ApplicationsPageContent() {
   // Uses baseFilteredApplications (without version filter) so widgets always show all versions
   const versionAnalysis = useMemo(() => {
     const analysis: VersionAnalysis = {}
-    
+
     baseFilteredApplications.forEach(app => {
       // Use normalized name as the key (same as what's in filterOptions.applicationNames)
       const normalizedName = normalizeAppName(app.name)
       if (!normalizedName) return // Skip if normalization results in empty string
-      
+
       if (!analysis[normalizedName]) {
         analysis[normalizedName] = {}
       }
       const version = app.version || 'Unknown'
       analysis[normalizedName][version] = (analysis[normalizedName][version] || 0) + 1
     })
-    
+
     return analysis
   }, [baseFilteredApplications])
+
+  // Multi-app utilization aggregates: per-device rows across all selected apps
+  // get rolled up by inventory dimension so the widget grid mirrors the
+  // single-app view. Each device's hours flow once into its bucket regardless
+  // of how many of the selected apps it touched.
+  const utilizationAggregates = useMemo(() => {
+    const devices = utilizationData?.devicesAggregate ?? []
+    const grandTotalHours = devices.reduce((s, d) => s + d.totalHours, 0) || 1
+
+    const sumBy = (keyFn: (d: DeviceAggregate) => string | null): Array<[string, number]> => {
+      const m = new Map<string, number>()
+      for (const d of devices) {
+        const k = keyFn(d) || 'Unknown'
+        m.set(k, (m.get(k) ?? 0) + d.totalHours)
+      }
+      return [...m.entries()].sort((a, b) => b[1] - a[1])
+    }
+
+    const byLocation = sumBy(d => d.location).slice(0, 10)
+    const byCatalog = sumBy(d => d.catalog)
+    const byUsage = sumBy(d => d.usage)
+    const byArea = sumBy(d => d.department).slice(0, 10)
+    const byFleet = sumBy(d => d.fleet)
+
+    const bins: Array<{ label: string; count: number; min: number; max: number }> = [
+      { label: '0–10h', count: 0, min: 0, max: 10 },
+      { label: '10–50h', count: 0, min: 10, max: 50 },
+      { label: '50–100h', count: 0, min: 50, max: 100 },
+      { label: '100–250h', count: 0, min: 100, max: 250 },
+      { label: '250h+', count: 0, min: 250, max: Infinity },
+    ]
+    for (const d of devices) {
+      const bin = bins.find(b => d.totalHours >= b.min && d.totalHours < b.max)
+      if (bin) bin.count += 1
+    }
+
+    return { grandTotalHours, byLocation, byCatalog, byUsage, byArea, byFleet, bins }
+  }, [utilizationData])
+
+  const widgetPalette = ['#3b82f6', '#22c55e', '#a855f7', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#ef4444']
 
   /* Commented out full-page error - using inline table error instead
   if (error) {
@@ -1525,8 +1579,8 @@ function ApplicationsPageContent() {
                 {reportType === 'usage' ? 'Applications Usage Report' : 'Applications Report'}
               </h2>
               <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                {reportType === 'usage' && utilizationData 
-                  ? `${utilizationData.summary.totalAppsTracked} apps tracked across ${utilizationData.summary.uniqueDevices} devices`
+                {reportType === 'usage' && utilizationData
+                  ? `${utilizationData.summary.totalAppsTracked.toLocaleString()} apps · ${utilizationData.summary.uniqueDevices.toLocaleString()} devices · ${utilizationData.summary.totalUsageHours.toLocaleString()} hours · ${utilizationData.summary.totalLaunches.toLocaleString()} launches · ${utilizationData.summary.uniqueUsers.toLocaleString()} unique users`
                   : reportType === 'versions' && sortedApplications.length > 0
                   ? `${sortedApplications.length} applications across ${new Set(sortedApplications.map(app => app.serialNumber)).size} devices`
                   : 'Generate report to see application inventory across your fleet'
@@ -2487,193 +2541,229 @@ function ApplicationsPageContent() {
                   </div>
                 </div>
               )}
-              {/* Widgets Accordion - Collapsible section - ONLY for Usage Report */}
-              {(utilizationData.topUsers.length > 0 || utilizationData.singleUserApps.length > 0 || utilizationData.unusedApps.length > 0 || utilizationData.applications.length > 0) && (
+              {/* Widgets accordion — aggregate stats across the selected apps,
+                  rolled up by inventory dimension. Mirrors the per-app view at
+                  /devices/applications/usage/[appName]. */}
+              {(utilizationData.devicesAggregate?.length ?? 0) > 0 && (
                 <div className={widgetsExpanded ? '' : 'border-b border-gray-200 dark:border-gray-700'}>
-                  {/* Widgets Accordion Header */}
                   <button
                     onClick={() => setWidgetsExpanded(!effectiveWidgetsExpanded)}
                     className="w-full px-6 py-3 flex items-center justify-between bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors border-b border-gray-200 dark:border-gray-700"
                   >
                     <div className="flex items-center gap-2">
-                      <svg 
-                        className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${effectiveWidgetsExpanded ? 'rotate-90' : 'rotate-180'}`} 
-                        fill="none" 
-                        stroke="currentColor" 
+                      <svg
+                        className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${effectiveWidgetsExpanded ? 'rotate-90' : ''}`}
+                        fill="none"
+                        stroke="currentColor"
                         viewBox="0 0 24 24"
                       >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                       </svg>
-                      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Usage Analytics</span>
+                      <span className="text-sm font-semibold text-gray-900 dark:text-white">Widgets</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {(() => {
+                          const dCount = utilizationData.devicesAggregate?.length ?? 0
+                          return `Aggregate stats across ${dCount.toLocaleString()} ${dCount === 1 ? 'device' : 'devices'}`
+                        })()}
+                      </span>
                     </div>
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      {effectiveWidgetsExpanded ? 'Click to collapse' : 'Click to expand'}
-                    </span>
+                    <span className="text-xs text-gray-400">{effectiveWidgetsExpanded ? 'Click to collapse' : 'Click to expand'}</span>
                   </button>
                 </div>
               )}
 
-              {/* Widgets Content - Collapsible */}
-              <CollapsibleSection expanded={effectiveWidgetsExpanded && (utilizationData.topUsers.length > 0 || utilizationData.singleUserApps.length > 0 || utilizationData.unusedApps.length > 0 || utilizationData.applications.length > 0)}>
-              <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-              
-              {/* Summary Cards - Inside Widgets Accordion */}
-              <div className="px-6 py-4 bg-blue-50 dark:bg-blue-900/20 border-b border-gray-100 dark:border-gray-700">
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-                  <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
-                      {utilizationData.summary.totalAppsTracked}
-                    </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Apps Tracked</div>
-                  </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <div className="text-2xl font-bold text-orange-600 dark:text-orange-400">
-                      {utilizationData.summary.uniqueUsers}
-                    </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Unique Users</div>
-                  </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <div className="text-2xl font-bold text-teal-600 dark:text-teal-400">
-                      {utilizationData.summary.uniqueDevices}
-                    </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Devices</div>
-                  </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <div className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">
-                      {utilizationData.summary.singleUserAppCount}
-                    </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Single-User Apps</div>
-                  </div>
-                  <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <div className="text-2xl font-bold text-red-600 dark:text-red-400">
-                      {utilizationData.summary.unusedAppCount}
-                    </div>
-                    <div className="text-xs text-gray-500 dark:text-gray-400">Unused Apps</div>
-                  </div>
-                </div>
-              </div>
-              
-              {/* Widgets Grid */}
-              <div className="px-6 py-4 grid grid-cols-1 lg:grid-cols-2 gap-6">
-                {/* Top Users Widget */}
-                <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-                    <svg className="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-                    </svg>
-                    Top Users by Usage
-                  </h3>
-                  <div className="space-y-3 max-h-64 overflow-y-auto">
-                    {utilizationData.topUsers.slice(0, 10).map((user, idx) => (
-                      <div key={user.username} className="flex items-center justify-between">
-                        <div className="flex items-center gap-3 min-w-0 flex-1">
-                          <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
-                            idx < 3 ? 'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-200' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
-                          }`}>
-                            {idx + 1}
-                          </span>
-                          <span className="text-sm text-gray-900 dark:text-white truncate">{user.username}</span>
-                        </div>
-                        <div className="flex items-center gap-4">
-                          <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
-                            {formatDuration(user.totalSeconds)}
-                          </span>
-                          <span className="text-xs text-gray-500 dark:text-gray-400">
-                            {user.appsUsed} apps
-                          </span>
-                        </div>
+              <CollapsibleSection expanded={effectiveWidgetsExpanded && (utilizationData.devicesAggregate?.length ?? 0) > 0}>
+                <div className="px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                  {/* Hours by Location (top 10) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                      Hours by Location <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                    </h3>
+                    {utilizationAggregates.byLocation.length === 0 ? (
+                      <p className="text-xs text-gray-500">No location data.</p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {(() => {
+                          const max = utilizationAggregates.byLocation[0][1] || 1
+                          return utilizationAggregates.byLocation.map(([name, hours]) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                <div className="h-full bg-blue-500" style={{ width: `${(hours / max) * 100}%` }} />
+                              </div>
+                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                                {hours.toFixed(0)}h
+                              </div>
+                            </div>
+                          ))
+                        })()}
                       </div>
-                    ))}
-                    {utilizationData.topUsers.length === 0 && (
-                      <p className="text-sm text-gray-500 dark:text-gray-400">No user data available</p>
                     )}
                   </div>
-                </div>
 
-                {/* Single-User Apps Widget */}
-                <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-                    <svg className="w-5 h-5 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                    </svg>
-                    Single-User Applications
-                  </h3>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">Apps used by only one person - may indicate specialized tools or license inefficiency</p>
-                  <div className="space-y-2 max-h-48 overflow-y-auto">
-                    {utilizationData.singleUserApps.slice(0, 15).map((app) => (
-                      <div key={app.name} className="flex items-center justify-between">
-                        <span className="text-sm text-gray-900 dark:text-white truncate flex-1">{app.name}</span>
-                        <span className="text-sm font-medium text-yellow-600 dark:text-yellow-400 ml-2">
-                          {app.totalHours.toFixed(1)}h
-                        </span>
-                      </div>
-                    ))}
-                    {utilizationData.singleUserApps.length === 0 && (
-                      <p className="text-sm text-gray-500 dark:text-gray-400">No single-user apps detected</p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Unused Apps Widget */}
-                <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-                    <svg className="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-                    </svg>
-                    Unused Applications ({utilizationDays} days)
-                  </h3>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">Installed but not used - candidates for removal or license reclamation</p>
-                  <div className="space-y-2 max-h-48 overflow-y-auto">
-                    {utilizationData.unusedApps.slice(0, 15).map((app) => (
-                      <div key={app.name} className="flex items-center justify-between">
-                        <span className="text-sm text-gray-900 dark:text-white truncate flex-1">{app.name}</span>
-                        <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
-                          {app.deviceCount} devices
-                        </span>
-                      </div>
-                    ))}
-                    {utilizationData.unusedApps.length === 0 && (
-                      <p className="text-sm text-gray-500 dark:text-gray-400">All installed apps have been used</p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Top Apps by Time Widget */}
-                <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600 p-4">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-                    <svg className="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                    Most Used by Time
-                  </h3>
-                  <div className="space-y-3 max-h-64 overflow-y-auto">
-                    {utilizationData.applications.slice(0, 10).map((app) => (
-                      <div key={app.name} className="space-y-1">
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm text-gray-900 dark:text-white truncate flex-1">{app.name}</span>
-                          <span className="text-sm font-medium text-blue-600 dark:text-blue-400 ml-2">
-                            {formatDuration(app.totalSeconds)}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                            <div 
-                              className="bg-blue-500 h-2 rounded-full"
-                              style={{ 
-                                width: `${utilizationData.applications[0]?.totalSeconds ? (app.totalSeconds / utilizationData.applications[0].totalSeconds) * 100 : 0}%` 
+                  {/* Hours by Catalog (stacked + legend) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Catalog</h3>
+                    {utilizationAggregates.byCatalog.length === 0 ? (
+                      <p className="text-xs text-gray-500">No catalog data.</p>
+                    ) : (
+                      <>
+                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                          {utilizationAggregates.byCatalog.map(([name, hours], i) => (
+                            <div
+                              key={name}
+                              style={{
+                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
+                                backgroundColor: widgetPalette[i % widgetPalette.length],
                               }}
+                              title={`${name}: ${hours.toFixed(0)}h`}
                             />
-                          </div>
-                          <span className="text-xs text-gray-500 dark:text-gray-400 w-16 text-right">
-                            {app.deviceCount} dev
-                          </span>
+                          ))}
                         </div>
+                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                          {utilizationAggregates.byCatalog.map(([name, hours], i) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <span
+                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
+                              />
+                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                              <span className="ml-auto tabular-nums text-gray-500">
+                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {/* Hours by Usage Type */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Usage Type</h3>
+                    {utilizationAggregates.byUsage.length === 0 ? (
+                      <p className="text-xs text-gray-500">No usage-type data.</p>
+                    ) : (
+                      <>
+                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                          {utilizationAggregates.byUsage.map(([name, hours], i) => (
+                            <div
+                              key={name}
+                              style={{
+                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
+                                backgroundColor: widgetPalette[i % widgetPalette.length],
+                              }}
+                              title={`${name}: ${hours.toFixed(0)}h`}
+                            />
+                          ))}
+                        </div>
+                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                          {utilizationAggregates.byUsage.map(([name, hours], i) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <span
+                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
+                              />
+                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                              <span className="ml-auto tabular-nums text-gray-500">
+                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {/* Hours by Area (top 10) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                      Hours by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                    </h3>
+                    {utilizationAggregates.byArea.length === 0 ? (
+                      <p className="text-xs text-gray-500">No area data.</p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {(() => {
+                          const max = utilizationAggregates.byArea[0][1] || 1
+                          return utilizationAggregates.byArea.map(([name, hours]) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                <div className="h-full bg-emerald-500" style={{ width: `${(hours / max) * 100}%` }} />
+                              </div>
+                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                                {hours.toFixed(0)}h
+                              </div>
+                            </div>
+                          ))
+                        })()}
                       </div>
-                    ))}
+                    )}
+                  </div>
+
+                  {/* Hours by Fleet (stacked + legend) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Fleet</h3>
+                    {utilizationAggregates.byFleet.length === 0 ? (
+                      <p className="text-xs text-gray-500">No fleet data.</p>
+                    ) : (
+                      <>
+                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                          {utilizationAggregates.byFleet.map(([name, hours], i) => (
+                            <div
+                              key={name}
+                              style={{
+                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
+                                backgroundColor: widgetPalette[i % widgetPalette.length],
+                              }}
+                              title={`${name}: ${hours.toFixed(0)}h`}
+                            />
+                          ))}
+                        </div>
+                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                          {utilizationAggregates.byFleet.map(([name, hours], i) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <span
+                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
+                              />
+                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                              <span className="ml-auto tabular-nums text-gray-500">
+                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {/* Device Hours Distribution */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                      Device Hours Distribution
+                    </h3>
+                    {(() => {
+                      const max = Math.max(...utilizationAggregates.bins.map(b => b.count), 1)
+                      return (
+                        <div className="space-y-1.5">
+                          {utilizationAggregates.bins.map(b => (
+                            <div key={b.label} className="flex items-center gap-2 text-xs">
+                              <div className="w-20 text-gray-700 dark:text-gray-300">{b.label}</div>
+                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
+                              </div>
+                              <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )
+                    })()}
                   </div>
                 </div>
-              </div>
-              </div>
               </CollapsibleSection>
 
               {/* Utilization Data Table */}

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -3,7 +3,7 @@
 // Force dynamic rendering and disable caching for applications page
 export const dynamic = 'force-dynamic'
 
-import { useEffect, useState, Suspense, useMemo, useRef } from "react"
+import React, { useEffect, useState, Suspense, useMemo, useRef } from "react"
 import Link from "next/link"
 import { useSearchParams, useRouter, usePathname } from "next/navigation"
 import { formatRelativeTime } from "../../../src/lib/time"
@@ -406,6 +406,110 @@ function shouldIncludeApplication(appName: string): boolean {
   return !excludePatterns.some(pattern => pattern.test(trimmed))
 }
 
+// Chip-cloud accordion that lives inside the multi-app Usage Report. Lets the
+// user click apps to include/exclude them from the table without regenerating
+// the whole report. Widget aggregates are device-level and unaffected.
+function UsageReportAppFilter({
+  apps,
+  enabled,
+  onToggle,
+  onSelectAll,
+  onClear,
+}: {
+  apps: string[]
+  enabled: Set<string> | null
+  onToggle: (name: string) => void
+  onSelectAll: () => void
+  onClear: () => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [query, setQuery] = useState('')
+  const sortedApps = useMemo(() => [...apps].sort((a, b) => a.localeCompare(b)), [apps])
+  const visibleApps = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return sortedApps
+    return sortedApps.filter(n => n.toLowerCase().includes(q))
+  }, [sortedApps, query])
+  const activeCount = enabled ? enabled.size : apps.length
+  const totalCount = apps.length
+
+  return (
+    <div className="border-b border-gray-200 dark:border-gray-700">
+      <button
+        onClick={() => setExpanded(prev => !prev)}
+        className="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Applications</span>
+          <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">
+            {activeCount} / {totalCount} active
+          </span>
+        </div>
+        <svg
+          className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${expanded ? 'rotate-90' : 'rotate-180'}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      <CollapsibleSection expanded={expanded}>
+        <div className="px-6 pb-4 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative flex-1 min-w-[12rem] max-w-md">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              </div>
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter chips…"
+                className="block w-full pl-9 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <button
+              onClick={onSelectAll}
+              className="px-2 py-1 text-xs bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg transition-colors"
+            >
+              Select All
+            </button>
+            <button
+              onClick={onClear}
+              className="px-2 py-1 text-xs bg-red-100 hover:bg-red-200 dark:bg-red-900 dark:hover:bg-red-800 text-red-700 dark:text-red-200 rounded-lg transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2 max-h-64 overflow-y-auto">
+            {visibleApps.map(name => {
+              const isOn = enabled ? enabled.has(name) : true
+              return (
+                <button
+                  key={name}
+                  onClick={() => onToggle(name)}
+                  className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                    isOn
+                      ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
+                      : 'bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                  }`}
+                  title={name}
+                >
+                  {name}
+                </button>
+              )
+            })}
+            {visibleApps.length === 0 && (
+              <span className="text-xs text-gray-500 dark:text-gray-400 px-2 py-1">No apps match &quot;{query}&quot;</span>
+            )}
+          </div>
+        </div>
+      </CollapsibleSection>
+    </div>
+  )
+}
+
 function ApplicationsPageContent() {
   const [applications, setApplications] = useState<ApplicationItem[]>([])
   const [filterOptions, setFilterOptions] = useState<FilterOptions>({
@@ -425,6 +529,9 @@ function ApplicationsPageContent() {
   const [error, setError] = useState<string | null>(null)
   const [filtersExpanded, setFiltersExpanded] = useState(true)
   const [widgetsExpanded, setWidgetsExpanded] = useState(false)
+  // Selections accordion is open by default while building a report, then
+  // collapsed once a report is generated so it doesn't shove the data down.
+  const [selectionsExpanded, setSelectionsExpanded] = useState(true)
 
   const { tableContainerRef, effectiveFiltersExpanded, effectiveWidgetsExpanded } = useScrollCollapse(
     { filters: filtersExpanded, widgets: widgetsExpanded },
@@ -589,6 +696,21 @@ function ApplicationsPageContent() {
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingReport])
+
+  // Re-run the active report when the global platform filter flips. The bulk
+  // and usage endpoints accept a server-side platform filter; for versions the
+  // client-side filter already scopes the table, so an extra refetch keeps
+  // device-set assumptions (which apps belong to which platform) tight.
+  useEffect(() => {
+    if (!hydratedRef.current) return
+    if (loading) return
+    if (reportType === 'usage') {
+      handleLoadUtilization()
+    } else if (reportType === 'versions') {
+      handleLoadVersionsReport()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [platformFilter])
 
   // Sync state → URL whenever selections, period, reportType, or reportMode
   // change. Skipped during hydration to avoid clobbering the incoming URL.
@@ -998,7 +1120,7 @@ function ApplicationsPageContent() {
       // Build query params for utilization endpoint - 30-90%
       const params = new URLSearchParams()
       params.set('days', effectiveDays.toString())
-      
+
       if (selectedApplications.length > 0) {
         params.set('applicationNames', selectedApplications.join(','))
       }
@@ -1010,6 +1132,18 @@ function ApplicationsPageContent() {
       }
       if (selectedLocations.length > 0) {
         params.set('locations', selectedLocations.join(','))
+      }
+      if (selectedAreas.length > 0) {
+        params.set('areas', selectedAreas.join(','))
+      }
+      if (selectedFleets.length > 0) {
+        params.set('fleets', selectedFleets.join(','))
+      }
+      if (selectedRooms.length > 0) {
+        params.set('rooms', selectedRooms.join(','))
+      }
+      if (platformFilter !== 'all') {
+        params.set('platforms', platformFilter)
       }
       
       const url = `/api/devices/applications/usage?${params.toString()}`
@@ -1040,9 +1174,11 @@ function ApplicationsPageContent() {
       } else {
         setUtilizationData(data)
         setReportType('usage')
+        setWidgetsExpanded(true)
+        setSelectionsExpanded(false)
         // Version distribution is now included in the utilization API response
         // No need for separate inventory fetch
-                
+
         setLoadingProgress({ current: 100, total: 100 })
         setLoadingMessage('Complete!')
       }
@@ -1079,17 +1215,27 @@ function ApplicationsPageContent() {
       setLoadingProgress({ current: 0, total: 100 })
       setLoadingMessage('Loading version distribution data...')
       
-      const selectedAppsParam = selectedApplications.length > 0 
-        ? selectedApplications.join(',') 
+      const selectedAppsParam = selectedApplications.length > 0
+        ? selectedApplications.join(',')
         : ''
-      
+
       // Load inventory data for version analysis
       setLoadingProgress({ current: 20, total: 100 })
       const inventoryParams = new URLSearchParams()
       if (selectedAppsParam) {
         inventoryParams.set('applicationNames', selectedAppsParam)
       }
-      
+      if (selectedUsages.length) inventoryParams.set('usages', selectedUsages.join(','))
+      if (selectedCatalogs.length) inventoryParams.set('catalogs', selectedCatalogs.join(','))
+      if (selectedAreas.length) inventoryParams.set('areas', selectedAreas.join(','))
+      if (selectedFleets.length) inventoryParams.set('fleets', selectedFleets.join(','))
+      if (selectedRooms.length) inventoryParams.set('rooms', selectedRooms.join(','))
+      if (selectedLocations.length) inventoryParams.set('locations', selectedLocations.join(','))
+      if (platformFilter !== 'all') inventoryParams.set('platforms', platformFilter)
+      // Without an applicationNames filter, raise the per-page cap so the broader
+      // scope (e.g. area=Animation) still surfaces enough apps to render the report.
+      if (!selectedAppsParam) inventoryParams.set('limit', '5000')
+
       const inventoryUrl = `/api/devices/applications?${inventoryParams.toString()}`
       
       const inventoryResponse = await fetch(inventoryUrl, {
@@ -1108,6 +1254,7 @@ function ApplicationsPageContent() {
       if (Array.isArray(inventoryData)) {
         setApplications(inventoryData)
         setReportType('versions')
+        setSelectionsExpanded(false)
         setUtilizationData(null) // Clear any previous usage data
         setLoadingProgress({ current: 100, total: 100 })
         setLoadingMessage('Complete!')
@@ -1135,11 +1282,64 @@ function ApplicationsPageContent() {
     }
   }
 
-  // Sort utilization applications
+  // Per-report app inclusion filter. When the user clicks chips in the
+  // report's Applications accordion, we narrow the displayed app rows + widget
+  // device-set without having to regenerate the report.
+  const [enabledApps, setEnabledApps] = useState<Set<string> | null>(null)
+
+  // Reset enabledApps whenever a fresh report payload arrives so the chip
+  // cloud always starts with every app in the report enabled.
+  useEffect(() => {
+    if (reportType === 'usage' && utilizationData?.applications) {
+      setEnabledApps(new Set(utilizationData.applications.map(a => a.name)))
+    } else if (reportType === 'versions' && applications.length > 0) {
+      const names = new Set<string>()
+      for (const a of applications) {
+        if (shouldIncludeApplication(a.name)) names.add(a.name)
+      }
+      setEnabledApps(names)
+    } else if (!reportType) {
+      setEnabledApps(null)
+    }
+  }, [reportType, utilizationData, applications])
+
+  const toggleEnabledApp = (name: string) => {
+    setEnabledApps(prev => {
+      const next = new Set(prev ?? [])
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  // Distinct app names in the active report — drives the chip cloud.
+  const appsInReport = useMemo(() => {
+    if (reportType === 'usage' && utilizationData?.applications) {
+      return utilizationData.applications.map(a => a.name)
+    }
+    if (reportType === 'versions') {
+      const seen = new Set<string>()
+      const names: string[] = []
+      for (const a of applications) {
+        if (!shouldIncludeApplication(a.name)) continue
+        if (seen.has(a.name)) continue
+        seen.add(a.name)
+        names.push(a.name)
+      }
+      return names
+    }
+    return []
+  }, [reportType, utilizationData, applications])
+
+  // Sort utilization applications, filtered by which apps the user has enabled
+  // in the report's Applications chip cloud.
   const sortedUtilizationApps = useMemo(() => {
     if (!utilizationData?.applications) return []
-    
-    return [...utilizationData.applications].sort((a, b) => {
+    const filtered = enabledApps
+      ? utilizationData.applications.filter(a => enabledApps.has(a.name))
+      : utilizationData.applications
+
+    return [...filtered].sort((a, b) => {
       let compareResult = 0
       
       switch (utilizationSortColumn) {
@@ -1167,7 +1367,7 @@ function ApplicationsPageContent() {
       
       return utilizationSortDirection === 'asc' ? compareResult : -compareResult
     })
-  }, [utilizationData?.applications, utilizationSortColumn, utilizationSortDirection])
+  }, [utilizationData?.applications, utilizationSortColumn, utilizationSortDirection, enabledApps])
 
   // Handle device table sorting
   const handleDeviceTableSort = (column: typeof deviceTableSortColumn) => {
@@ -1201,7 +1401,10 @@ function ApplicationsPageContent() {
   const baseFilteredApplications = applications.filter(app => {
     // First filter: exclude junk applications
     if (!shouldIncludeApplication(app.name)) return false
-    
+
+    // Per-report app inclusion (versions report chip cloud)
+    if (reportType === 'versions' && enabledApps && !enabledApps.has(app.name)) return false
+
     // Global platform filter
     if (platformFilter !== 'all' && !isPlatformVisible(app.platform || '')) return false
     
@@ -1216,13 +1419,15 @@ function ApplicationsPageContent() {
     const matchesUsages = selectedUsages.length === 0 || selectedUsages.includes(app.usage?.toLowerCase() || '')
     const matchesCatalogs = selectedCatalogs.length === 0 || selectedCatalogs.includes(app.catalog?.toLowerCase() || '')
     const matchesLocations = selectedLocations.length === 0 || selectedLocations.includes(app.location?.toLowerCase() || '')
-    const matchesRooms = selectedRooms.length === 0 || 
-      selectedRooms.some(room => 
-        app.location?.toLowerCase().includes(room.toLowerCase()) || 
+    const matchesRooms = selectedRooms.length === 0 ||
+      selectedRooms.some(room =>
+        app.location?.toLowerCase().includes(room.toLowerCase()) ||
         app.room?.toLowerCase().includes(room.toLowerCase())
       )
-    const matchesFleets = selectedFleets.length === 0 || selectedFleets.includes(app.fleet || '')
-    const matchesAreas = selectedAreas.length === 0 || selectedAreas.includes((app.department || '') as string)
+    const appFleet = (app.fleet || '').toLowerCase()
+    const matchesFleets = selectedFleets.length === 0 || selectedFleets.some(f => f.toLowerCase() === appFleet)
+    const appArea = (app.department || (app as any).area || '').toLowerCase()
+    const matchesAreas = selectedAreas.length === 0 || selectedAreas.some(a => a.toLowerCase() === appArea)
 
     return matchesSearch && matchesUsages && matchesCatalogs && matchesLocations && matchesRooms && matchesFleets && matchesAreas
   })
@@ -1479,21 +1684,49 @@ function ApplicationsPageContent() {
     return analysis
   }, [baseFilteredApplications])
 
+  const [widgetMetric, setWidgetMetric] = useState<'hours' | 'launches'>('launches')
+
   // Multi-app utilization aggregates: per-device rows across all selected apps
   // get rolled up by inventory dimension so the widget grid mirrors the
-  // single-app view. Each device's hours flow once into its bucket regardless
+  // single-app view. Each device's value flows once into its bucket regardless
   // of how many of the selected apps it touched.
   const utilizationAggregates = useMemo(() => {
-    const devices = utilizationData?.devicesAggregate ?? []
-    const grandTotalHours = devices.reduce((s, d) => s + d.totalHours, 0) || 1
+    const allDevices = utilizationData?.devicesAggregate ?? []
+    // Narrow the device set to those that touched at least one of the enabled
+    // apps, so toggling chips in the Applications cloud reshapes the widget
+    // aggregates. This is an approximation: a device's totalHours/launchCount
+    // here still includes other apps' time on that device, but the device-set
+    // shift is what most users want when "focusing" on a subset.
+    let enabledDeviceSet: Set<string> | null = null
+    if (enabledApps && utilizationData?.applications) {
+      enabledDeviceSet = new Set()
+      for (const app of utilizationData.applications) {
+        if (enabledApps.has(app.name)) {
+          for (const sn of app.devices ?? []) enabledDeviceSet.add(sn)
+        }
+      }
+    }
+    const devices = enabledDeviceSet
+      ? allDevices.filter(d => enabledDeviceSet!.has(d.serialNumber))
+      : allDevices
+    const valueOf = (d: DeviceAggregate) => widgetMetric === 'hours' ? d.totalHours : d.launchCount
+    const grandTotal = devices.reduce((s, d) => s + valueOf(d), 0) || 1
+
+    const isUnknown = (k: string | null | undefined) => {
+      if (!k) return true
+      const v = k.trim().toLowerCase()
+      return v === '' || v === 'unknown' || v === 'null' || v === 'n/a'
+    }
 
     const sumBy = (keyFn: (d: DeviceAggregate) => string | null): Array<[string, number]> => {
       const m = new Map<string, number>()
       for (const d of devices) {
-        const k = keyFn(d) || 'Unknown'
-        m.set(k, (m.get(k) ?? 0) + d.totalHours)
+        const raw = keyFn(d)
+        if (isUnknown(raw)) continue
+        const k = raw as string
+        m.set(k, (m.get(k) ?? 0) + valueOf(d))
       }
-      return [...m.entries()].sort((a, b) => b[1] - a[1])
+      return [...m.entries()].filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1])
     }
 
     const byLocation = sumBy(d => d.location).slice(0, 10)
@@ -1502,20 +1735,33 @@ function ApplicationsPageContent() {
     const byArea = sumBy(d => d.department).slice(0, 10)
     const byFleet = sumBy(d => d.fleet)
 
-    const bins: Array<{ label: string; count: number; min: number; max: number }> = [
-      { label: '0–10h', count: 0, min: 0, max: 10 },
-      { label: '10–50h', count: 0, min: 10, max: 50 },
-      { label: '50–100h', count: 0, min: 50, max: 100 },
-      { label: '100–250h', count: 0, min: 100, max: 250 },
-      { label: '250h+', count: 0, min: 250, max: Infinity },
-    ]
+    const binDefs = widgetMetric === 'hours'
+      ? [
+          { label: '0–10h', min: 0, max: 10 },
+          { label: '10–50h', min: 10, max: 50 },
+          { label: '50–100h', min: 50, max: 100 },
+          { label: '100–250h', min: 100, max: 250 },
+          { label: '250h+', min: 250, max: Infinity },
+        ]
+      : [
+          { label: '0–10', min: 0, max: 10 },
+          { label: '10–50', min: 10, max: 50 },
+          { label: '50–250', min: 50, max: 250 },
+          { label: '250–1000', min: 250, max: 1000 },
+          { label: '1000+', min: 1000, max: Infinity },
+        ]
+    const bins = binDefs.map(b => ({ ...b, count: 0 }))
     for (const d of devices) {
-      const bin = bins.find(b => d.totalHours >= b.min && d.totalHours < b.max)
+      const v = valueOf(d)
+      const bin = bins.find(b => v >= b.min && v < b.max)
       if (bin) bin.count += 1
     }
 
-    return { grandTotalHours, byLocation, byCatalog, byUsage, byArea, byFleet, bins }
-  }, [utilizationData])
+    return { grandTotal, byLocation, byCatalog, byUsage, byArea, byFleet, bins, deviceCount: devices.length }
+  }, [utilizationData, widgetMetric, enabledApps])
+
+  const widgetMetricLabel = widgetMetric === 'hours' ? 'Hours' : 'Launches'
+  const fmtWidgetVal = (v: number) => widgetMetric === 'hours' ? `${v.toFixed(0)}h` : v.toLocaleString()
 
   const widgetPalette = ['#3b82f6', '#22c55e', '#a855f7', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#ef4444']
 
@@ -1593,8 +1839,8 @@ function ApplicationsPageContent() {
         <div className="flex-1 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 flex flex-col min-h-0 overflow-hidden">
 
           {/* Header Section */}
-          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between sm:flex-wrap gap-4 px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:items-start gap-4 px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <div className="min-w-0 sm:flex-1">
               <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                 {reportType === 'usage' ? 'Applications Usage Report' : 'Applications Report'}
               </h2>
@@ -1608,7 +1854,35 @@ function ApplicationsPageContent() {
               </p>
             </div>
 
-            <div className="flex flex-wrap items-center gap-3">
+            <div className="flex flex-col items-stretch sm:items-end gap-3 sm:flex-shrink-0">
+              {/* Search Input — pinned to the top-right above the action row so it
+                  doesn't wrap to a third row on report views. */}
+              <div className="relative w-full sm:w-64">
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                  <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                  </svg>
+                </div>
+                <input
+                  type="text"
+                  placeholder="Search applications..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="block w-full pl-10 pr-8 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery('')}
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  >
+                    <svg className="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center justify-end gap-3">
               {/* Time Period Selector - Only show for usage reports */}
               {reportType === 'usage' && utilizationData && (
                 <div className="flex items-center gap-2">
@@ -1866,14 +2140,16 @@ function ApplicationsPageContent() {
                     } else {
                       // Export installed applications report (existing behavior)
                       const csvContent = [
-                        ['Device', 'Serial Number', 'Application', 'Version', 'Catalog', 'Location'].join(','),
+                        ['Application', 'Version', 'Usage', 'Catalog', 'Area', 'Location', 'Device', 'Serial Number'].join(','),
                         ...sortedApplications.map(app => [
-                          app.deviceName || app.serialNumber,
-                          app.serialNumber,
                           app.name,
                           app.version,
+                          app.usage || '',
                           app.catalog || '',
-                          app.location || ''
+                          app.department || app.area || '',
+                          app.location || '',
+                          app.deviceName || app.serialNumber,
+                          app.serialNumber,
                         ].map(field => `"${String(field).replace(/"/g, '""')}"`).join(','))
                       ].join('\n')
                       
@@ -1895,30 +2171,6 @@ function ApplicationsPageContent() {
                 </button>
               )}
               
-              {/* Search Input */}
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                  </svg>
-                </div>
-                <input
-                  type="text"
-                  placeholder="Search applications..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="block w-64 pl-10 pr-8 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                {searchQuery && (
-                  <button
-                    onClick={() => setSearchQuery('')}
-                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  >
-                    <svg className="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                )}
               </div>
             </div>
           </div>
@@ -2019,38 +2271,39 @@ function ApplicationsPageContent() {
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
                 locationCounts={locCounts}
+                expanded={selectionsExpanded}
+                onToggle={() => setSelectionsExpanded(prev => !prev)}
               />
             )
           })()}
 
-          {/* Applications report-builder accordion (page-specific) */}
-          {!filtersLoading && (
+          {/* Applications report-builder accordion (page-specific).
+              Only shown before a report has been generated — once we have a
+              versions or usage report, the in-report chip cloud (below the
+              Widgets accordion) replaces this big picker. */}
+          {!filtersLoading && !reportType && (
             <div className="border-b border-gray-200 dark:border-gray-700">
               {/* Collapsible Header */}
               <button
                 onClick={() => setFiltersExpanded(!effectiveFiltersExpanded)}
-                className="w-full px-6 py-3 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 flex items-center justify-between"
+                className="w-full px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center justify-between transition-colors"
               >
-                <div className="flex items-center gap-3">
-                  <svg
-                    className={`w-5 h-5 text-gray-600 dark:text-gray-300 transition-transform ${effectiveFiltersExpanded ? 'rotate-90' : ''}`}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                  <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-                    Applications {selectedApplications.length > 0 && (
-                      <span className="ml-2 text-blue-600 dark:text-blue-400">
-                        ({selectedApplications.length} active)
-                      </span>
-                    )}
-                  </h3>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Applications</span>
+                  {selectedApplications.length > 0 && (
+                    <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">
+                      {selectedApplications.length} active
+                    </span>
+                  )}
                 </div>
-                <span className="text-xs text-gray-500 dark:text-gray-400">
-                  {effectiveFiltersExpanded ? 'Click to collapse' : 'Click to expand'}
-                </span>
+                <svg
+                  className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${effectiveFiltersExpanded ? 'rotate-90' : 'rotate-180'}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
               </button>
               
               {/* Cool Progress View - Show when generating report */}
@@ -2492,220 +2745,244 @@ function ApplicationsPageContent() {
                     className="w-full px-6 py-3 flex items-center justify-between bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors border-b border-gray-200 dark:border-gray-700"
                   >
                     <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Widgets</span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {(() => {
+                          const dCount = utilizationAggregates.deviceCount
+                          return `Aggregate stats across ${dCount.toLocaleString()} ${dCount === 1 ? 'device' : 'devices'}`
+                        })()}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <button
+                          onClick={() => setWidgetMetric('launches')}
+                          className={`px-3 py-1 ${widgetMetric === 'launches' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+                        >
+                          Launches
+                        </button>
+                        <button
+                          onClick={() => setWidgetMetric('hours')}
+                          className={`px-3 py-1 ${widgetMetric === 'hours' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+                        >
+                          Hours
+                        </button>
+                      </div>
                       <svg
-                        className={`w-4 h-4 text-gray-500 dark:text-gray-400 transition-transform ${effectiveWidgetsExpanded ? 'rotate-90' : ''}`}
+                        className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${effectiveWidgetsExpanded ? 'rotate-90' : 'rotate-180'}`}
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
                       >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                       </svg>
-                      <span className="text-sm font-semibold text-gray-900 dark:text-white">Widgets</span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        {(() => {
-                          const dCount = utilizationData.devicesAggregate?.length ?? 0
-                          return `Aggregate stats across ${dCount.toLocaleString()} ${dCount === 1 ? 'device' : 'devices'}`
-                        })()}
-                      </span>
                     </div>
-                    <span className="text-xs text-gray-400">{effectiveWidgetsExpanded ? 'Click to collapse' : 'Click to expand'}</span>
                   </button>
                 </div>
               )}
 
               <CollapsibleSection expanded={effectiveWidgetsExpanded && (utilizationData.devicesAggregate?.length ?? 0) > 0}>
-                <div className="px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-                  {/* Hours by Location (top 10) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Hours by Location <span className="text-xs font-normal text-gray-500">(top 10)</span>
-                    </h3>
-                    {utilizationAggregates.byLocation.length === 0 ? (
-                      <p className="text-xs text-gray-500">No location data.</p>
-                    ) : (
-                      <div className="space-y-1.5">
-                        {(() => {
-                          const max = utilizationAggregates.byLocation[0][1] || 1
-                          return utilizationAggregates.byLocation.map(([name, hours]) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-blue-500" style={{ width: `${(hours / max) * 100}%` }} />
-                              </div>
-                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                                {hours.toFixed(0)}h
-                              </div>
-                            </div>
-                          ))
-                        })()}
+                <div className="px-6 py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                  {/* Row 1: By Usage | By Catalog | Distribution */}
+
+                  {/* By Usage Type */}
+                  {utilizationAggregates.byUsage.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{widgetMetricLabel} by Usage Type</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {utilizationAggregates.byUsage.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / utilizationAggregates.grandTotal) * 100}%`,
+                              backgroundColor: widgetPalette[i % widgetPalette.length],
+                            }}
+                            title={`${name}: ${fmtWidgetVal(val)}`}
+                          />
+                        ))}
                       </div>
-                    )}
-                  </div>
-
-                  {/* Hours by Catalog (stacked + legend) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Catalog</h3>
-                    {utilizationAggregates.byCatalog.length === 0 ? (
-                      <p className="text-xs text-gray-500">No catalog data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {utilizationAggregates.byCatalog.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: widgetPalette[i % widgetPalette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {utilizationAggregates.byUsage.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
                             />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {utilizationAggregates.byCatalog.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
-
-                  {/* Hours by Usage Type */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Usage Type</h3>
-                    {utilizationAggregates.byUsage.length === 0 ? (
-                      <p className="text-xs text-gray-500">No usage-type data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {utilizationAggregates.byUsage.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: widgetPalette[i % widgetPalette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
-                            />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {utilizationAggregates.byUsage.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
-
-                  {/* Hours by Area (top 10) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Hours by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
-                    </h3>
-                    {utilizationAggregates.byArea.length === 0 ? (
-                      <p className="text-xs text-gray-500">No area data.</p>
-                    ) : (
-                      <div className="space-y-1.5">
-                        {(() => {
-                          const max = utilizationAggregates.byArea[0][1] || 1
-                          return utilizationAggregates.byArea.map(([name, hours]) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-emerald-500" style={{ width: `${(hours / max) * 100}%` }} />
-                              </div>
-                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                                {hours.toFixed(0)}h
-                              </div>
-                            </div>
-                          ))
-                        })()}
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
                       </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
 
-                  {/* Hours by Fleet (stacked + legend) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Fleet</h3>
-                    {utilizationAggregates.byFleet.length === 0 ? (
-                      <p className="text-xs text-gray-500">No fleet data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {utilizationAggregates.byFleet.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / utilizationAggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: widgetPalette[i % widgetPalette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
+                  {/* By Catalog */}
+                  {utilizationAggregates.byCatalog.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{widgetMetricLabel} by Catalog</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {utilizationAggregates.byCatalog.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / utilizationAggregates.grandTotal) * 100}%`,
+                              backgroundColor: widgetPalette[i % widgetPalette.length],
+                            }}
+                            title={`${name}: ${fmtWidgetVal(val)}`}
+                          />
+                        ))}
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {utilizationAggregates.byCatalog.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
                             />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {utilizationAggregates.byFleet.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / utilizationAggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
 
-                  {/* Device Hours Distribution */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Device Hours Distribution
-                    </h3>
-                    {(() => {
-                      const max = Math.max(...utilizationAggregates.bins.map(b => b.count), 1)
-                      return (
-                        <div className="space-y-1.5">
-                          {utilizationAggregates.bins.map(b => (
-                            <div key={b.label} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 text-gray-700 dark:text-gray-300">{b.label}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
+                  {/* Device Distribution */}
+                  {utilizationAggregates.bins.some(b => b.count > 0) && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        Device {widgetMetricLabel} Distribution
+                      </h3>
+                      {(() => {
+                        const max = Math.max(...utilizationAggregates.bins.map(b => b.count), 1)
+                        return (
+                          <div className="space-y-1.5">
+                            {utilizationAggregates.bins.map(b => (
+                              <div key={b.label} className="flex items-center gap-2 text-xs">
+                                <div className="w-20 text-gray-700 dark:text-gray-300">{b.label}</div>
+                                <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
+                                </div>
+                                <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
+                                </div>
                               </div>
-                              <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
-                                {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      )
-                    })()}
-                  </div>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
+
+                  {/* Row 2: By Fleet | By Area | By Location */}
+
+                  {/* By Fleet */}
+                  {utilizationAggregates.byFleet.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{widgetMetricLabel} by Fleet</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {utilizationAggregates.byFleet.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / utilizationAggregates.grandTotal) * 100}%`,
+                              backgroundColor: widgetPalette[i % widgetPalette.length],
+                            }}
+                            title={`${name}: ${fmtWidgetVal(val)}`}
+                          />
+                        ))}
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {utilizationAggregates.byFleet.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
+                            />
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* By Area (top 10) */}
+                  {utilizationAggregates.byArea.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        {widgetMetricLabel} by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                      </h3>
+                      {(() => {
+                        const max = utilizationAggregates.byArea[0][1] || 1
+                        return (
+                          <div className="grid grid-cols-[minmax(0,max-content)_1fr_auto] gap-x-2 gap-y-1.5 items-center text-xs">
+                            {utilizationAggregates.byArea.map(([name, val]) => (
+                              <React.Fragment key={name}>
+                                <div className="whitespace-nowrap text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                                <div className="bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-emerald-500" style={{ width: `${(val / max) * 100}%` }} />
+                                </div>
+                                <div className="text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {fmtWidgetVal(val)}
+                                </div>
+                              </React.Fragment>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
+
+                  {/* By Location (top 10) */}
+                  {utilizationAggregates.byLocation.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        {widgetMetricLabel} by Location <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                      </h3>
+                      {(() => {
+                        const max = utilizationAggregates.byLocation[0][1] || 1
+                        return (
+                          <div className="grid grid-cols-[minmax(0,max-content)_1fr_auto] gap-x-2 gap-y-1.5 items-center text-xs">
+                            {utilizationAggregates.byLocation.map(([name, val]) => (
+                              <React.Fragment key={name}>
+                                <div className="whitespace-nowrap text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                                <div className="bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-blue-500" style={{ width: `${(val / max) * 100}%` }} />
+                                </div>
+                                <div className="text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {fmtWidgetVal(val)}
+                                </div>
+                              </React.Fragment>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
                 </div>
               </CollapsibleSection>
+
+              {/* Applications chip cloud — narrow the table + widget device-set
+                  to a subset of the apps in the report. */}
+              {appsInReport.length > 0 && (
+                <UsageReportAppFilter
+                  apps={appsInReport}
+                  enabled={enabledApps}
+                  onToggle={toggleEnabledApp}
+                  onSelectAll={() => setEnabledApps(new Set(appsInReport))}
+                  onClear={() => setEnabledApps(new Set())}
+                />
+              )}
 
               {/* Utilization Data Table */}
               <div>
@@ -2836,8 +3113,9 @@ function ApplicationsPageContent() {
                         const fromQs = searchParams.toString()
                         const fromUrl = `${pathname}${fromQs ? `?${fromQs}` : ''}`
                         const drillHref = `/devices/applications/usage/${encodeURIComponent(app.name)}?days=${utilizationDays}&from=${encodeURIComponent(fromUrl)}`
+                        const noData = (app.deviceCount ?? 0) === 0 && (app.launchCount ?? 0) === 0 && (app.totalSeconds ?? 0) === 0
                         return (
-                        <tr key={app.name} className="hover:bg-blue-50 dark:hover:bg-blue-900/10">
+                        <tr key={app.name} className={`hover:bg-blue-50 dark:hover:bg-blue-900/10 ${noData ? 'opacity-60' : ''}`}>
                           <td className="px-4 lg:px-6 py-4">
                             <Link
                               href={drillHref}
@@ -2917,7 +3195,14 @@ function ApplicationsPageContent() {
                             </div>
                           </td>
                           <td className="px-4 lg:px-6 py-4">
-                            {app.isSingleUser ? (
+                            {noData ? (
+                              <span
+                                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                                title="No usage records in the selected time window"
+                              >
+                                No data
+                              </span>
+                            ) : app.isSingleUser ? (
                               <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
                                 Single User
                               </span>
@@ -2939,6 +3224,19 @@ function ApplicationsPageContent() {
                 </table>
               </div>
             </div>
+          )}
+
+          {/* Applications chip cloud — versions report. Sits below the
+              Version Distribution widget so the user can narrow the table to
+              a subset of apps in the report. */}
+          {reportType === 'versions' && appsInReport.length > 0 && (
+            <UsageReportAppFilter
+              apps={appsInReport}
+              enabled={enabledApps}
+              onToggle={toggleEnabledApp}
+              onSelectAll={() => setEnabledApps(new Set(appsInReport))}
+              onClear={() => setEnabledApps(new Set())}
+            />
           )}
 
           {/* Missing Devices Table - Shown when report mode is 'missing' */}
@@ -3126,20 +3424,46 @@ function ApplicationsPageContent() {
                           )}
                         </div>
                       </th>
-                      <th 
+                      <th
                         className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 select-none"
-                        onClick={() => handleDeviceTableSort('deviceName')}
+                        onClick={() => handleDeviceTableSort('usage' as any)}
                       >
                         <div className="flex items-center gap-1">
-                          Device
-                          {deviceTableSortColumn === 'deviceName' && (
+                          Usage
+                          {(deviceTableSortColumn as string) === 'usage' && (
                             <svg className={`w-4 h-4 transition-transform ${deviceTableSortDirection === 'desc' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
                             </svg>
                           )}
                         </div>
                       </th>
-                      <th 
+                      <th
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 select-none"
+                        onClick={() => handleDeviceTableSort('catalog')}
+                      >
+                        <div className="flex items-center gap-1">
+                          Catalog
+                          {deviceTableSortColumn === 'catalog' && (
+                            <svg className={`w-4 h-4 transition-transform ${deviceTableSortDirection === 'desc' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                            </svg>
+                          )}
+                        </div>
+                      </th>
+                      <th
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 select-none"
+                        onClick={() => handleDeviceTableSort('area' as any)}
+                      >
+                        <div className="flex items-center gap-1">
+                          Area
+                          {(deviceTableSortColumn as string) === 'area' && (
+                            <svg className={`w-4 h-4 transition-transform ${deviceTableSortDirection === 'desc' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                            </svg>
+                          )}
+                        </div>
+                      </th>
+                      <th
                         className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 select-none"
                         onClick={() => handleDeviceTableSort('location')}
                       >
@@ -3152,13 +3476,13 @@ function ApplicationsPageContent() {
                           )}
                         </div>
                       </th>
-                      <th 
+                      <th
                         className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 select-none"
-                        onClick={() => handleDeviceTableSort('catalog')}
+                        onClick={() => handleDeviceTableSort('deviceName')}
                       >
                         <div className="flex items-center gap-1">
-                          Catalog
-                          {deviceTableSortColumn === 'catalog' && (
+                          Device
+                          {deviceTableSortColumn === 'deviceName' && (
                             <svg className={`w-4 h-4 transition-transform ${deviceTableSortDirection === 'desc' ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
                             </svg>
@@ -3174,7 +3498,7 @@ function ApplicationsPageContent() {
                         let aVal: string | undefined
                         let bVal: string | undefined
                         
-                        switch (deviceTableSortColumn) {
+                        switch (deviceTableSortColumn as string) {
                           case 'deviceName':
                             aVal = a.deviceName || a.serialNumber
                             bVal = b.deviceName || b.serialNumber
@@ -3187,13 +3511,21 @@ function ApplicationsPageContent() {
                             aVal = a.version
                             bVal = b.version
                             break
-                          case 'location':
-                            aVal = a.location || ''
-                            bVal = b.location || ''
+                          case 'usage':
+                            aVal = a.usage || ''
+                            bVal = b.usage || ''
                             break
                           case 'catalog':
                             aVal = a.catalog || ''
                             bVal = b.catalog || ''
+                            break
+                          case 'area':
+                            aVal = a.department || ''
+                            bVal = b.department || ''
+                            break
+                          case 'location':
+                            aVal = a.location || ''
+                            bVal = b.location || ''
                             break
                           default:
                             aVal = a.name
@@ -3212,6 +3544,18 @@ function ApplicationsPageContent() {
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                             v{app.version}
                           </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                            {app.usage || '-'}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                            {app.catalog || '-'}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                            {(app as any).department || (app as any).area || '-'}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                            {app.location || '-'}
+                          </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             <div className="flex items-center gap-2">
                               <Link
@@ -3222,12 +3566,6 @@ function ApplicationsPageContent() {
                               </Link>
                               <PlatformBadge platform={app.platform || ''} size="sm" />
                             </div>
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                            {app.location || '-'}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                            {app.catalog || '-'}
                           </td>
                         </tr>
                       ))

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -11,6 +11,7 @@ import { PlatformBadge } from '../../../src/components/ui/PlatformBadge'
 import { usePlatformFilterSafe } from '../../../src/providers/PlatformFilterProvider'
 import { CollapsibleSection } from '../../../src/components/ui/CollapsibleSection'
 import { useScrollCollapse } from '../../../src/hooks/useScrollCollapse'
+import DeviceFilters, { FilterOptions as SharedFilterOptions } from '../../../src/components/shared/DeviceFilters'
 
 interface ApplicationItem {
   id: string
@@ -1987,7 +1988,42 @@ function ApplicationsPageContent() {
             </div>
           )}
 
-          {/* Filter Clouds Section */}
+          {/* Selections accordion (shared inventory dimensions) */}
+          {!filtersLoading && (() => {
+            const sharedFilterOptions: SharedFilterOptions = {
+              statuses: [],
+              usages: filterOptions.usages,
+              catalogs: filterOptions.catalogs,
+              areas: filterOptions.areas,
+              locations: filterOptions.rooms,
+              fleets: filterOptions.fleets,
+            }
+            const locCounts: Record<string, number> = {}
+            allDevices.forEach(d => { if (d.room) locCounts[d.room] = (locCounts[d.room] || 0) + 1 })
+            return (
+              <DeviceFilters
+                filterOptions={sharedFilterOptions}
+                selectedStatuses={[]}
+                selectedCatalogs={selectedCatalogs}
+                selectedAreas={selectedAreas}
+                selectedLocations={selectedRooms}
+                selectedFleets={selectedFleets}
+                selectedUsages={selectedUsages}
+                onStatusToggle={() => { /* no statuses on /applications */ }}
+                onCatalogToggle={(c) => toggleCatalog(c.toLowerCase())}
+                onAreaToggle={toggleArea}
+                onLocationToggle={toggleRoom}
+                onFleetToggle={toggleFleet}
+                onUsageToggle={(u) => toggleUsage(u.toLowerCase())}
+                onClearAll={() => { /* page-specific clear handled elsewhere */ }}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                locationCounts={locCounts}
+              />
+            )
+          })()}
+
+          {/* Applications report-builder accordion (page-specific) */}
           {!filtersLoading && (
             <div className="border-b border-gray-200 dark:border-gray-700">
               {/* Collapsible Header */}
@@ -1996,18 +2032,18 @@ function ApplicationsPageContent() {
                 className="w-full px-6 py-3 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 flex items-center justify-between"
               >
                 <div className="flex items-center gap-3">
-                  <svg 
+                  <svg
                     className={`w-5 h-5 text-gray-600 dark:text-gray-300 transition-transform ${effectiveFiltersExpanded ? 'rotate-90' : ''}`}
-                    fill="none" 
-                    stroke="currentColor" 
+                    fill="none"
+                    stroke="currentColor"
                     viewBox="0 0 24 24"
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                   <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-                    Selections {(selectedApplications.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0) && (
+                    Applications {selectedApplications.length > 0 && (
                       <span className="ml-2 text-blue-600 dark:text-blue-400">
-                        ({[selectedApplications, selectedUsages, selectedCatalogs, selectedLocations, selectedRooms, selectedFleets, selectedAreas].reduce((sum, arr) => sum + arr.length, 0)} active)
+                        ({selectedApplications.length} active)
                       </span>
                     )}
                   </h3>
@@ -2068,146 +2104,6 @@ function ApplicationsPageContent() {
                 <div className="px-6 py-4 bg-gray-50 dark:bg-gray-700">
                   <div className="space-y-4">
                 
-                {/* Inventory Filter Sections - Top */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                  
-                  {/* Usage Filter */}
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Usage {selectedUsages.length > 0 && `(${selectedUsages.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {filterOptions.usages.map(usage => (
-                        <button
-                          key={usage}
-                          onClick={() => toggleUsage(usage.toLowerCase())}
-                          className={`px-2 py-1 text-xs rounded-full border ${
-                            selectedUsages.includes(usage.toLowerCase())
-                              ? 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {usage}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Catalog Filter */}
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Catalog {selectedCatalogs.length > 0 && `(${selectedCatalogs.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {filterOptions.catalogs.map(catalog => (
-                        <button
-                          key={catalog}
-                          onClick={() => toggleCatalog(catalog.toLowerCase())}
-                          className={`px-2 py-1 text-xs rounded-full border ${
-                            selectedCatalogs.includes(catalog.toLowerCase())
-                              ? 'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-900 dark:text-teal-200 dark:border-teal-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {catalog}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Fleet Filter - Only show if fleets exist */}
-                  {filterOptions.fleets.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Fleet {selectedFleets.length > 0 && `(${selectedFleets.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {filterOptions.fleets.map(fleet => (
-                        <button
-                          key={fleet}
-                          onClick={() => toggleFleet(fleet)}
-                          className={`px-2 py-1 text-xs rounded-full border ${
-                            selectedFleets.includes(fleet)
-                              ? 'bg-indigo-100 text-indigo-800 border-indigo-300 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {fleet}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
-                </div>
-
-                {/* Area Filter - Full width row above Locations */}
-                {filterOptions.areas.length > 0 && (
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
-                    </h3>
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                    {filterOptions.areas.map(area => (
-                      <button
-                        key={area}
-                        onClick={() => toggleArea(area)}
-                        className={`px-2 py-1 text-xs rounded-full border ${
-                          selectedAreas.includes(area)
-                            ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        {area}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                )}
-
-                {/* Locations Filter Cloud - Full Width */}
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Locations {selectedRooms.length > 0 && `(${selectedRooms.length} selected)`}
-                    </h3>
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                      {(() => {
-                        const roomCountsMap: Record<string, number> = {}
-                        allDevices.forEach(d => { if (d.room) roomCountsMap[d.room] = (roomCountsMap[d.room] || 0) + 1 })
-                        const filteredRooms = filterOptions.rooms.filter(room => room.toLowerCase().includes(searchQuery.toLowerCase()))
-                        const maxCount = Math.max(...filteredRooms.map(r => roomCountsMap[r] || 0), 1)
-                        return filteredRooms.map(room => {
-                          const count = roomCountsMap[room] || 0
-                          const scale = count / maxCount
-                          const sizeClass = scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold' : scale > 0.3 ? 'px-3 py-1 text-xs font-medium' : 'px-2.5 py-0.5 text-[11px]'
-                          return (
-                        <button
-                          key={room}
-                          onClick={() => toggleRoom(room)}
-                          title={`${room} (${count} devices)`}
-                          className={`${sizeClass} rounded-full border transition-colors ${
-                            selectedRooms.includes(room)
-                              ? 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-200 dark:border-green-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {room}
-                        </button>
-                          )
-                        })
-                      })()}
-                      {filterOptions.rooms.length === 0 && (
-                        <span className="px-2 py-1 text-xs text-gray-500 dark:text-gray-400">
-                          No location data available
-                        </span>
-                      )}
-                  </div>
-                </div>
-
                 {/* Applications Filter Cloud */}
                 <div>
                   <div className="flex items-center justify-between mb-2">

--- a/app/devices/applications/usage/[appName]/page.tsx
+++ b/app/devices/applications/usage/[appName]/page.tsx
@@ -15,6 +15,8 @@ interface DeviceRow {
   catalog: string | null
   location: string | null
   room: string | null
+  department: string | null
+  fleet: string | null
   assetTag: string | null
   totalSeconds: number
   totalHours: number
@@ -129,6 +131,8 @@ export default function ApplicationUsageByDevicePage() {
     const byLocation = sumBy(d => d.location).slice(0, 10)
     const byCatalog = sumBy(d => d.catalog)
     const byUsage = sumBy(d => d.usage)
+    const byArea = sumBy(d => d.department).slice(0, 10)
+    const byFleet = sumBy(d => d.fleet)
 
     // Hours distribution: histogram bins
     const bins: Array<{ label: string; count: number; min: number; max: number }> = [
@@ -143,7 +147,7 @@ export default function ApplicationUsageByDevicePage() {
       if (bin) bin.count += 1
     }
 
-    return { grandTotalHours, byLocation, byCatalog, byUsage, bins }
+    return { grandTotalHours, byLocation, byCatalog, byUsage, byArea, byFleet, bins }
   }, [data])
 
   const palette = ['#3b82f6', '#22c55e', '#a855f7', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#ef4444']
@@ -403,6 +407,70 @@ export default function ApplicationUsageByDevicePage() {
                         </div>
                         <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
                           {aggregates.byUsage.map(([name, hours], i) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <span
+                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                                style={{ backgroundColor: palette[i % palette.length] }}
+                              />
+                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                              <span className="ml-auto tabular-nums text-gray-500">
+                                {hours.toFixed(0)}h ({((hours / aggregates.grandTotalHours) * 100).toFixed(0)}%)
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  {/* Hours by Area (top 10) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                      Hours by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                    </h3>
+                    {aggregates.byArea.length === 0 ? (
+                      <p className="text-xs text-gray-500">No area data.</p>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {(() => {
+                          const max = aggregates.byArea[0][1] || 1
+                          return aggregates.byArea.map(([name, hours]) => (
+                            <div key={name} className="flex items-center gap-2 text-xs">
+                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                <div className="h-full bg-emerald-500" style={{ width: `${(hours / max) * 100}%` }} />
+                              </div>
+                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                                {hours.toFixed(0)}h
+                              </div>
+                            </div>
+                          ))
+                        })()}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Hours by Fleet (stacked + legend) */}
+                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Fleet</h3>
+                    {aggregates.byFleet.length === 0 ? (
+                      <p className="text-xs text-gray-500">No fleet data.</p>
+                    ) : (
+                      <>
+                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                          {aggregates.byFleet.map(([name, hours], i) => (
+                            <div
+                              key={name}
+                              style={{
+                                width: `${(hours / aggregates.grandTotalHours) * 100}%`,
+                                backgroundColor: palette[i % palette.length],
+                              }}
+                              title={`${name}: ${hours.toFixed(0)}h`}
+                            />
+                          ))}
+                        </div>
+                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                          {aggregates.byFleet.map(([name, hours], i) => (
                             <div key={name} className="flex items-center gap-2 text-xs">
                               <span
                                 className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"

--- a/app/devices/applications/usage/[appName]/page.tsx
+++ b/app/devices/applications/usage/[appName]/page.tsx
@@ -2,7 +2,7 @@
 
 export const dynamic = 'force-dynamic'
 
-import { useEffect, useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useParams, useSearchParams } from "next/navigation"
 import { formatRelativeTime } from "../../../../../src/lib/time"
@@ -48,7 +48,7 @@ interface ApiResponse {
   lastUpdated: string
 }
 
-type SortColumn = 'deviceName' | 'location' | 'totalHours' | 'launchCount' | 'userCount' | 'lastUsed'
+type SortColumn = 'deviceName' | 'location' | 'usage' | 'catalog' | 'area' | 'totalHours' | 'launchCount' | 'userCount' | 'lastUsed'
 
 function formatDuration(seconds: number): string {
   if (!seconds || seconds <= 0) return '0m'
@@ -78,6 +78,7 @@ export default function ApplicationUsageByDevicePage() {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
   const [linkCopied, setLinkCopied] = useState(false)
   const [widgetsExpanded, setWidgetsExpanded] = useState(true)
+  const [metric, setMetric] = useState<'hours' | 'launches'>('launches')
 
   useEffect(() => {
     let cancelled = false
@@ -117,15 +118,24 @@ export default function ApplicationUsageByDevicePage() {
   // already have so this stays a single-request page.
   const aggregates = useMemo(() => {
     const devices = data?.devices ?? []
-    const grandTotalHours = devices.reduce((s, d) => s + d.totalHours, 0) || 1
+    const valueOf = (d: DeviceRow) => metric === 'hours' ? d.totalHours : d.launchCount
+    const grandTotal = devices.reduce((s, d) => s + valueOf(d), 0) || 1
+
+    const isUnknown = (k: string | null | undefined) => {
+      if (!k) return true
+      const v = k.trim().toLowerCase()
+      return v === '' || v === 'unknown' || v === 'null' || v === 'n/a'
+    }
 
     const sumBy = (keyFn: (d: DeviceRow) => string | null): Array<[string, number]> => {
       const m = new Map<string, number>()
       for (const d of devices) {
-        const k = keyFn(d) || 'Unknown'
-        m.set(k, (m.get(k) ?? 0) + d.totalHours)
+        const raw = keyFn(d)
+        if (isUnknown(raw)) continue
+        const k = raw as string
+        m.set(k, (m.get(k) ?? 0) + valueOf(d))
       }
-      return [...m.entries()].sort((a, b) => b[1] - a[1])
+      return [...m.entries()].filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1])
     }
 
     const byLocation = sumBy(d => d.location).slice(0, 10)
@@ -134,21 +144,34 @@ export default function ApplicationUsageByDevicePage() {
     const byArea = sumBy(d => d.department).slice(0, 10)
     const byFleet = sumBy(d => d.fleet)
 
-    // Hours distribution: histogram bins
-    const bins: Array<{ label: string; count: number; min: number; max: number }> = [
-      { label: '0–10h', count: 0, min: 0, max: 10 },
-      { label: '10–50h', count: 0, min: 10, max: 50 },
-      { label: '50–100h', count: 0, min: 50, max: 100 },
-      { label: '100–250h', count: 0, min: 100, max: 250 },
-      { label: '250h+', count: 0, min: 250, max: Infinity },
-    ]
+    // Distribution: histogram bins (units depend on metric)
+    const binDefs = metric === 'hours'
+      ? [
+          { label: '0–10h', min: 0, max: 10 },
+          { label: '10–50h', min: 10, max: 50 },
+          { label: '50–100h', min: 50, max: 100 },
+          { label: '100–250h', min: 100, max: 250 },
+          { label: '250h+', min: 250, max: Infinity },
+        ]
+      : [
+          { label: '0–10', min: 0, max: 10 },
+          { label: '10–50', min: 10, max: 50 },
+          { label: '50–250', min: 50, max: 250 },
+          { label: '250–1000', min: 250, max: 1000 },
+          { label: '1000+', min: 1000, max: Infinity },
+        ]
+    const bins = binDefs.map(b => ({ ...b, count: 0 }))
     for (const d of devices) {
-      const bin = bins.find(b => d.totalHours >= b.min && d.totalHours < b.max)
+      const v = valueOf(d)
+      const bin = bins.find(b => v >= b.min && v < b.max)
       if (bin) bin.count += 1
     }
 
-    return { grandTotalHours, byLocation, byCatalog, byUsage, byArea, byFleet, bins }
-  }, [data])
+    return { grandTotal, byLocation, byCatalog, byUsage, byArea, byFleet, bins }
+  }, [data, metric])
+
+  const fmtVal = (v: number) => metric === 'hours' ? `${v.toFixed(0)}h` : v.toLocaleString()
+  const metricLabel = metric === 'hours' ? 'Hours' : 'Launches'
 
   const palette = ['#3b82f6', '#22c55e', '#a855f7', '#f59e0b', '#ec4899', '#06b6d4', '#84cc16', '#ef4444']
 
@@ -163,6 +186,15 @@ export default function ApplicationUsageByDevicePage() {
           break
         case 'location':
           cmp = (a.location || '').localeCompare(b.location || '')
+          break
+        case 'usage':
+          cmp = (a.usage || '').localeCompare(b.usage || '')
+          break
+        case 'catalog':
+          cmp = (a.catalog || '').localeCompare(b.catalog || '')
+          break
+        case 'area':
+          cmp = (a.department || '').localeCompare(b.department || '')
           break
         case 'totalHours':
           cmp = a.totalHours - b.totalHours
@@ -196,13 +228,14 @@ export default function ApplicationUsageByDevicePage() {
 
   const exportCSV = () => {
     if (!sortedDevices.length) return
-    const header = ['Device', 'Serial', 'Location', 'Catalog', 'Usage', 'Asset Tag', 'Hours', 'Launches', 'Users', 'Variants', 'First Used', 'Last Used']
+    const header = ['Usage', 'Catalog', 'Area', 'Location', 'Device', 'Serial', 'Asset Tag', 'Hours', 'Launches', 'Users', 'Variants', 'First Used', 'Last Used']
     const rows = sortedDevices.map(d => [
+      d.usage || '',
+      d.catalog || '',
+      d.department || '',
+      d.location || '',
       d.deviceName,
       d.serialNumber,
-      d.location || '',
-      d.catalog || '',
-      d.usage || '',
       d.assetTag || '',
       d.totalHours.toFixed(2),
       d.launchCount,
@@ -305,212 +338,224 @@ export default function ApplicationUsageByDevicePage() {
                 className="w-full flex items-center justify-between px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors"
               >
                 <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Widgets</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    Aggregate stats across {data.summary.deviceCount} {data.summary.deviceCount === 1 ? 'device' : 'devices'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <div
+                    className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      onClick={() => setMetric('launches')}
+                      className={`px-3 py-1 ${metric === 'launches' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+                    >
+                      Launches
+                    </button>
+                    <button
+                      onClick={() => setMetric('hours')}
+                      className={`px-3 py-1 ${metric === 'hours' ? 'bg-blue-600 text-white' : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'}`}
+                    >
+                      Hours
+                    </button>
+                  </div>
                   <svg
-                    className={`w-4 h-4 text-gray-500 transition-transform ${widgetsExpanded ? 'rotate-90' : ''}`}
+                    className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${widgetsExpanded ? 'rotate-90' : 'rotate-180'}`}
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
                   >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
-                  <span className="text-sm font-semibold text-gray-900 dark:text-white">Widgets</span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    Aggregate stats across {data.summary.deviceCount} {data.summary.deviceCount === 1 ? 'device' : 'devices'}
-                  </span>
                 </div>
-                <span className="text-xs text-gray-400">{widgetsExpanded ? 'Click to collapse' : 'Click to expand'}</span>
               </button>
               <CollapsibleSection expanded={widgetsExpanded}>
-                <div className="px-6 pb-5 grid grid-cols-1 md:grid-cols-2 gap-5">
-                  {/* Hours by Location (top 10) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Hours by Location <span className="text-xs font-normal text-gray-500">(top 10)</span>
-                    </h3>
-                    {aggregates.byLocation.length === 0 ? (
-                      <p className="text-xs text-gray-500">No location data.</p>
-                    ) : (
-                      <div className="space-y-1.5">
-                        {(() => {
-                          const max = aggregates.byLocation[0][1] || 1
-                          return aggregates.byLocation.map(([name, hours]) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-blue-500" style={{ width: `${(hours / max) * 100}%` }} />
-                              </div>
-                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                                {hours.toFixed(0)}h
-                              </div>
-                            </div>
-                          ))
-                        })()}
+                <div className="px-6 pb-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                  {/* Row 1: By Usage | By Catalog | Distribution */}
+
+                  {/* By Usage Type */}
+                  {aggregates.byUsage.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{metricLabel} by Usage Type</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {aggregates.byUsage.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / aggregates.grandTotal) * 100}%`,
+                              backgroundColor: palette[i % palette.length],
+                            }}
+                            title={`${name}: ${fmtVal(val)}`}
+                          />
+                        ))}
                       </div>
-                    )}
-                  </div>
-
-                  {/* Hours by Catalog (stacked + legend) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Catalog</h3>
-                    {aggregates.byCatalog.length === 0 ? (
-                      <p className="text-xs text-gray-500">No catalog data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {aggregates.byCatalog.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / aggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: palette[i % palette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {aggregates.byUsage.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: palette[i % palette.length] }}
                             />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {aggregates.byCatalog.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: palette[i % palette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / aggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
-
-                  {/* Hours by Usage Type */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Usage Type</h3>
-                    {aggregates.byUsage.length === 0 ? (
-                      <p className="text-xs text-gray-500">No usage-type data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {aggregates.byUsage.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / aggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: palette[i % palette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
-                            />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {aggregates.byUsage.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: palette[i % palette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / aggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
-
-                  {/* Hours by Area (top 10) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Hours by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
-                    </h3>
-                    {aggregates.byArea.length === 0 ? (
-                      <p className="text-xs text-gray-500">No area data.</p>
-                    ) : (
-                      <div className="space-y-1.5">
-                        {(() => {
-                          const max = aggregates.byArea[0][1] || 1
-                          return aggregates.byArea.map(([name, hours]) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 truncate text-gray-700 dark:text-gray-300" title={name}>{name}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-emerald-500" style={{ width: `${(hours / max) * 100}%` }} />
-                              </div>
-                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                                {hours.toFixed(0)}h
-                              </div>
-                            </div>
-                          ))
-                        })()}
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtVal(val)} ({((val / aggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
                       </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
 
-                  {/* Hours by Fleet (stacked + legend) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Hours by Fleet</h3>
-                    {aggregates.byFleet.length === 0 ? (
-                      <p className="text-xs text-gray-500">No fleet data.</p>
-                    ) : (
-                      <>
-                        <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
-                          {aggregates.byFleet.map(([name, hours], i) => (
-                            <div
-                              key={name}
-                              style={{
-                                width: `${(hours / aggregates.grandTotalHours) * 100}%`,
-                                backgroundColor: palette[i % palette.length],
-                              }}
-                              title={`${name}: ${hours.toFixed(0)}h`}
+                  {/* By Catalog */}
+                  {aggregates.byCatalog.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{metricLabel} by Catalog</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {aggregates.byCatalog.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / aggregates.grandTotal) * 100}%`,
+                              backgroundColor: palette[i % palette.length],
+                            }}
+                            title={`${name}: ${fmtVal(val)}`}
+                          />
+                        ))}
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {aggregates.byCatalog.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: palette[i % palette.length] }}
                             />
-                          ))}
-                        </div>
-                        <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
-                          {aggregates.byFleet.map(([name, hours], i) => (
-                            <div key={name} className="flex items-center gap-2 text-xs">
-                              <span
-                                className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                                style={{ backgroundColor: palette[i % palette.length] }}
-                              />
-                              <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                              <span className="ml-auto tabular-nums text-gray-500">
-                                {hours.toFixed(0)}h ({((hours / aggregates.grandTotalHours) * 100).toFixed(0)}%)
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )}
-                  </div>
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtVal(val)} ({((val / aggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
 
-                  {/* Hours Distribution (histogram of devices by usage bucket) */}
-                  <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
-                    <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-                      Device Hours Distribution
-                    </h3>
-                    {(() => {
-                      const max = Math.max(...aggregates.bins.map(b => b.count), 1)
-                      return (
-                        <div className="space-y-1.5">
-                          {aggregates.bins.map(b => (
-                            <div key={b.label} className="flex items-center gap-2 text-xs">
-                              <div className="w-20 text-gray-700 dark:text-gray-300">{b.label}</div>
-                              <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
-                                <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
+                  {/* Device Distribution (histogram by metric bucket) */}
+                  {aggregates.bins.some(b => b.count > 0) && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        Device {metricLabel} Distribution
+                      </h3>
+                      {(() => {
+                        const max = Math.max(...aggregates.bins.map(b => b.count), 1)
+                        return (
+                          <div className="space-y-1.5">
+                            {aggregates.bins.map(b => (
+                              <div key={b.label} className="flex items-center gap-2 text-xs">
+                                <div className="w-20 text-gray-700 dark:text-gray-300">{b.label}</div>
+                                <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
+                                </div>
+                                <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
+                                </div>
                               </div>
-                              <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
-                                {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      )
-                    })()}
-                  </div>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
+
+                  {/* Row 2: By Fleet | By Area | By Location */}
+
+                  {/* By Fleet */}
+                  {aggregates.byFleet.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">{metricLabel} by Fleet</h3>
+                      <div className="flex h-4 rounded overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        {aggregates.byFleet.map(([name, val], i) => (
+                          <div
+                            key={name}
+                            style={{
+                              width: `${(val / aggregates.grandTotal) * 100}%`,
+                              backgroundColor: palette[i % palette.length],
+                            }}
+                            title={`${name}: ${fmtVal(val)}`}
+                          />
+                        ))}
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                        {aggregates.byFleet.map(([name, val], i) => (
+                          <div key={name} className="flex items-center gap-2 text-xs">
+                            <span
+                              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                              style={{ backgroundColor: palette[i % palette.length] }}
+                            />
+                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500">
+                              {fmtVal(val)} ({((val / aggregates.grandTotal) * 100).toFixed(0)}%)
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* By Area (top 10) */}
+                  {aggregates.byArea.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        {metricLabel} by Area <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                      </h3>
+                      {(() => {
+                        const max = aggregates.byArea[0][1] || 1
+                        return (
+                          <div className="grid grid-cols-[minmax(0,max-content)_1fr_auto] gap-x-2 gap-y-1.5 items-center text-xs">
+                            {aggregates.byArea.map(([name, val]) => (
+                              <React.Fragment key={name}>
+                                <div className="whitespace-nowrap text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                                <div className="bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-emerald-500" style={{ width: `${(val / max) * 100}%` }} />
+                                </div>
+                                <div className="text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {fmtVal(val)}
+                                </div>
+                              </React.Fragment>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
+
+                  {/* By Location (top 10) */}
+                  {aggregates.byLocation.length > 0 && (
+                    <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/50 dark:bg-gray-900/30">
+                      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
+                        {metricLabel} by Location <span className="text-xs font-normal text-gray-500">(top 10)</span>
+                      </h3>
+                      {(() => {
+                        const max = aggregates.byLocation[0][1] || 1
+                        return (
+                          <div className="grid grid-cols-[minmax(0,max-content)_1fr_auto] gap-x-2 gap-y-1.5 items-center text-xs">
+                            {aggregates.byLocation.map(([name, val]) => (
+                              <React.Fragment key={name}>
+                                <div className="whitespace-nowrap text-gray-700 dark:text-gray-300" title={name}>{name}</div>
+                                <div className="bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
+                                  <div className="h-full bg-blue-500" style={{ width: `${(val / max) * 100}%` }} />
+                                </div>
+                                <div className="text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                  {fmtVal(val)}
+                                </div>
+                              </React.Fragment>
+                            ))}
+                          </div>
+                        )
+                      })()}
+                    </div>
+                  )}
                 </div>
               </CollapsibleSection>
             </div>
@@ -536,9 +581,21 @@ export default function ApplicationUsageByDevicePage() {
                   <tr>
                     <th
                       className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
-                      onClick={() => toggleSort('deviceName')}
+                      onClick={() => toggleSort('usage')}
                     >
-                      Device{sortArrow('deviceName')}
+                      Usage{sortArrow('usage')}
+                    </th>
+                    <th
+                      className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                      onClick={() => toggleSort('catalog')}
+                    >
+                      Catalog{sortArrow('catalog')}
+                    </th>
+                    <th
+                      className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                      onClick={() => toggleSort('area')}
+                    >
+                      Area{sortArrow('area')}
                     </th>
                     <th
                       className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
@@ -546,11 +603,11 @@ export default function ApplicationUsageByDevicePage() {
                     >
                       Location{sortArrow('location')}
                     </th>
-                    <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Catalog
-                    </th>
-                    <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                      Usage
+                    <th
+                      className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                      onClick={() => toggleSort('deviceName')}
+                    >
+                      Device{sortArrow('deviceName')}
                     </th>
                     <th
                       className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
@@ -581,6 +638,18 @@ export default function ApplicationUsageByDevicePage() {
                 <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                   {sortedDevices.map((d) => (
                     <tr key={d.serialNumber} className="hover:bg-blue-50 dark:hover:bg-blue-900/10">
+                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
+                        {d.usage || '-'}
+                      </td>
+                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
+                        {d.catalog || '-'}
+                      </td>
+                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
+                        {d.department || '-'}
+                      </td>
+                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
+                        {d.location || '-'}
+                      </td>
                       <td className="px-4 lg:px-6 py-3">
                         <Link
                           href={`/device/${encodeURIComponent(d.serialNumber)}`}
@@ -594,15 +663,6 @@ export default function ApplicationUsageByDevicePage() {
                             {d.appVariantCount} variants
                           </div>
                         )}
-                      </td>
-                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
-                        {d.location || '-'}
-                      </td>
-                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
-                        {d.catalog || '-'}
-                      </td>
-                      <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
-                        {d.usage || '-'}
                       </td>
                       <td className="px-4 lg:px-6 py-3">
                         <div className="text-sm font-medium text-blue-600 dark:text-blue-400">

--- a/app/devices/applications/usage/[appName]/page.tsx
+++ b/app/devices/applications/usage/[appName]/page.tsx
@@ -16,6 +16,7 @@ interface DeviceRow {
   location: string | null
   room: string | null
   department: string | null
+  area: string | null
   fleet: string | null
   assetTag: string | null
   totalSeconds: number
@@ -141,7 +142,7 @@ export default function ApplicationUsageByDevicePage() {
     const byLocation = sumBy(d => d.location).slice(0, 10)
     const byCatalog = sumBy(d => d.catalog)
     const byUsage = sumBy(d => d.usage)
-    const byArea = sumBy(d => d.department).slice(0, 10)
+    const byArea = sumBy(d => d.area || d.department).slice(0, 10)
     const byFleet = sumBy(d => d.fleet)
 
     // Distribution: histogram bins (units depend on metric)
@@ -194,7 +195,7 @@ export default function ApplicationUsageByDevicePage() {
           cmp = (a.catalog || '').localeCompare(b.catalog || '')
           break
         case 'area':
-          cmp = (a.department || '').localeCompare(b.department || '')
+          cmp = ((a.area || a.department || '')).localeCompare(b.area || b.department || '')
           break
         case 'totalHours':
           cmp = a.totalHours - b.totalHours
@@ -232,7 +233,7 @@ export default function ApplicationUsageByDevicePage() {
     const rows = sortedDevices.map(d => [
       d.usage || '',
       d.catalog || '',
-      d.department || '',
+      d.area || d.department || '',
       d.location || '',
       d.deviceName,
       d.serialNumber,
@@ -645,7 +646,7 @@ export default function ApplicationUsageByDevicePage() {
                         {d.catalog || '-'}
                       </td>
                       <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
-                        {d.department || '-'}
+                        {d.area || d.department || '-'}
                       </td>
                       <td className="px-4 lg:px-6 py-3 text-sm text-gray-900 dark:text-white">
                         {d.location || '-'}

--- a/app/devices/applications/usage/[appName]/page.tsx
+++ b/app/devices/applications/usage/[appName]/page.tsx
@@ -434,8 +434,8 @@ export default function ApplicationUsageByDevicePage() {
                               <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded h-3 overflow-hidden">
                                 <div className="h-full bg-purple-500" style={{ width: `${(b.count / max) * 100}%` }} />
                               </div>
-                              <div className="w-16 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                                {b.count} {b.count === 1 ? 'device' : 'devices'}
+                              <div className="w-28 text-right tabular-nums whitespace-nowrap text-gray-700 dark:text-gray-300">
+                                {b.count.toLocaleString()} {b.count === 1 ? 'device' : 'devices'}
                               </div>
                             </div>
                           ))}

--- a/app/devices/hardware/page.tsx
+++ b/app/devices/hardware/page.tsx
@@ -92,6 +92,8 @@ function HardwarePageContent() {
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
   
   // Main devices (with inventory) from the devices API
   const { devices: allDevices } = useDeviceData()
@@ -106,6 +108,12 @@ function HardwarePageContent() {
     )).sort() as string[],
     locations: Array.from(new Set(
       allDevices.map((d: any) => d.modules?.inventory?.location).filter(Boolean)
+    )).sort() as string[],
+    areas: Array.from(new Set(
+      allDevices.map((d: any) => d.modules?.inventory?.area || d.modules?.inventory?.department).filter(Boolean)
+    )).sort() as string[],
+    fleets: Array.from(new Set(
+      allDevices.map((d: any) => d.modules?.inventory?.fleet).filter(Boolean)
     )).sort() as string[],
     locationCounts: allDevices.reduce((acc: Record<string, number>, d: any) => {
       const loc = d.modules?.inventory?.location
@@ -172,22 +180,31 @@ function HardwarePageContent() {
   const toggleLocation = (location: string) => {
     setSelectedLocations(prev => prev.includes(location) ? prev.filter(l => l !== location) : [...prev, location])
   }
+  const toggleArea = (area: string) => {
+    setSelectedAreas(prev => prev.includes(area) ? prev.filter(a => a !== area) : [...prev, area])
+  }
+  const toggleFleet = (fleet: string) => {
+    setSelectedFleets(prev => prev.includes(fleet) ? prev.filter(f => f !== fleet) : [...prev, fleet])
+  }
 
   const _hasActiveFilters = () => {
     return selectedModels.length > 0 || selectedMemoryRanges.length > 0 || selectedStorageRanges.length > 0 ||
            selectedArchitectures.length > 0 || selectedDeviceTypes.length > 0 || selectedProcessors.length > 0 ||
            selectedGraphics.length > 0 || selectedPlatforms.length > 0 || selectedStatuses.length > 0 ||
-           selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0
+           selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedLocations.length > 0 ||
+           selectedAreas.length > 0 || selectedFleets.length > 0
   }
 
   // Count for Selections accordion (inventory filters only)
-  const totalSelectionsFilters = selectedStatuses.length + selectedUsages.length + selectedCatalogs.length + selectedLocations.length
-  
+  const totalSelectionsFilters = selectedStatuses.length + selectedUsages.length + selectedCatalogs.length +
+    selectedLocations.length + selectedAreas.length + selectedFleets.length
+
   // Count for all active filters (for Clear button)
-  const totalActiveFilters = selectedModels.length + selectedMemoryRanges.length + selectedStorageRanges.length + 
-    selectedArchitectures.length + selectedDeviceTypes.length + selectedProcessors.length + 
+  const totalActiveFilters = selectedModels.length + selectedMemoryRanges.length + selectedStorageRanges.length +
+    selectedArchitectures.length + selectedDeviceTypes.length + selectedProcessors.length +
     selectedGraphics.length + selectedPlatforms.length + selectedChipConfigs.length + selectedStatuses.length +
-    selectedUsages.length + selectedCatalogs.length + selectedLocations.length
+    selectedUsages.length + selectedCatalogs.length + selectedLocations.length +
+    selectedAreas.length + selectedFleets.length
 
   const clearAllFilters = () => {
     setSelectedModels([])
@@ -203,6 +220,8 @@ function HardwarePageContent() {
     setSelectedUsages([])
     setSelectedCatalogs([])
     setSelectedLocations([])
+    setSelectedAreas([])
+    setSelectedFleets([])
     setSearchQuery('')
   }
   
@@ -641,6 +660,8 @@ function HardwarePageContent() {
     if (selectedUsages.length > 0 && !selectedUsages.includes(inventory.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(inventory.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(inventory.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes((inventory as any).area || (inventory as any).department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes((inventory as any).fleet || '')) return false
 
     // Hardware-specific filters (from widget charts)
     if (selectedPlatforms.length > 0 && !selectedPlatforms.includes(getDevicePlatform(h))) return false
@@ -821,6 +842,28 @@ function HardwarePageContent() {
                     <div className="flex flex-wrap gap-2">
                       {filterOptions.catalogs.map(catalog => (
                         <button key={catalog} onClick={() => toggleCatalog(catalog)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedCatalogs.includes(catalog) ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{catalog}</button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {/* Area Filter */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button key={area} onClick={() => toggleArea(area)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedAreas.includes(area) ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{area}</button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {/* Fleet Filter */}
+                {filterOptions.fleets.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.fleets.map(fleet => (
+                        <button key={fleet} onClick={() => toggleFleet(fleet)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedFleets.includes(fleet) ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{fleet}</button>
                       ))}
                     </div>
                   </div>

--- a/app/devices/hardware/page.tsx
+++ b/app/devices/hardware/page.tsx
@@ -197,10 +197,6 @@ function HardwarePageContent() {
            selectedAreas.length > 0 || selectedFleets.length > 0
   }
 
-  // Count for Selections accordion (inventory filters only)
-  const totalSelectionsFilters = selectedStatuses.length + selectedUsages.length + selectedCatalogs.length +
-    selectedLocations.length + selectedAreas.length + selectedFleets.length
-
   // Count for all active filters (for Clear button)
   const totalActiveFilters = selectedModels.length + selectedMemoryRanges.length + selectedStorageRanges.length +
     selectedArchitectures.length + selectedDeviceTypes.length + selectedProcessors.length +

--- a/app/devices/hardware/page.tsx
+++ b/app/devices/hardware/page.tsx
@@ -846,17 +846,6 @@ function HardwarePageContent() {
                     </div>
                   </div>
                 )}
-                {/* Area Filter */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button key={area} onClick={() => toggleArea(area)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedAreas.includes(area) ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{area}</button>
-                      ))}
-                    </div>
-                  </div>
-                )}
                 {/* Fleet Filter */}
                 {filterOptions.fleets.length > 0 && (
                   <div>
@@ -864,6 +853,17 @@ function HardwarePageContent() {
                     <div className="flex flex-wrap gap-2">
                       {filterOptions.fleets.map(fleet => (
                         <button key={fleet} onClick={() => toggleFleet(fleet)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedFleets.includes(fleet) ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{fleet}</button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {/* Area Filter - Full width row above Location */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button key={area} onClick={() => toggleArea(area)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedAreas.includes(area) ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{area}</button>
                       ))}
                     </div>
                   </div>

--- a/app/devices/hardware/page.tsx
+++ b/app/devices/hardware/page.tsx
@@ -11,6 +11,7 @@ import { Copy } from "lucide-react"
 import { CollapsibleSection } from "../../../src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "../../../src/hooks/useScrollCollapse"
 import { useDeviceData } from "../../../src/hooks/useDeviceData"
+import DeviceFilters, { FilterOptions } from "../../../src/components/shared/DeviceFilters"
 import { 
   ArchitectureDonutChart, 
   MemoryBreakdownChart, 
@@ -99,7 +100,8 @@ function HardwarePageContent() {
   const { devices: allDevices } = useDeviceData()
 
   // Filter options computed from inventory data
-  const filterOptions = {
+  const filterOptions: FilterOptions = {
+    statuses: ['Active', 'Stale', 'Missing'],
     usages: Array.from(new Set(
       allDevices.map((d: any) => d.modules?.inventory?.usage).filter(Boolean)
     )).sort() as string[],
@@ -115,12 +117,12 @@ function HardwarePageContent() {
     fleets: Array.from(new Set(
       allDevices.map((d: any) => d.modules?.inventory?.fleet).filter(Boolean)
     )).sort() as string[],
-    locationCounts: allDevices.reduce((acc: Record<string, number>, d: any) => {
-      const loc = d.modules?.inventory?.location
-      if (loc) acc[loc] = (acc[loc] || 0) + 1
-      return acc
-    }, {} as Record<string, number>)
   }
+  const locationCounts = allDevices.reduce((acc: Record<string, number>, d: any) => {
+    const loc = d.modules?.inventory?.location
+    if (loc) acc[loc] = (acc[loc] || 0) + 1
+    return acc
+  }, {} as Record<string, number>)
   
   const handleSort = (column: typeof sortColumn) => {
     if (sortColumn === column) {
@@ -804,87 +806,28 @@ function HardwarePageContent() {
             </div>
           </div>
 
-          {/* Selections Accordion */}
-          <div className="border-b border-gray-200 dark:border-gray-700">
-            <button onClick={() => setFiltersExpanded(!filtersExpanded)} className="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Selections</span>
-                {totalSelectionsFilters > 0 && <span className="px-2 py-0.5 text-xs font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 rounded-full">{totalSelectionsFilters} active</span>}
-              </div>
-              <svg className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${effectiveFiltersExpanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-            </button>
-            <CollapsibleSection expanded={effectiveFiltersExpanded}>
-              <div className="px-6 pb-4 space-y-4">
-                {/* Status Filter */}
-                <div>
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Status</div>
-                  <div className="flex flex-wrap gap-2">
-                    {['Active', 'Stale', 'Missing'].map(status => (
-                      <button key={status} onClick={() => toggleStatus(status)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedStatuses.includes(status) ? (status === 'Active' ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700' : status === 'Stale' ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700' : 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 border-red-300 dark:border-red-700') : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{status}</button>
-                    ))}
-                  </div>
-                </div>
-                {/* Usage Filter */}
-                {filterOptions.usages.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Usage</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.usages.map(usage => (
-                        <button key={usage} onClick={() => toggleUsage(usage)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedUsages.includes(usage) ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{usage}</button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {/* Catalog Filter */}
-                {filterOptions.catalogs.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.catalogs.map(catalog => (
-                        <button key={catalog} onClick={() => toggleCatalog(catalog)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedCatalogs.includes(catalog) ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{catalog}</button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {/* Fleet Filter */}
-                {filterOptions.fleets.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.fleets.map(fleet => (
-                        <button key={fleet} onClick={() => toggleFleet(fleet)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedFleets.includes(fleet) ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{fleet}</button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {/* Area Filter - Full width row above Location */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button key={area} onClick={() => toggleArea(area)} className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${selectedAreas.includes(area) ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{area}</button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {/* Location Filter */}
-                {filterOptions.locations.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Location</div>
-                    <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto">
-                      {(() => { const maxCount = Math.max(...Object.values(filterOptions.locationCounts).map(Number), 1); return filterOptions.locations.map(location => {
-                        const count = filterOptions.locationCounts[location] || 0
-                        const scale = count / maxCount
-                        const sizeClass = scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold' : scale > 0.3 ? 'px-3 py-1 text-xs font-medium' : 'px-2.5 py-0.5 text-[11px]'
-                        return <button key={location} onClick={() => toggleLocation(location)} title={`${location} (${count} devices)`} className={`${sizeClass} rounded-full border transition-colors ${selectedLocations.includes(location) ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700' : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'}`}>{location}</button>
-                      })})()}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </CollapsibleSection>
-          </div>
+          {/* Selections accordion (shared component) */}
+          <DeviceFilters
+            filterOptions={filterOptions}
+            selectedStatuses={selectedStatuses}
+            selectedCatalogs={selectedCatalogs}
+            selectedAreas={selectedAreas}
+            selectedLocations={selectedLocations}
+            selectedFleets={selectedFleets}
+            selectedUsages={selectedUsages}
+            onStatusToggle={toggleStatus}
+            onCatalogToggle={toggleCatalog}
+            onAreaToggle={toggleArea}
+            onLocationToggle={toggleLocation}
+            onFleetToggle={toggleFleet}
+            onUsageToggle={toggleUsage}
+            onClearAll={clearAllFilters}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            expanded={effectiveFiltersExpanded}
+            onToggle={() => setFiltersExpanded(!filtersExpanded)}
+            locationCounts={locationCounts}
+          />
 
           {/* Widgets Accordion */}
           <div className="border-b border-gray-200 dark:border-gray-700">

--- a/app/devices/identity/page.tsx
+++ b/app/devices/identity/page.tsx
@@ -9,6 +9,7 @@ import { formatRelativeTime } from "../../../src/lib/time"
 import { usePlatformFilterSafe, normalizePlatform } from "../../../src/providers/PlatformFilterProvider"
 import { CollapsibleSection } from "../../../src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "../../../src/hooks/useScrollCollapse"
+import DeviceFilters, { FilterOptions } from "../../../src/components/shared/DeviceFilters"
 
 interface IdentityDevice {
   id: string
@@ -53,6 +54,13 @@ interface IdentityDevice {
     avgSessionMinutes: number
     medianSessionMinutes: number
   } | null
+  // Inventory dimensions (for Selections accordion)
+  usage?: string | null
+  catalog?: string | null
+  location?: string | null
+  area?: string | null
+  department?: string | null
+  fleet?: string | null
 }
 
 function LoadingSkeleton() {
@@ -129,11 +137,26 @@ function IdentityPageContent() {
   const [searchQuery, setSearchQuery] = useState(searchParams.get('search') || '')
   const [adminFilter, setAdminFilter] = useState('all')
   const [widgetsExpanded, setWidgetsExpanded] = useState(true)
+  const [filtersExpanded, setFiltersExpanded] = useState(false)
   // Utilization report mode
   const [showUtilizationReport, setShowUtilizationReport] = useState(false)
   // Widget click filters
   const [directoryFilter, setDirectoryFilter] = useState<string | null>(null)
   const [authFilter, setAuthFilter] = useState<string | null>(null)
+  // Selections accordion state
+  const [selectedUsages, setSelectedUsages] = useState<string[]>([])
+  const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const toggleUsage = (u: string) => setSelectedUsages(p => p.includes(u) ? p.filter(x => x !== u) : [...p, u])
+  const toggleCatalog = (c: string) => setSelectedCatalogs(p => p.includes(c) ? p.filter(x => x !== c) : [...p, c])
+  const toggleLocation = (l: string) => setSelectedLocations(p => p.includes(l) ? p.filter(x => x !== l) : [...p, l])
+  const toggleArea = (a: string) => setSelectedAreas(p => p.includes(a) ? p.filter(x => x !== a) : [...p, a])
+  const toggleFleet = (f: string) => setSelectedFleets(p => p.includes(f) ? p.filter(x => x !== f) : [...p, f])
+  const clearAllSelections = () => {
+    setSelectedUsages([]); setSelectedCatalogs([]); setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
+  }
   // Expandable legend categories
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
   const toggleCategory = (label: string) => {
@@ -147,8 +170,8 @@ function IdentityPageContent() {
   const hasActiveWidgetFilter = directoryFilter !== null || authFilter !== null
   const clearWidgetFilters = () => { setDirectoryFilter(null); setAuthFilter(null) }
 
-  const { tableContainerRef, effectiveWidgetsExpanded } = useScrollCollapse(
-    { widgets: widgetsExpanded },
+  const { tableContainerRef, effectiveFiltersExpanded, effectiveWidgetsExpanded } = useScrollCollapse(
+    { filters: filtersExpanded, widgets: widgetsExpanded },
     { enabled: !loading }
   )
   
@@ -235,6 +258,12 @@ function IdentityPageContent() {
       }
     }
     
+    if (selectedUsages.length > 0 && !selectedUsages.includes(d.usage || '')) return false
+    if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(d.catalog || '')) return false
+    if (selectedLocations.length > 0 && !selectedLocations.includes(d.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(d.area || d.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(d.fleet || '')) return false
+
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
       return (
@@ -244,7 +273,7 @@ function IdentityPageContent() {
         d.loggedInUsernames?.some(u => u?.toLowerCase().includes(query))
       )
     }
-    
+
     return true
   }).sort((a, b) => {
     let aValue: string | number = ''
@@ -476,6 +505,43 @@ function IdentityPageContent() {
               </button>
             </div>
           )}
+
+          {/* Selections accordion (shared component) */}
+          {(() => {
+            const sharedFilterOptions: FilterOptions = {
+              statuses: [],
+              usages: Array.from(new Set(platformFilteredDevices.map(d => d.usage).filter(Boolean) as string[])).sort(),
+              catalogs: Array.from(new Set(platformFilteredDevices.map(d => d.catalog).filter(Boolean) as string[])).sort(),
+              areas: Array.from(new Set(platformFilteredDevices.map(d => d.area || d.department).filter(Boolean) as string[])).sort(),
+              locations: Array.from(new Set(platformFilteredDevices.map(d => d.location).filter(Boolean) as string[])).sort(),
+              fleets: Array.from(new Set(platformFilteredDevices.map(d => d.fleet).filter(Boolean) as string[])).sort(),
+            }
+            const locCounts: Record<string, number> = {}
+            platformFilteredDevices.forEach(d => { if (d.location) locCounts[d.location] = (locCounts[d.location] || 0) + 1 })
+            return (
+              <DeviceFilters
+                filterOptions={sharedFilterOptions}
+                selectedStatuses={[]}
+                selectedCatalogs={selectedCatalogs}
+                selectedAreas={selectedAreas}
+                selectedLocations={selectedLocations}
+                selectedFleets={selectedFleets}
+                selectedUsages={selectedUsages}
+                onStatusToggle={() => { /* no statuses on /identity */ }}
+                onCatalogToggle={toggleCatalog}
+                onAreaToggle={toggleArea}
+                onLocationToggle={toggleLocation}
+                onFleetToggle={toggleFleet}
+                onUsageToggle={toggleUsage}
+                onClearAll={clearAllSelections}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                expanded={effectiveFiltersExpanded}
+                onToggle={() => setFiltersExpanded(!filtersExpanded)}
+                locationCounts={locCounts}
+              />
+            )
+          })()}
 
           {/* Widgets Accordion */}
           <div className="border-b border-gray-200 dark:border-gray-700">

--- a/app/devices/installs/page.tsx
+++ b/app/devices/installs/page.tsx
@@ -200,14 +200,6 @@ function InstallsPageContent() {
     )
   }
 
-  const togglePlatform = (platform: string) => {
-    setSelectedPlatforms(prev => 
-      prev.includes(platform) 
-        ? prev.filter(p => p !== platform)
-        : [...prev, platform]
-    )
-  }
-
   const clearAllFilters = () => {
     setSelectedInstalls([])
     setSelectedUsages([])

--- a/app/devices/installs/page.tsx
+++ b/app/devices/installs/page.tsx
@@ -27,6 +27,7 @@ interface FilterOptions {
   catalogs: string[]
   rooms: string[]
   fleets: string[]
+  areas: string[]
   platforms: string[]
   devicesWithData: number
 }
@@ -46,6 +47,8 @@ interface InstallRecord {
   catalog?: string
   room?: string
   fleet?: string
+  area?: string
+  department?: string
   platform?: string
   manifest?: string
   raw?: any
@@ -119,8 +122,9 @@ function InstallsPageContent() {
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedRooms, setSelectedRooms] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([])
-  
+
   // Track last applied filters to detect changes for smart button text
   const [lastAppliedFilters, setLastAppliedFilters] = useState<{
     installs: string[]
@@ -128,9 +132,10 @@ function InstallsPageContent() {
     catalogs: string[]
     rooms: string[]
     fleets: string[]
+    areas: string[]
     platforms: string[]
-  }>({ installs: [], usages: [], catalogs: [], rooms: [], fleets: [], platforms: [] })
-  
+  }>({ installs: [], usages: [], catalogs: [], rooms: [], fleets: [], areas: [], platforms: [] })
+
   const [filterOptions, setFilterOptions] = useState<FilterOptions>({
     managedInstalls: [],
     otherInstalls: [],
@@ -140,6 +145,7 @@ function InstallsPageContent() {
     catalogs: [],
     rooms: [],
     fleets: [],
+    areas: [],
     platforms: [],
     devicesWithData: 0
   })
@@ -178,10 +184,18 @@ function InstallsPageContent() {
   }
 
   const toggleFleet = (fleet: string) => {
-    setSelectedFleets(prev => 
-      prev.includes(fleet) 
+    setSelectedFleets(prev =>
+      prev.includes(fleet)
         ? prev.filter(f => f !== fleet)
         : [...prev, fleet]
+    )
+  }
+
+  const toggleArea = (area: string) => {
+    setSelectedAreas(prev =>
+      prev.includes(area)
+        ? prev.filter(a => a !== area)
+        : [...prev, area]
     )
   }
 
@@ -199,6 +213,7 @@ function InstallsPageContent() {
     setSelectedCatalogs([])
     setSelectedRooms([])
     setSelectedFleets([])
+    setSelectedAreas([])
     setSelectedPlatforms([])
     setSearchQuery('')
     setItemsStatusFilter('all')
@@ -367,6 +382,7 @@ function InstallsPageContent() {
       selectedCatalogs.forEach(catalog => params.append('catalogs', catalog))
       selectedRooms.forEach(room => params.append('rooms', room))
       selectedFleets.forEach(fleet => params.append('fleets', fleet))
+      selectedAreas.forEach(area => params.append('areas', area))
       selectedPlatforms.forEach(platform => params.append('platforms', platform))
 
       const response = await fetch(`/api/devices/installs?${params}`, {
@@ -416,6 +432,7 @@ function InstallsPageContent() {
         catalogs: [...selectedCatalogs],
         rooms: [...selectedRooms],
         fleets: [...selectedFleets],
+        areas: [...selectedAreas],
         platforms: [...selectedPlatforms]
       })
     } catch (error) {
@@ -448,8 +465,9 @@ function InstallsPageContent() {
            !arraysEqual(selectedCatalogs, lastAppliedFilters.catalogs) ||
            !arraysEqual(selectedRooms, lastAppliedFilters.rooms) ||
            !arraysEqual(selectedFleets, lastAppliedFilters.fleets) ||
+           !arraysEqual(selectedAreas, lastAppliedFilters.areas) ||
            !arraysEqual(selectedPlatforms, lastAppliedFilters.platforms)
-  }, [selectedInstalls, selectedUsages, selectedCatalogs, selectedRooms, selectedFleets, selectedPlatforms, lastAppliedFilters, installs.length])
+  }, [selectedInstalls, selectedUsages, selectedCatalogs, selectedRooms, selectedFleets, selectedAreas, selectedPlatforms, lastAppliedFilters, installs.length])
   
   // Helper function to classify item status
   const classifyItemStatus = (item: any): 'installed' | 'pending' | 'error' | 'warning' | 'removed' => {
@@ -583,7 +601,7 @@ function InstallsPageContent() {
     setSelectedCimianVersion('')
     setSortColumn('deviceName')
     setSortDirection('asc')
-    setLastAppliedFilters({ installs: [], usages: [], catalogs: [], rooms: [], fleets: [], platforms: [] })
+    setLastAppliedFilters({ installs: [], usages: [], catalogs: [], rooms: [], fleets: [], areas: [], platforms: [] })
     setSearchQuery('')
     setItemsStatusFilter('all')
     setDeviceStatusFilter('all')
@@ -594,6 +612,7 @@ function InstallsPageContent() {
     setSelectedCatalogs([])
     setSelectedRooms([])
     setSelectedFleets([])
+    setSelectedAreas([])
     setSelectedPlatforms([])
     // Go to Generate Report view with filters expanded
     setIsGeneratingReport(true)
@@ -682,6 +701,12 @@ function InstallsPageContent() {
         return selectedFleets.some(f => fleet.toLowerCase().includes(f.toLowerCase()))
       })
     }
+    if (selectedAreas.length > 0) {
+      filtered = filtered.filter(device => {
+        const area = (device.area || device.department || '').toLowerCase()
+        return selectedAreas.some(a => area.includes(a.toLowerCase()))
+      })
+    }
     if (selectedPlatforms.length > 0) {
       filtered = filtered.filter(device => {
         const platform = device.platform?.toLowerCase() || ''
@@ -727,7 +752,7 @@ function InstallsPageContent() {
     })
     
     return filtered
-  }, [configReportData, deviceStatusFilter, installStatusFilter, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedPlatforms, selectedRooms, searchQuery, sortColumn, sortDirection])
+  }, [configReportData, deviceStatusFilter, installStatusFilter, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedAreas, selectedPlatforms, selectedRooms, searchQuery, sortColumn, sortDirection])
   
   // Filter installs based on search query AND inventory filters AND device status AND install status
   const filteredInstalls = useMemo(() => {
@@ -808,8 +833,14 @@ function InstallsPageContent() {
     
     // Apply Fleet filter
     if (selectedFleets.length > 0) {
-      filtered = filtered.filter(install => 
+      filtered = filtered.filter(install =>
         install.fleet && selectedFleets.includes(install.fleet)
+      )
+    }
+    // Apply Area filter
+    if (selectedAreas.length > 0) {
+      filtered = filtered.filter(install =>
+        (install.area || install.department) && selectedAreas.includes((install.area || install.department) as string)
       )
     }
     
@@ -854,7 +885,7 @@ function InstallsPageContent() {
     })
 
     return sorted
-  }, [installs, searchQuery, selectedUsages, selectedCatalogs, selectedFleets, selectedPlatforms, selectedRooms, deviceStatusFilter, installStatusFilter, sortColumn, sortDirection])
+  }, [installs, searchQuery, selectedUsages, selectedCatalogs, selectedFleets, selectedAreas, selectedPlatforms, selectedRooms, deviceStatusFilter, installStatusFilter, sortColumn, sortDirection])
 
   useEffect(() => {
     fetchFilterOptions()
@@ -960,6 +991,12 @@ function InstallsPageContent() {
           return selectedFleets.some(f => fleet.toLowerCase().includes(f.toLowerCase()))
         })
       }
+      if (selectedAreas.length > 0) {
+        dataToCount = dataToCount.filter(device => {
+          const area = (device.area || device.department || '').toLowerCase()
+          return selectedAreas.some(a => area.includes(a.toLowerCase()))
+        })
+      }
       if (selectedPlatforms.length > 0) {
         dataToCount = dataToCount.filter(device => {
           const platform = device.platform?.toLowerCase() || ''
@@ -1042,8 +1079,13 @@ function InstallsPageContent() {
         )
       }
       if (selectedFleets.length > 0) {
-        installsToCount = installsToCount.filter(install => 
+        installsToCount = installsToCount.filter(install =>
           install.fleet && selectedFleets.includes(install.fleet)
+        )
+      }
+      if (selectedAreas.length > 0) {
+        installsToCount = installsToCount.filter(install =>
+          (install.area || install.department) && selectedAreas.includes((install.area || install.department) as string)
         )
       }
       if (selectedPlatforms.length > 0) {
@@ -1142,7 +1184,7 @@ function InstallsPageContent() {
       })
     }
     return counts
-  }, [installs, platformFilteredDevices, devicesWithErrors, devicesWithWarnings, devicesWithPending, searchQuery, itemsStatusFilter, isConfigReport, configReportData, installStatusFilter, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedPlatforms, selectedRooms])
+  }, [installs, platformFilteredDevices, devicesWithErrors, devicesWithWarnings, devicesWithPending, searchQuery, itemsStatusFilter, isConfigReport, configReportData, installStatusFilter, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedAreas, selectedPlatforms, selectedRooms])
 
   // Calculate install status counts (Installed/Pending/Warnings/Errors/Removed)
   // Counts should reflect data with OTHER filters applied (not installStatusFilter itself)
@@ -1207,6 +1249,12 @@ function InstallsPageContent() {
         dataToCount = dataToCount.filter(device => {
           const fleet = device.fleet?.toLowerCase() || ''
           return selectedFleets.some(f => fleet.toLowerCase().includes(f.toLowerCase()))
+        })
+      }
+      if (selectedAreas.length > 0) {
+        dataToCount = dataToCount.filter(device => {
+          const area = (device.area || device.department || '').toLowerCase()
+          return selectedAreas.some(a => area.includes(a.toLowerCase()))
         })
       }
       if (selectedPlatforms.length > 0) {
@@ -1274,8 +1322,13 @@ function InstallsPageContent() {
         )
       }
       if (selectedFleets.length > 0) {
-        installsToCount = installsToCount.filter(install => 
+        installsToCount = installsToCount.filter(install =>
           install.fleet && selectedFleets.includes(install.fleet)
+        )
+      }
+      if (selectedAreas.length > 0) {
+        installsToCount = installsToCount.filter(install =>
+          (install.area || install.department) && selectedAreas.includes((install.area || install.department) as string)
         )
       }
       if (selectedPlatforms.length > 0) {
@@ -1306,33 +1359,37 @@ function InstallsPageContent() {
       })
     }
     return counts
-  }, [installs, configReportData, isConfigReport, deviceStatusFilter, searchQuery, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedPlatforms, selectedRooms])
+  }, [installs, configReportData, isConfigReport, deviceStatusFilter, searchQuery, selectedManifest, selectedSoftwareRepo, selectedMunkiVersion, selectedCimianVersion, selectedUsages, selectedCatalogs, selectedFleets, selectedAreas, selectedPlatforms, selectedRooms])
 
   // Compute available filter options from the current report data (installs array)
   // Only show filter values that actually exist in the report
   const reportFilterOptions = useMemo(() => {
     if (installs.length === 0) {
-      return { usages: [], catalogs: [], fleets: [], platforms: [], rooms: [] }
+      return { usages: [], catalogs: [], fleets: [], areas: [], platforms: [], rooms: [] }
     }
-    
+
     const usages = new Set<string>()
     const catalogs = new Set<string>()
     const fleets = new Set<string>()
+    const areas = new Set<string>()
     const platforms = new Set<string>()
     const rooms = new Set<string>()
-    
+
     installs.forEach(install => {
       if (install.usage) usages.add(install.usage)
       if (install.catalog) catalogs.add(install.catalog)
       if (install.fleet) fleets.add(install.fleet)
+      const a = install.area || install.department
+      if (a) areas.add(a)
       if (install.platform) platforms.add(install.platform)
       if (install.room) rooms.add(install.room)
     })
-    
+
     return {
       usages: Array.from(usages).sort(),
       catalogs: Array.from(catalogs).sort(),
       fleets: Array.from(fleets).sort(),
+      areas: Array.from(areas).sort(),
       platforms: Array.from(platforms).sort(),
       rooms: Array.from(rooms).sort()
     }
@@ -1395,6 +1452,12 @@ function InstallsPageContent() {
       filtered = filtered.filter((device: any) => {
         const fleet = device.modules?.inventory?.fleet?.toLowerCase() || ''
         return selectedFleets.some(f => fleet.toLowerCase().includes(f.toLowerCase()))
+      })
+    }
+    if (selectedAreas.length > 0) {
+      filtered = filtered.filter((device: any) => {
+        const area = (device.modules?.inventory?.area || device.modules?.inventory?.department || '').toLowerCase()
+        return selectedAreas.some(a => area.includes(a.toLowerCase()))
       })
     }
     if (selectedPlatforms.length > 0) {
@@ -1480,7 +1543,7 @@ function InstallsPageContent() {
     }
     
     return filtered
-  }, [itemsStatusFilter, deviceStatusFilter, platformFilteredDevices, devicesWithErrors, devicesWithWarnings, devicesWithPending, searchQuery, selectedInstalls, selectedUsages, selectedCatalogs, selectedFleets, selectedPlatforms, selectedRooms])
+  }, [itemsStatusFilter, deviceStatusFilter, platformFilteredDevices, devicesWithErrors, devicesWithWarnings, devicesWithPending, searchQuery, selectedInstalls, selectedUsages, selectedCatalogs, selectedFleets, selectedAreas, selectedPlatforms, selectedRooms])
 
   // Aggregate items with errors across all devices
   const itemsWithErrors = useMemo(() => {
@@ -3160,9 +3223,9 @@ function InstallsPageContent() {
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                     Filters
                   </span>
-                  {(selectedInstalls.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedPlatforms.length > 0) && (
+                  {(selectedInstalls.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0) && (
                     <span className="px-2 py-0.5 text-xs rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                      {selectedInstalls.length + selectedUsages.length + selectedCatalogs.length + selectedRooms.length + selectedFleets.length + selectedPlatforms.length} active
+                      {selectedInstalls.length + selectedUsages.length + selectedCatalogs.length + selectedRooms.length + selectedFleets.length + selectedAreas.length + selectedPlatforms.length} active
                     </span>
                   )}
                 </div>
@@ -3294,6 +3357,30 @@ function InstallsPageContent() {
                   </div>
                   )}
 
+                  {/* Area Filter - Only show if data exists */}
+                  {activeFilters.areas && activeFilters.areas.length > 0 && (
+                  <div>
+                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
+                    </h3>
+                    <div className="flex flex-wrap gap-1">
+                      {activeFilters.areas.map((area: string) => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
+                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
+                          }`}
+                        >
+                          {area}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  )}
+
                   {/* Fleet Filter - Only show if data exists */}
                   {activeFilters.fleets && activeFilters.fleets.length > 0 && (
                   <div>
@@ -3307,7 +3394,7 @@ function InstallsPageContent() {
                           onClick={() => toggleFleet(fleet)}
                           className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
                             selectedFleets.includes(fleet)
-                              ? 'bg-orange-100 text-orange-800 border-orange-300 dark:bg-orange-900 dark:text-orange-200 dark:border-orange-600'
+                              ? 'bg-indigo-100 text-indigo-800 border-indigo-300 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-600'
                               : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
                           }`}
                         >
@@ -3545,7 +3632,7 @@ function InstallsPageContent() {
                   )}
                 </div>
                 {/* Clear Filter(s) Button - Show when any filter is active */}
-                {(searchQuery || itemsStatusFilter !== 'all' || deviceStatusFilter !== 'all' || installStatusFilter !== 'all' || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedFleets.length > 0 || selectedPlatforms.length > 0 || selectedRooms.length > 0 || selectedManifest || selectedSoftwareRepo || selectedMunkiVersion || selectedCimianVersion) && (
+                {(searchQuery || itemsStatusFilter !== 'all' || deviceStatusFilter !== 'all' || installStatusFilter !== 'all' || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0 || selectedRooms.length > 0 || selectedManifest || selectedSoftwareRepo || selectedMunkiVersion || selectedCimianVersion) && (
                   <button
                     onClick={() => {
                       setItemsStatusFilter('all')

--- a/app/devices/installs/page.tsx
+++ b/app/devices/installs/page.tsx
@@ -12,6 +12,7 @@ import { PlatformBadge } from '../../../src/components/ui/PlatformBadge'
 import { getDevicePlatform, usePlatformFilterSafe } from '../../../src/providers/PlatformFilterProvider'
 import { CollapsibleSection } from '../../../src/components/ui/CollapsibleSection'
 import { useScrollCollapse } from '../../../src/hooks/useScrollCollapse'
+import DeviceFilters, { FilterOptions as SharedFilterOptions } from '../../../src/components/shared/DeviceFilters'
 
 // Force dynamic rendering
 export const dynamic = 'force-dynamic'
@@ -3210,7 +3211,41 @@ function InstallsPageContent() {
             </div>
           )}
 
-          {/* Filters Accordion - Hide when in generate report mode since items are already expanded */}
+          {/* Selections accordion (shared inventory dimensions) */}
+          {!filtersLoading && (() => {
+            const activeFilters = installs.length > 0 ? reportFilterOptions : filterOptions
+            const sharedFilterOptions: SharedFilterOptions = {
+              statuses: [],
+              usages: activeFilters.usages || [],
+              catalogs: activeFilters.catalogs || [],
+              areas: (activeFilters as any).areas || [],
+              locations: (activeFilters as any).rooms || [],
+              fleets: activeFilters.fleets || [],
+            }
+            return (
+              <DeviceFilters
+                filterOptions={sharedFilterOptions}
+                selectedStatuses={[]}
+                selectedCatalogs={selectedCatalogs}
+                selectedAreas={selectedAreas}
+                selectedLocations={selectedRooms}
+                selectedFleets={selectedFleets}
+                selectedUsages={selectedUsages}
+                onStatusToggle={() => { /* no statuses on /installs */ }}
+                onCatalogToggle={toggleCatalog}
+                onAreaToggle={toggleArea}
+                onLocationToggle={toggleRoom}
+                onFleetToggle={toggleFleet}
+                onUsageToggle={toggleUsage}
+                onClearAll={clearAllFilters}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                locationCounts={roomCounts}
+              />
+            )
+          })()}
+
+          {/* Installs report-builder accordion (page-specific) */}
           {!filtersLoading && (
             <div className="border-b border-gray-200 dark:border-gray-700">
               {/* Accordion Header - Hide button when in generate report mode */}
@@ -3221,7 +3256,7 @@ function InstallsPageContent() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Filters
+                    Installs
                   </span>
                   {(selectedInstalls.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0) && (
                     <span className="px-2 py-0.5 text-xs rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
@@ -3291,195 +3326,6 @@ function InstallsPageContent() {
                   </div>
                 </div>
                 )}
-
-                {/* Inventory Filter Sections - Show from report data when report exists, otherwise from all data */}
-                {(() => {
-                  // Use report-specific filters when report is generated, otherwise use all filter options
-                  // Show filters when: has report data, OR is generating report, OR is in config report mode
-                  if (installs.length === 0 && !isGeneratingReport && !isConfigReport) return null
-                  
-                  const activeFilters = installs.length > 0 ? reportFilterOptions : filterOptions
-                  const hasAnyFilter = (activeFilters.usages?.length > 0) ||
-                    (activeFilters.catalogs?.length > 0) ||
-                    (activeFilters.fleets?.length > 0) ||
-                    (activeFilters.platforms?.length > 0)
-                  
-                  if (!hasAnyFilter) return null
-                  
-                  return (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                  
-                  {/* Usage Filter - Only show if data exists */}
-                  {activeFilters.usages && activeFilters.usages.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Usage {selectedUsages.length > 0 && `(${selectedUsages.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {activeFilters.usages.map((usage: string) => (
-                        <button
-                          key={usage}
-                          onClick={() => toggleUsage(usage)}
-                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                            selectedUsages.includes(usage.toLowerCase())
-                              ? 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {usage}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
-                  {/* Catalog Filter - Only show if data exists */}
-                  {activeFilters.catalogs && activeFilters.catalogs.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Catalog {selectedCatalogs.length > 0 && `(${selectedCatalogs.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {activeFilters.catalogs.map((catalog: string) => (
-                        <button
-                          key={catalog}
-                          onClick={() => toggleCatalog(catalog)}
-                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                            selectedCatalogs.includes(catalog.toLowerCase())
-                              ? 'bg-teal-100 text-teal-800 border-teal-300 dark:bg-teal-900 dark:text-teal-200 dark:border-teal-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {catalog}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
-                  {/* Fleet Filter - Only show if data exists */}
-                  {activeFilters.fleets && activeFilters.fleets.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Fleet {selectedFleets.length > 0 && `(${selectedFleets.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {activeFilters.fleets.map((fleet: string) => (
-                        <button
-                          key={fleet}
-                          onClick={() => toggleFleet(fleet)}
-                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                            selectedFleets.includes(fleet)
-                              ? 'bg-indigo-100 text-indigo-800 border-indigo-300 dark:bg-indigo-900 dark:text-indigo-200 dark:border-indigo-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {fleet}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
-                  {/* Platform Filter - Only show if data exists */}
-                  {activeFilters.platforms && activeFilters.platforms.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Platform {selectedPlatforms.length > 0 && `(${selectedPlatforms.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {activeFilters.platforms.map((platform: string) => (
-                        <button
-                          key={platform}
-                          onClick={() => togglePlatform(platform)}
-                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                            selectedPlatforms.includes(platform)
-                              ? 'bg-blue-100 text-blue-800 border-blue-300 dark:bg-blue-900 dark:text-blue-200 dark:border-blue-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {platform}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
-                </div>
-                  )
-                })()}
-
-                {/* Area Filter - Full width row above Locations */}
-                {(() => {
-                  const activeAreas = installs.length > 0 ? reportFilterOptions.areas : filterOptions.areas
-                  if (!activeAreas || activeAreas.length === 0) return null
-                  return (
-                    <div>
-                      <div className="flex items-center justify-between mb-2">
-                        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                          Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
-                        </h3>
-                      </div>
-                      <div className="flex flex-wrap gap-1">
-                        {activeAreas.map((area: string) => (
-                          <button
-                            key={area}
-                            onClick={() => toggleArea(area)}
-                            className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                              selectedAreas.includes(area)
-                                ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
-                                : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                            }`}
-                          >
-                            {area}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  )
-                })()}
-
-                {/* Locations Filter Cloud - Only show if report data exists AND has locations */}
-                {(() => {
-                  // Only show locations when there's report data
-                  if (installs.length === 0 && !isGeneratingReport) return null
-                  
-                  const activeRooms = installs.length > 0 ? reportFilterOptions.rooms : filterOptions.rooms
-                  const filteredRooms = activeRooms?.filter((room: string) => room.toLowerCase().includes(searchQuery.toLowerCase())) || []
-                  
-                  if (filteredRooms.length === 0) return null
-                  
-                  return (
-                <div>
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      Locations {selectedRooms.length > 0 && `(${selectedRooms.length} selected)`}
-                    </h3>
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                      {(() => { const maxCount = Math.max(...filteredRooms.map((r: string) => roomCounts[r] || 0), 1); return filteredRooms.map((room: string) => {
-                        const count = roomCounts[room] || 0
-                        const scale = count / maxCount
-                        const sizeClass = scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold' : scale > 0.3 ? 'px-3 py-1 text-xs font-medium' : 'px-2.5 py-0.5 text-[11px]'
-                        return (
-                        <button
-                          key={room}
-                          onClick={() => toggleRoom(room)}
-                          title={`${room} (${count} devices)`}
-                          className={`${sizeClass} rounded-full border transition-colors ${
-                            selectedRooms.includes(room)
-                              ? 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-200 dark:border-green-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {room}
-                        </button>
-                        )
-                      })})()}
-                  </div>
-                </div>
-                  )
-                })()}
 
                 {/* Device Status and Install Status Filters - Only show after report is generated */}
                 {!isGeneratingReport && (installs.length > 0 || (isConfigReport && configReportData.length > 0)) && (

--- a/app/devices/installs/page.tsx
+++ b/app/devices/installs/page.tsx
@@ -3357,30 +3357,6 @@ function InstallsPageContent() {
                   </div>
                   )}
 
-                  {/* Area Filter - Only show if data exists */}
-                  {activeFilters.areas && activeFilters.areas.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      {activeFilters.areas.map((area: string) => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
-                              : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  )}
-
                   {/* Fleet Filter - Only show if data exists */}
                   {activeFilters.fleets && activeFilters.fleets.length > 0 && (
                   <div>
@@ -3430,6 +3406,36 @@ function InstallsPageContent() {
                   )}
 
                 </div>
+                  )
+                })()}
+
+                {/* Area Filter - Full width row above Locations */}
+                {(() => {
+                  const activeAreas = installs.length > 0 ? reportFilterOptions.areas : filterOptions.areas
+                  if (!activeAreas || activeAreas.length === 0) return null
+                  return (
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Area {selectedAreas.length > 0 && `(${selectedAreas.length} selected)`}
+                        </h3>
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {activeAreas.map((area: string) => (
+                          <button
+                            key={area}
+                            onClick={() => toggleArea(area)}
+                            className={`px-3 py-1.5 text-xs rounded-full border transition-colors ${
+                              selectedAreas.includes(area)
+                                ? 'bg-purple-100 text-purple-800 border-purple-300 dark:bg-purple-900 dark:text-purple-200 dark:border-purple-600'
+                                : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
+                            }`}
+                          >
+                            {area}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   )
                 })()}
 

--- a/app/devices/management/page.tsx
+++ b/app/devices/management/page.tsx
@@ -345,14 +345,15 @@ function ManagementPageContent() {
   }, {} as Record<string, number>)
 
   // Create filter options for shared DeviceFilters component
+  const isStr = (x: string | undefined | null): x is string => !!x
   const filterOptions: FilterOptions = {
-    statuses: [...new Set(management.map(m => m.status).filter(Boolean))].sort(),
-    catalogs: [...new Set(management.map(m => m.catalog).filter(Boolean))].sort(),
-    areas: [...new Set(management.map(m => m.area || m.department).filter(Boolean))].sort() as string[],
-    locations: [...new Set(management.map(m => m.location).filter(Boolean))].sort(),
-    fleets: [...new Set(management.map(m => m.fleet).filter(Boolean))].sort() as string[],
+    statuses: [...new Set(management.map(m => m.status).filter(isStr))].sort(),
+    catalogs: [...new Set(management.map(m => m.catalog).filter(isStr))].sort(),
+    areas: [...new Set(management.map(m => m.area || m.department).filter(isStr))].sort(),
+    locations: [...new Set(management.map(m => m.location).filter(isStr))].sort(),
+    fleets: [...new Set(management.map(m => m.fleet).filter(isStr))].sort(),
     platforms: [...new Set(management.map(m => m.osName || 'Unknown').filter(p => p !== 'Unknown'))].sort(),
-    usages: [...new Set(management.map(m => m.usage).filter(Boolean))].sort()
+    usages: [...new Set(management.map(m => m.usage).filter(isStr))].sort()
   }
 
   // Compute device count per location for proportional pill sizing

--- a/app/devices/management/page.tsx
+++ b/app/devices/management/page.tsx
@@ -33,6 +33,8 @@ interface Management {
   assetTag?: string
   location?: string
   department?: string
+  area?: string
+  fleet?: string
   autopilotConfig?: any
   osName?: string
 }
@@ -346,9 +348,9 @@ function ManagementPageContent() {
   const filterOptions: FilterOptions = {
     statuses: [...new Set(management.map(m => m.status).filter(Boolean))].sort(),
     catalogs: [...new Set(management.map(m => m.catalog).filter(Boolean))].sort(),
-    areas: [], // Add areas when available in data
+    areas: [...new Set(management.map(m => m.area || m.department).filter(Boolean))].sort() as string[],
     locations: [...new Set(management.map(m => m.location).filter(Boolean))].sort(),
-    fleets: [], // Add fleets when available in data  
+    fleets: [...new Set(management.map(m => m.fleet).filter(Boolean))].sort() as string[],
     platforms: [...new Set(management.map(m => m.osName || 'Unknown').filter(p => p !== 'Unknown'))].sort(),
     usages: [...new Set(management.map(m => m.usage).filter(Boolean))].sort()
   }
@@ -456,6 +458,8 @@ function ManagementPageContent() {
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(m.catalog || '')) return false
     if (selectedUsages.length > 0 && !selectedUsages.includes(m.usage || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(m.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(m.area || m.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(m.fleet || '')) return false
     if (selectedPlatforms.length > 0) {
       const platform = m.osName || ''
       if (!selectedPlatforms.includes(platform)) return false

--- a/app/devices/management/page.tsx
+++ b/app/devices/management/page.tsx
@@ -139,7 +139,6 @@ function ManagementPageContent() {
   const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
-  const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   
   // Sorting state - default to Device column ascending
@@ -202,12 +201,6 @@ function ManagementPageContent() {
     )
   }
   
-  const togglePlatform = (platform: string) => {
-    setSelectedPlatforms(prev => 
-      prev.includes(platform) ? prev.filter(p => p !== platform) : [...prev, platform]
-    )
-  }
-  
   const toggleUsage = (usage: string) => {
     setSelectedUsages(prev => 
       prev.includes(usage) ? prev.filter(u => u !== usage) : [...prev, usage]
@@ -220,7 +213,6 @@ function ManagementPageContent() {
     setSelectedAreas([])
     setSelectedLocations([])
     setSelectedFleets([])
-    setSelectedPlatforms([])
     setSelectedUsages([])
     setProviderFilter('all')
     setEnrollmentStatusFilter('all')
@@ -352,7 +344,6 @@ function ManagementPageContent() {
     areas: [...new Set(management.map(m => m.area || m.department).filter(isStr))].sort(),
     locations: [...new Set(management.map(m => m.location).filter(isStr))].sort(),
     fleets: [...new Set(management.map(m => m.fleet).filter(isStr))].sort(),
-    platforms: [...new Set(management.map(m => m.osName || 'Unknown').filter(p => p !== 'Unknown'))].sort(),
     usages: [...new Set(management.map(m => m.usage).filter(isStr))].sort()
   }
 
@@ -461,10 +452,6 @@ function ManagementPageContent() {
     if (selectedLocations.length > 0 && !selectedLocations.includes(m.location || '')) return false
     if (selectedAreas.length > 0 && !selectedAreas.includes(m.area || m.department || '')) return false
     if (selectedFleets.length > 0 && !selectedFleets.includes(m.fleet || '')) return false
-    if (selectedPlatforms.length > 0) {
-      const platform = m.osName || ''
-      if (!selectedPlatforms.includes(platform)) return false
-    }
     return true
   }).sort((a, b) => {
     // Apply sorting
@@ -912,7 +899,6 @@ function ManagementPageContent() {
             selectedAreas.length > 0 ||
             selectedLocations.length > 0 ||
             selectedFleets.length > 0 ||
-            selectedPlatforms.length > 0 ||
             selectedUsages.length > 0) && (
             <div className="px-6 py-3 bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800 flex items-center justify-between">
               <div className="flex items-center gap-2 text-sm text-yellow-800 dark:text-yellow-200">
@@ -944,14 +930,12 @@ function ManagementPageContent() {
             selectedAreas={selectedAreas}
             selectedLocations={selectedLocations}
             selectedFleets={selectedFleets}
-            selectedPlatforms={selectedPlatforms}
             selectedUsages={selectedUsages}
             onStatusToggle={toggleStatus}
             onCatalogToggle={toggleCatalog}
             onAreaToggle={toggleArea}
             onLocationToggle={toggleLocation}
             onFleetToggle={toggleFleet}
-            onPlatformToggle={togglePlatform}
             onUsageToggle={toggleUsage}
             onClearAll={clearAllFilters}
             searchQuery={searchQuery}

--- a/app/devices/network/page.tsx
+++ b/app/devices/network/page.tsx
@@ -52,6 +52,8 @@ function NetworkPageContent() {
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
   const [speedFilter, setSpeedFilter] = useState<'excellent' | 'good' | 'fair' | 'poor' | 'nodata' | null>(null)
   
   const handleSort = (column: typeof sortColumn) => {
@@ -77,20 +79,35 @@ function NetworkPageContent() {
   }
   
   const toggleLocation = (location: string) => {
-    setSelectedLocations(prev => 
+    setSelectedLocations(prev =>
       prev.includes(location) ? prev.filter(l => l !== location) : [...prev, location]
     )
   }
-  
+
+  const toggleArea = (area: string) => {
+    setSelectedAreas(prev =>
+      prev.includes(area) ? prev.filter(a => a !== area) : [...prev, area]
+    )
+  }
+
+  const toggleFleet = (fleet: string) => {
+    setSelectedFleets(prev =>
+      prev.includes(fleet) ? prev.filter(f => f !== fleet) : [...prev, fleet]
+    )
+  }
+
   const _clearAllFilters = () => {
     setSelectedUsages([])
     setSelectedCatalogs([])
     setSelectedLocations([])
+    setSelectedAreas([])
+    setSelectedFleets([])
     setConnectionFilter('all')
     setSearchQuery('')
   }
-  
-  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length + 
+
+  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length +
+    selectedAreas.length + selectedFleets.length +
     (connectionFilter !== 'all' ? 1 : 0)
 
   // Use useDeviceData hook to get devices with inventory data
@@ -180,7 +197,13 @@ function NetworkPageContent() {
     )).sort() as string[],
     locations: Array.from(new Set(
       devices.map(d => d.modules?.inventory?.location).filter(Boolean)
-    )).sort() as string[]
+    )).sort() as string[],
+    areas: Array.from(new Set(
+      devices.map(d => d.modules?.inventory?.area || d.modules?.inventory?.department).filter(Boolean)
+    )).sort() as string[],
+    fleets: Array.from(new Set(
+      devices.map(d => d.modules?.inventory?.fleet).filter(Boolean)
+    )).sort() as string[],
   }
 
   // Compute location counts for proportional pill sizing
@@ -306,6 +329,8 @@ function NetworkPageContent() {
     if (selectedUsages.length > 0 && !selectedUsages.includes(inventory?.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(inventory?.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(inventory?.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(inventory?.area || inventory?.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(inventory?.fleet || '')) return false
 
     // Network quality widget filter
     if (speedFilter) {
@@ -725,7 +750,51 @@ function NetworkPageContent() {
                     </div>
                   </div>
                 )}
-                
+
+                {/* Area Filter */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {area}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Fleet Filter */}
+                {filterOptions.fleets.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.fleets.map(fleet => (
+                        <button
+                          key={fleet}
+                          onClick={() => toggleFleet(fleet)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedFleets.includes(fleet)
+                              ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {fleet}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 {/* Location Filter */}
                 {filterOptions.locations.length > 0 && (
                   <div>

--- a/app/devices/network/page.tsx
+++ b/app/devices/network/page.tsx
@@ -107,10 +107,6 @@ function NetworkPageContent() {
     setSearchQuery('')
   }
 
-  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length +
-    selectedAreas.length + selectedFleets.length +
-    (connectionFilter !== 'all' ? 1 : 0)
-
   // Use useDeviceData hook to get devices with inventory data
   const { devices } = useDeviceData({
     includeModuleData: false
@@ -214,7 +210,6 @@ function NetworkPageContent() {
     if (loc) acc[loc] = (acc[loc] || 0) + 1
     return acc
   }, {} as Record<string, number>)
-  const maxLocationCount = Math.max(...Object.values(locationCounts).map(Number), 1)
 
   // Calculate wireless statistics for widgets (uses platform-filtered data)
   const wirelessStats = {

--- a/app/devices/network/page.tsx
+++ b/app/devices/network/page.tsx
@@ -751,28 +751,6 @@ function NetworkPageContent() {
                   </div>
                 )}
 
-                {/* Area Filter */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
                 {/* Fleet Filter */}
                 {filterOptions.fleets.length > 0 && (
                   <div>
@@ -789,6 +767,28 @@ function NetworkPageContent() {
                           }`}
                         >
                           {fleet}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Area Filter - Full width row above Location */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {area}
                         </button>
                       ))}
                     </div>

--- a/app/devices/network/page.tsx
+++ b/app/devices/network/page.tsx
@@ -11,6 +11,7 @@ import { usePlatformFilterSafe, getDevicePlatform } from "../../../src/providers
 import { Copy } from "lucide-react"
 import { CollapsibleSection } from "../../../src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "../../../src/hooks/useScrollCollapse"
+import DeviceFilters, { FilterOptions } from "../../../src/components/shared/DeviceFilters"
 
 interface NetworkDevice {
   id: string
@@ -188,7 +189,8 @@ function NetworkPageContent() {
   const vpnDeviceCount = platformFilteredDevices.filter(n => n.networkInfo.vpnActive).length
 
   // Extract unique filter options from devices (inventory data)
-  const filterOptions = {
+  const filterOptions: FilterOptions = {
+    statuses: [],
     usages: Array.from(new Set(
       devices.map(d => d.modules?.inventory?.usage).filter(Boolean)
     )).sort() as string[],
@@ -681,150 +683,28 @@ function NetworkPageContent() {
             </div>
           </div>
 
-          {/* Filters Accordion Section */}
-          <div className="border-b border-gray-200 dark:border-gray-700">
-            <button
-              onClick={() => setFiltersExpanded(!filtersExpanded)}
-              className="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Selections</span>
-                {totalActiveFilters > 0 && (
-                  <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">
-                    {totalActiveFilters} active
-                  </span>
-                )}
-              </div>
-              <svg 
-                className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${effectiveFiltersExpanded ? 'rotate-90' : 'rotate-180'}`} 
-                fill="none" 
-                stroke="currentColor" 
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-            
-            <CollapsibleSection expanded={effectiveFiltersExpanded}>
-              <div className="px-6 pb-4 space-y-4">
-                {/* Usage Filter */}
-                {filterOptions.usages.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Usage</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.usages.map(usage => (
-                        <button
-                          key={usage}
-                          onClick={() => toggleUsage(usage)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedUsages.includes(usage)
-                              ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {usage}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Catalog Filter */}
-                {filterOptions.catalogs.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.catalogs.map(catalog => (
-                        <button
-                          key={catalog}
-                          onClick={() => toggleCatalog(catalog)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedCatalogs.includes(catalog)
-                              ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {catalog}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Fleet Filter */}
-                {filterOptions.fleets.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.fleets.map(fleet => (
-                        <button
-                          key={fleet}
-                          onClick={() => toggleFleet(fleet)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedFleets.includes(fleet)
-                              ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {fleet}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Area Filter - Full width row above Location */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Location Filter */}
-                {filterOptions.locations.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Location</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.locations.map(location => {
-                        const count = locationCounts[location] || 0
-                        const scale = count / maxLocationCount
-                        const sizeClass = scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold' : scale > 0.3 ? 'px-3 py-1 text-xs font-medium' : 'px-2.5 py-0.5 text-[11px]'
-                        return (
-                        <button
-                          key={location}
-                          onClick={() => toggleLocation(location)}
-                          title={`${location} (${count} devices)`}
-                          className={`${sizeClass} rounded-full border transition-colors ${
-                            selectedLocations.includes(location)
-                              ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {location}
-                        </button>
-                        )
-                      })}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </CollapsibleSection>
-          </div>
+          {/* Selections accordion (shared component) */}
+          <DeviceFilters
+            filterOptions={filterOptions}
+            selectedStatuses={[]}
+            selectedCatalogs={selectedCatalogs}
+            selectedAreas={selectedAreas}
+            selectedLocations={selectedLocations}
+            selectedFleets={selectedFleets}
+            selectedUsages={selectedUsages}
+            onStatusToggle={() => { /* no statuses on /network */ }}
+            onCatalogToggle={toggleCatalog}
+            onAreaToggle={toggleArea}
+            onLocationToggle={toggleLocation}
+            onFleetToggle={toggleFleet}
+            onUsageToggle={toggleUsage}
+            onClearAll={_clearAllFilters}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            expanded={effectiveFiltersExpanded}
+            onToggle={() => setFiltersExpanded(!filtersExpanded)}
+            locationCounts={locationCounts}
+          />
 
           {/* Widgets Accordion */}
           <div className="border-b border-gray-200 dark:border-gray-700">

--- a/app/devices/peripherals/page.tsx
+++ b/app/devices/peripherals/page.tsx
@@ -9,6 +9,7 @@ import { formatRelativeTime } from "../../../src/lib/time"
 import { usePlatformFilterSafe, normalizePlatform } from "../../../src/providers/PlatformFilterProvider"
 import { CollapsibleSection } from "../../../src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "../../../src/hooks/useScrollCollapse"
+import DeviceFilters, { FilterOptions } from "../../../src/components/shared/DeviceFilters"
 
 interface Peripheral {
   id: string
@@ -27,6 +28,13 @@ interface Peripheral {
   inputDevices: any[]
   storageDevices: any[]
   lastUpdated: string
+  // Inventory dimensions (for Selections accordion)
+  usage?: string | null
+  catalog?: string | null
+  location?: string | null
+  area?: string | null
+  department?: string | null
+  fleet?: string | null
 }
 
 function LoadingSkeleton() {
@@ -113,9 +121,24 @@ function PeripheralsPageContent() {
   const [sortColumn, setSortColumn] = useState<'device' | 'total' | 'lastSeen'>('device')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
   const [widgetsExpanded, setWidgetsExpanded] = useState(true)
+  const [filtersExpanded, setFiltersExpanded] = useState(false)
+  // Selections accordion state
+  const [selectedUsages, setSelectedUsages] = useState<string[]>([])
+  const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const toggleUsage = (u: string) => setSelectedUsages(p => p.includes(u) ? p.filter(x => x !== u) : [...p, u])
+  const toggleCatalog = (c: string) => setSelectedCatalogs(p => p.includes(c) ? p.filter(x => x !== c) : [...p, c])
+  const toggleLocation = (l: string) => setSelectedLocations(p => p.includes(l) ? p.filter(x => x !== l) : [...p, l])
+  const toggleArea = (a: string) => setSelectedAreas(p => p.includes(a) ? p.filter(x => x !== a) : [...p, a])
+  const toggleFleet = (f: string) => setSelectedFleets(p => p.includes(f) ? p.filter(x => x !== f) : [...p, f])
+  const clearAllSelections = () => {
+    setSelectedUsages([]); setSelectedCatalogs([]); setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
+  }
 
-  const { tableContainerRef, effectiveWidgetsExpanded } = useScrollCollapse(
-    { widgets: widgetsExpanded },
+  const { tableContainerRef, effectiveFiltersExpanded, effectiveWidgetsExpanded } = useScrollCollapse(
+    { filters: filtersExpanded, widgets: widgetsExpanded },
     { enabled: !loading }
   )
   
@@ -198,6 +221,12 @@ function PeripheralsPageContent() {
       (deviceTypeFilter === 'input' && getDeviceCount(peripheral.inputDevices) > 0) ||
       (deviceTypeFilter === 'storage' && getDeviceCount(peripheral.storageDevices) > 0)
     )
+
+    if (selectedUsages.length > 0 && !selectedUsages.includes(peripheral.usage || '')) return false
+    if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(peripheral.catalog || '')) return false
+    if (selectedLocations.length > 0 && !selectedLocations.includes(peripheral.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(peripheral.area || peripheral.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(peripheral.fleet || '')) return false
 
     return matchesSearch && matchesFilter
   }).sort((a, b) => {
@@ -317,6 +346,43 @@ function PeripheralsPageContent() {
               </div>
             </div>
           </div>
+
+          {/* Selections accordion (shared component) */}
+          {(() => {
+            const sharedFilterOptions: FilterOptions = {
+              statuses: [],
+              usages: Array.from(new Set(peripherals.map(p => p.usage).filter(Boolean) as string[])).sort(),
+              catalogs: Array.from(new Set(peripherals.map(p => p.catalog).filter(Boolean) as string[])).sort(),
+              areas: Array.from(new Set(peripherals.map(p => p.area || p.department).filter(Boolean) as string[])).sort(),
+              locations: Array.from(new Set(peripherals.map(p => p.location).filter(Boolean) as string[])).sort(),
+              fleets: Array.from(new Set(peripherals.map(p => p.fleet).filter(Boolean) as string[])).sort(),
+            }
+            const locCounts: Record<string, number> = {}
+            peripherals.forEach(p => { if (p.location) locCounts[p.location] = (locCounts[p.location] || 0) + 1 })
+            return (
+              <DeviceFilters
+                filterOptions={sharedFilterOptions}
+                selectedStatuses={[]}
+                selectedCatalogs={selectedCatalogs}
+                selectedAreas={selectedAreas}
+                selectedLocations={selectedLocations}
+                selectedFleets={selectedFleets}
+                selectedUsages={selectedUsages}
+                onStatusToggle={() => { /* no statuses on /peripherals */ }}
+                onCatalogToggle={toggleCatalog}
+                onAreaToggle={toggleArea}
+                onLocationToggle={toggleLocation}
+                onFleetToggle={toggleFleet}
+                onUsageToggle={toggleUsage}
+                onClearAll={clearAllSelections}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+                expanded={effectiveFiltersExpanded}
+                onToggle={() => setFiltersExpanded(!filtersExpanded)}
+                locationCounts={locCounts}
+              />
+            )
+          })()}
 
           {/* Widgets Accordion */}
           <div className="border-b border-gray-200 dark:border-gray-700">

--- a/app/devices/security/page.tsx
+++ b/app/devices/security/page.tsx
@@ -65,6 +65,9 @@ interface SecurityDevice {
   usage?: string
   location?: string
   assetTag?: string
+  department?: string
+  area?: string
+  fleet?: string
 }
 
 interface CertificateResult {
@@ -478,6 +481,8 @@ function SecurityPageContent() {
     if (selectedStatuses.length > 0 && d.status && !selectedStatuses.includes(d.status)) return false
     if (selectedCatalogs.length > 0 && d.catalog && !selectedCatalogs.includes(d.catalog)) return false
     if (selectedLocations.length > 0 && d.location && !selectedLocations.includes(d.location)) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(d.area || d.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(d.fleet || '')) return false
     if (selectedUsages.length > 0 && d.usage && !selectedUsages.includes(d.usage)) return false
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase()
@@ -514,9 +519,9 @@ function SecurityPageContent() {
   const filterOptions: FilterOptions = {
     statuses: [...new Set(devices.map(d => d.status).filter(Boolean))].sort() as string[],
     catalogs: [...new Set(devices.map(d => d.catalog).filter(Boolean))].sort() as string[],
-    areas: [],
+    areas: [...new Set(devices.map(d => d.area || d.department).filter(Boolean))].sort() as string[],
     locations: [...new Set(devices.map(d => d.location).filter(Boolean))].sort() as string[],
-    fleets: [],
+    fleets: [...new Set(devices.map(d => d.fleet).filter(Boolean))].sort() as string[],
     platforms: [...new Set(devices.map(d => normalizePlatform(d.platform)).filter(p => p !== 'Unknown'))].sort(),
     usages: [...new Set(devices.map(d => d.usage).filter(Boolean))].sort() as string[],
   }
@@ -536,6 +541,8 @@ function SecurityPageContent() {
     if (selectedStatuses.length > 0 && d.status && !selectedStatuses.includes(d.status)) return false
     if (selectedCatalogs.length > 0 && d.catalog && !selectedCatalogs.includes(d.catalog)) return false
     if (selectedLocations.length > 0 && d.location && !selectedLocations.includes(d.location)) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes(d.area || d.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes(d.fleet || '')) return false
     if (selectedPlatforms.length > 0 && !selectedPlatforms.includes(normalizePlatform(d.platform))) return false
     if (selectedUsages.length > 0 && d.usage && !selectedUsages.includes(d.usage)) return false
     // Widget filters

--- a/app/devices/security/page.tsx
+++ b/app/devices/security/page.tsx
@@ -267,7 +267,6 @@ function SecurityPageContent() {
   const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
-  const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
 
   // Widget click-filters
@@ -411,12 +410,11 @@ function SecurityPageContent() {
   const toggleArea = (a: string) => setSelectedAreas(prev => prev.includes(a) ? prev.filter(x => x !== a) : [...prev, a])
   const toggleLocation = (l: string) => setSelectedLocations(prev => prev.includes(l) ? prev.filter(x => x !== l) : [...prev, l])
   const toggleFleet = (f: string) => setSelectedFleets(prev => prev.includes(f) ? prev.filter(x => x !== f) : [...prev, f])
-  const togglePlatform = (p: string) => setSelectedPlatforms(prev => prev.includes(p) ? prev.filter(x => x !== p) : [...prev, p])
   const toggleUsage = (u: string) => setSelectedUsages(prev => prev.includes(u) ? prev.filter(x => x !== u) : [...prev, u])
 
   const clearAllFilters = () => {
     setSelectedStatuses([]); setSelectedCatalogs([]); setSelectedAreas([])
-    setSelectedLocations([]); setSelectedFleets([]); setSelectedPlatforms([]); setSelectedUsages([])
+    setSelectedLocations([]); setSelectedFleets([]); setSelectedUsages([])
     setEncryptionFilter(''); setProtectionFilter(''); setDetectionFilter('')
     setFirewallFilter(''); setTamperingFilter(''); setRemoteFilter('')
     setCertFilter(''); setCveFilter(''); setSearchQuery('')
@@ -477,7 +475,6 @@ function SecurityPageContent() {
 
   const selectionFiltered = devices.filter(d => {
     if (globalPlatformFilter !== 'all' && !isPlatformVisible(normalizePlatform(d.platform))) return false
-    if (selectedPlatforms.length > 0 && !selectedPlatforms.includes(normalizePlatform(d.platform))) return false
     if (selectedStatuses.length > 0 && d.status && !selectedStatuses.includes(d.status)) return false
     if (selectedCatalogs.length > 0 && d.catalog && !selectedCatalogs.includes(d.catalog)) return false
     if (selectedLocations.length > 0 && d.location && !selectedLocations.includes(d.location)) return false
@@ -522,7 +519,6 @@ function SecurityPageContent() {
     areas: [...new Set(devices.map(d => d.area || d.department).filter(Boolean))].sort() as string[],
     locations: [...new Set(devices.map(d => d.location).filter(Boolean))].sort() as string[],
     fleets: [...new Set(devices.map(d => d.fleet).filter(Boolean))].sort() as string[],
-    platforms: [...new Set(devices.map(d => normalizePlatform(d.platform)).filter(p => p !== 'Unknown'))].sort(),
     usages: [...new Set(devices.map(d => d.usage).filter(Boolean))].sort() as string[],
   }
 
@@ -543,7 +539,6 @@ function SecurityPageContent() {
     if (selectedLocations.length > 0 && d.location && !selectedLocations.includes(d.location)) return false
     if (selectedAreas.length > 0 && !selectedAreas.includes(d.area || d.department || '')) return false
     if (selectedFleets.length > 0 && !selectedFleets.includes(d.fleet || '')) return false
-    if (selectedPlatforms.length > 0 && !selectedPlatforms.includes(normalizePlatform(d.platform))) return false
     if (selectedUsages.length > 0 && d.usage && !selectedUsages.includes(d.usage)) return false
     // Widget filters
     if (encryptionFilter && (d.encryptionEnabled ? 'Encrypted' : 'Not Encrypted') !== encryptionFilter) return false
@@ -683,14 +678,12 @@ function SecurityPageContent() {
             selectedAreas={selectedAreas}
             selectedLocations={selectedLocations}
             selectedFleets={selectedFleets}
-            selectedPlatforms={selectedPlatforms}
             selectedUsages={selectedUsages}
             onStatusToggle={toggleStatus}
             onCatalogToggle={toggleCatalog}
             onAreaToggle={toggleArea}
             onLocationToggle={toggleLocation}
             onFleetToggle={toggleFleet}
-            onPlatformToggle={togglePlatform}
             onUsageToggle={toggleUsage}
             onClearAll={clearAllFilters}
             searchQuery={searchQuery}

--- a/app/devices/system/page.tsx
+++ b/app/devices/system/page.tsx
@@ -251,6 +251,8 @@ function SystemPageContent() {
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
   const [selectedEditions, setSelectedEditions] = useState<string[]>([])
   const [selectedActivationStatus, setSelectedActivationStatus] = useState<string[]>([])
   const [selectedLicenseType, setSelectedLicenseType] = useState<string[]>([])
@@ -296,11 +298,23 @@ function SystemPageContent() {
   }
   
   const toggleLocation = (location: string) => {
-    setSelectedLocations(prev => 
+    setSelectedLocations(prev =>
       prev.includes(location) ? prev.filter(l => l !== location) : [...prev, location]
     )
   }
-  
+
+  const toggleArea = (area: string) => {
+    setSelectedAreas(prev =>
+      prev.includes(area) ? prev.filter(a => a !== area) : [...prev, area]
+    )
+  }
+
+  const toggleFleet = (fleet: string) => {
+    setSelectedFleets(prev =>
+      prev.includes(fleet) ? prev.filter(f => f !== fleet) : [...prev, fleet]
+    )
+  }
+
   const toggleEdition = (edition: string) => {
     setSelectedEditions(prev => 
       prev.includes(edition) ? prev.filter(e => e !== edition) : [...prev, edition]
@@ -361,6 +375,8 @@ function SystemPageContent() {
     setSelectedUsages([])
     setSelectedCatalogs([])
     setSelectedLocations([])
+    setSelectedAreas([])
+    setSelectedFleets([])
     setSelectedEditions([])
     setSelectedActivationStatus([])
     setSelectedLicenseType([])
@@ -376,7 +392,8 @@ function SystemPageContent() {
     if (osVersionFilter) router.push('/devices/system')
   }
   
-  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length + 
+  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length +
+    selectedAreas.length + selectedFleets.length +
     selectedEditions.length + selectedActivationStatus.length + selectedLicenseType.length +
     selectedArchitectures.length + selectedTimeZones.length + selectedUptimeBuckets.length + selectedLicenseSources.length +
     selectedPendingBuckets.length +
@@ -462,6 +479,12 @@ function SystemPageContent() {
     )).sort() as string[],
     locations: Array.from(new Set(
       devices.map(d => d.modules?.inventory?.location).filter(Boolean)
+    )).sort() as string[],
+    areas: Array.from(new Set(
+      devices.map(d => d.modules?.inventory?.area || d.modules?.inventory?.department).filter(Boolean)
+    )).sort() as string[],
+    fleets: Array.from(new Set(
+      devices.map(d => d.modules?.inventory?.fleet).filter(Boolean)
     )).sort() as string[],
     editions: Array.from(new Set(
       systems.map(s => s.edition).filter(Boolean)
@@ -605,6 +628,8 @@ function SystemPageContent() {
     if (selectedUsages.length > 0 && !selectedUsages.includes(inventory?.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(inventory?.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(inventory?.location || '')) return false
+    if (selectedAreas.length > 0 && !selectedAreas.includes((inventory as any)?.area || (inventory as any)?.department || '')) return false
+    if (selectedFleets.length > 0 && !selectedFleets.includes((inventory as any)?.fleet || '')) return false
     
     return true
   })
@@ -1075,7 +1100,51 @@ function SystemPageContent() {
                     </div>
                   </div>
                 )}
-                
+
+                {/* Area Filter */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {area}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Fleet Filter */}
+                {filterOptions.fleets.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.fleets.map(fleet => (
+                        <button
+                          key={fleet}
+                          onClick={() => toggleFleet(fleet)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedFleets.includes(fleet)
+                              ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {fleet}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 {/* Location Filter */}
                 {filterOptions.locations.length > 0 && (
                   <div>

--- a/app/devices/system/page.tsx
+++ b/app/devices/system/page.tsx
@@ -16,6 +16,7 @@ import { useDeviceData } from "../../../src/hooks/useDeviceData"
 import { usePlatformFilterSafe, normalizePlatform } from "../../../src/providers/PlatformFilterProvider"
 import { CollapsibleSection } from "../../../src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "../../../src/hooks/useScrollCollapse"
+import DeviceFilters, { FilterOptions } from "../../../src/components/shared/DeviceFilters"
 
 interface SystemDevice {
   id: string
@@ -500,6 +501,16 @@ function SystemPageContent() {
     )).sort() as string[],
   }
 
+  // FilterOptions slice fed to the shared DeviceFilters component (inventory dimensions only)
+  const selectionFilterOptions: FilterOptions = {
+    statuses: [],
+    usages: filterOptions.usages,
+    catalogs: filterOptions.catalogs,
+    areas: filterOptions.areas,
+    locations: filterOptions.locations,
+    fleets: filterOptions.fleets,
+  }
+
   // Compute location counts for proportional pill sizing
   const locationCounts = devices.reduce((acc: Record<string, number>, d: any) => {
     const loc = d.modules?.inventory?.location
@@ -875,162 +886,28 @@ function SystemPageContent() {
             </div>
           </div>
 
-          {/* Selections Accordion Section - First */}
-          <div className="border-b border-gray-200 dark:border-gray-700">
-            <button
-              onClick={() => setFiltersExpanded(!effectiveFiltersExpanded)}
-              className="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Selections</span>
-                {totalActiveFilters > 0 && (
-                  <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">
-                    {totalActiveFilters} active
-                  </span>
-                )}
-              </div>
-              <svg 
-                className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${effectiveFiltersExpanded ? 'rotate-90' : ''}`} 
-                fill="none" 
-                stroke="currentColor" 
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-            
-            <CollapsibleSection expanded={effectiveFiltersExpanded}>
-              <div className="px-6 pb-4 space-y-4">
-                {/* Usage Filter */}
-                {filterOptions.usages.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Usage</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.usages.map(usage => (
-                        <button
-                          key={usage}
-                          onClick={() => toggleUsage(usage)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedUsages.includes(usage)
-                              ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {usage}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Catalog Filter */}
-                {filterOptions.catalogs.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.catalogs.map(catalog => (
-                        <button
-                          key={catalog}
-                          onClick={() => toggleCatalog(catalog)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedCatalogs.includes(catalog)
-                              ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {catalog}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Fleet Filter */}
-                {filterOptions.fleets.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.fleets.map(fleet => (
-                        <button
-                          key={fleet}
-                          onClick={() => toggleFleet(fleet)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedFleets.includes(fleet)
-                              ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {fleet}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Area Filter - Full width row above Location */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Location Filter */}
-                {filterOptions.locations.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Location</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.locations.map(location => {
-                        const count = locationCounts[location] || 0
-                        const scale = count / maxLocationCount
-                        const sizeClass = scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold' : scale > 0.3 ? 'px-3 py-1 text-xs font-medium' : 'px-2.5 py-0.5 text-[11px]'
-                        return (
-                        <button
-                          key={location}
-                          onClick={() => toggleLocation(location)}
-                          title={`${location} (${count} devices)`}
-                          className={`${sizeClass} rounded-full border transition-colors ${
-                            selectedLocations.includes(location)
-                              ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {location}
-                        </button>
-                        )
-                      })}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Clear All Selections */}
-                {totalActiveFilters > 0 && (
-                  <div className="pt-2">
-                    <button
-                      onClick={clearAllFilters}
-                      className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
-                    >
-                      Clear all selections
-                    </button>
-                  </div>
-                )}
-              </div>
-            </CollapsibleSection>
-          </div>
+          {/* Selections accordion (shared component) */}
+          <DeviceFilters
+            filterOptions={selectionFilterOptions}
+            selectedStatuses={[]}
+            selectedCatalogs={selectedCatalogs}
+            selectedAreas={selectedAreas}
+            selectedLocations={selectedLocations}
+            selectedFleets={selectedFleets}
+            selectedUsages={selectedUsages}
+            onStatusToggle={() => { /* no statuses on /system */ }}
+            onCatalogToggle={toggleCatalog}
+            onAreaToggle={toggleArea}
+            onLocationToggle={toggleLocation}
+            onFleetToggle={toggleFleet}
+            onUsageToggle={toggleUsage}
+            onClearAll={clearAllFilters}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            expanded={effectiveFiltersExpanded}
+            onToggle={() => setFiltersExpanded(!filtersExpanded)}
+            locationCounts={locationCounts}
+          />
 
           {/* Widgets Accordion - OS Version Charts */}
           <div className={widgetsExpanded ? '' : 'border-b border-gray-200 dark:border-gray-700'}>

--- a/app/devices/system/page.tsx
+++ b/app/devices/system/page.tsx
@@ -901,162 +901,6 @@ function SystemPageContent() {
             
             <CollapsibleSection expanded={effectiveFiltersExpanded}>
               <div className="px-6 pb-4 space-y-4">
-                {/* OS Version Filter */}
-                {osVersionFilter && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">OS Version</div>
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        onClick={() => router.push('/devices/system')}
-                        className="px-3 py-1 text-xs font-medium rounded-full border transition-colors bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700 flex items-center gap-1 group"
-                      >
-                        {decodeURIComponent(osVersionFilter)}
-                        <svg className="w-3 h-3 group-hover:text-blue-600 dark:group-hover:text-blue-300" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-                      </button>
-                    </div>
-                  </div>
-                )}
-                
-                {/* Edition Filter */}
-                {filterOptions.editions.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Edition</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.editions.map(edition => (
-                        <button
-                          key={edition}
-                          onClick={() => toggleEdition(edition)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedEditions.includes(edition)
-                              ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {edition}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Architecture Filter */}
-                {filterOptions.architectures.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Architecture</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.architectures.map(arch => (
-                        <button
-                          key={arch}
-                          onClick={() => toggleArchitecture(arch)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedArchitectures.includes(arch)
-                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {arch}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Pending Updates Filter */}
-                {systems.some(s => s.pendingUpdatesCount != null) && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Pending Updates</div>
-                    <div className="flex flex-wrap gap-2">
-                      {[
-                        { key: 'up-to-date', label: 'Up to date' },
-                        { key: '1-5', label: '1-5 pending' },
-                        { key: '6-10', label: '6-10 pending' },
-                        { key: '10+', label: '10+ pending' },
-                      ].map(bucket => (
-                        <button
-                          key={bucket.key}
-                          onClick={() => togglePendingBucket(bucket.key)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedPendingBuckets.includes(bucket.key)
-                              ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200 border-orange-300 dark:border-orange-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {bucket.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* License Source Filter */}
-                {filterOptions.licenseSources.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">License Source</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.licenseSources.map(src => (
-                        <button
-                          key={src}
-                          onClick={() => toggleLicenseSource(src)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedLicenseSources.includes(src)
-                              ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 border-amber-300 dark:border-amber-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {src}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                
-                {/* Activation Status Filter */}
-                <div>
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Activation Status</div>
-                  <div className="flex flex-wrap gap-2">
-                    {['Activated', 'Not Activated'].map(status => (
-                      <button
-                        key={status}
-                        onClick={() => toggleActivationStatus(status)}
-                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                          selectedActivationStatus.includes(status)
-                            ? status === 'Activated' 
-                              ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
-                              : 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 border-red-300 dark:border-red-700'
-                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                        }`}
-                      >
-                        {status}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                
-                {/* License Type Filter */}
-                <div>
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">OEM License</div>
-                  <div className="flex flex-wrap gap-2">
-                    {['Has OEM License', 'No OEM License'].map(type => (
-                      <button
-                        key={type}
-                        onClick={() => toggleLicenseType(type)}
-                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                          selectedLicenseType.includes(type)
-                            ? type === 'Has OEM License'
-                              ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border-emerald-300 dark:border-emerald-700'
-                              : 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 border-amber-300 dark:border-amber-700'
-                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                        }`}
-                        title={type === 'Has OEM License' 
-                          ? 'Has usable firmware-embedded (UEFI/BIOS) Pro/Enterprise license' 
-                          : 'No usable OEM license - may lose activation when migrating from AD to Entra ID'}
-                      >
-                        {type}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                
                 {/* Usage Filter */}
                 {filterOptions.usages.length > 0 && (
                   <div>
@@ -1101,28 +945,6 @@ function SystemPageContent() {
                   </div>
                 )}
 
-                {/* Area Filter */}
-                {filterOptions.areas.length > 0 && (
-                  <div>
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                    <div className="flex flex-wrap gap-2">
-                      {filterOptions.areas.map(area => (
-                        <button
-                          key={area}
-                          onClick={() => toggleArea(area)}
-                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                            selectedAreas.includes(area)
-                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                          }`}
-                        >
-                          {area}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
                 {/* Fleet Filter */}
                 {filterOptions.fleets.length > 0 && (
                   <div>
@@ -1139,6 +961,28 @@ function SystemPageContent() {
                           }`}
                         >
                           {fleet}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Area Filter - Full width row above Location */}
+                {filterOptions.areas.length > 0 && (
+                  <div>
+                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+                    <div className="flex flex-wrap gap-2">
+                      {filterOptions.areas.map(area => (
+                        <button
+                          key={area}
+                          onClick={() => toggleArea(area)}
+                          className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                            selectedAreas.includes(area)
+                              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                              : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                          }`}
+                        >
+                          {area}
                         </button>
                       ))}
                     </div>

--- a/app/devices/system/page.tsx
+++ b/app/devices/system/page.tsx
@@ -517,7 +517,6 @@ function SystemPageContent() {
     if (loc) acc[loc] = (acc[loc] || 0) + 1
     return acc
   }, {} as Record<string, number>)
-  const maxLocationCount = Math.max(...Object.values(locationCounts).map(Number), 1)
 
   // Filter systems
   const filteredSystems = systems.filter(s => {

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -92,44 +92,52 @@ export default function DeviceFilters({
         <div className="px-6 pb-4">
           {/* Smart Grid Layout - maximizes space usage */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-x-8 gap-y-4">
-            {/* Status Filter - Always show */}
-            <div>
-              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Status</div>
-              <div className="flex flex-wrap gap-2">
-                {filterOptions.statuses.map(status => (
-                  <button
-                    key={status}
-                    onClick={() => onStatusToggle(status)}
-                    className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                      selectedStatuses.includes(status)
-                        ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
-                        : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    {status.charAt(0).toUpperCase() + status.slice(1)}
-                  </button>
-                ))}
+            {/* Status Filter - When available */}
+            {filterOptions.statuses.length > 0 && (
+              <div>
+                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Status</div>
+                <div className="flex flex-wrap gap-2">
+                  {filterOptions.statuses.map(status => {
+                    const isSelected = selectedStatuses.some(s => s.toLowerCase() === status.toLowerCase())
+                    return (
+                      <button
+                        key={status}
+                        onClick={() => onStatusToggle(status)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                          isSelected
+                            ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border-blue-300 dark:border-blue-700'
+                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {status.charAt(0).toUpperCase() + status.slice(1)}
+                      </button>
+                    )
+                  })}
+                </div>
               </div>
-            </div>
+            )}
 
             {/* Usage Filter - When available */}
             {filterOptions.usages.length > 0 && (
               <div>
                 <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Usage</div>
                 <div className="flex flex-wrap gap-2">
-                  {filterOptions.usages.map(usage => (
-                    <button
-                      key={usage}
-                      onClick={() => onUsageToggle(usage)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                        selectedUsages.includes(usage)
-                          ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {usage}
-                    </button>
-                  ))}
+                  {filterOptions.usages.map(usage => {
+                    const isSelected = selectedUsages.some(s => s.toLowerCase() === usage.toLowerCase())
+                    return (
+                      <button
+                        key={usage}
+                        onClick={() => onUsageToggle(usage)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                          isSelected
+                            ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700'
+                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {usage}
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
             )}
@@ -139,19 +147,22 @@ export default function DeviceFilters({
               <div>
                 <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
                 <div className="flex flex-wrap gap-2">
-                  {filterOptions.catalogs.map(catalog => (
-                    <button
-                      key={catalog}
-                      onClick={() => onCatalogToggle(catalog)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                        selectedCatalogs.includes(catalog)
-                          ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {catalog}
-                    </button>
-                  ))}
+                  {filterOptions.catalogs.map(catalog => {
+                    const isSelected = selectedCatalogs.some(s => s.toLowerCase() === catalog.toLowerCase())
+                    return (
+                      <button
+                        key={catalog}
+                        onClick={() => onCatalogToggle(catalog)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                          isSelected
+                            ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
+                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {catalog}
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
             )}
@@ -161,19 +172,22 @@ export default function DeviceFilters({
               <div>
                 <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
                 <div className="flex flex-wrap gap-2">
-                  {filterOptions.fleets.map(fleet => (
-                    <button
-                      key={fleet}
-                      onClick={() => onFleetToggle(fleet)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                        selectedFleets.includes(fleet)
-                          ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {fleet}
-                    </button>
-                  ))}
+                  {filterOptions.fleets.map(fleet => {
+                    const isSelected = selectedFleets.some(s => s.toLowerCase() === fleet.toLowerCase())
+                    return (
+                      <button
+                        key={fleet}
+                        onClick={() => onFleetToggle(fleet)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                          isSelected
+                            ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
+                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {fleet}
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
             )}
@@ -185,19 +199,22 @@ export default function DeviceFilters({
             <div className="mt-4">
               <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
               <div className="flex flex-wrap gap-2">
-                {filterOptions.areas.map(area => (
-                  <button
-                    key={area}
-                    onClick={() => onAreaToggle(area)}
-                    className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                      selectedAreas.includes(area)
-                        ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                        : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    {area}
-                  </button>
-                ))}
+                {filterOptions.areas.map(area => {
+                  const isSelected = selectedAreas.some(s => s.toLowerCase() === area.toLowerCase())
+                  return (
+                    <button
+                      key={area}
+                      onClick={() => onAreaToggle(area)}
+                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                        isSelected
+                          ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                      }`}
+                    >
+                      {area}
+                    </button>
+                  )
+                })}
               </div>
             </div>
           )}
@@ -217,12 +234,13 @@ export default function DeviceFilters({
                     : scale > 0.7 ? 'px-4 py-1.5 text-sm font-semibold'
                     : scale > 0.3 ? 'px-3 py-1 text-xs font-medium'
                     : 'px-2.5 py-0.5 text-[11px]'
+                  const isSelected = selectedLocations.some(s => s.toLowerCase() === location.toLowerCase())
                   return (
                     <button
                       key={location}
                       onClick={() => onLocationToggle(location)}
                       className={`rounded-full border transition-colors ${sizeClass} ${
-                        selectedLocations.includes(location)
+                        isSelected
                           ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 border-green-300 dark:border-green-700'
                           : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
                       }`}

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -9,7 +9,6 @@ export interface FilterOptions {
   areas: string[]
   locations: string[]
   fleets: string[]
-  platforms: string[]
   usages: string[]
 }
 
@@ -20,14 +19,12 @@ interface DeviceFiltersProps {
   selectedAreas: string[]
   selectedLocations: string[]
   selectedFleets: string[]
-  selectedPlatforms: string[]
   selectedUsages: string[]
   onStatusToggle: (status: string) => void
   onCatalogToggle: (catalog: string) => void
   onAreaToggle: (area: string) => void
   onLocationToggle: (location: string) => void
   onFleetToggle: (fleet: string) => void
-  onPlatformToggle: (platform: string) => void
   onUsageToggle: (usage: string) => void
   onClearAll: () => void
   searchQuery: string
@@ -47,14 +44,12 @@ export default function DeviceFilters({
   selectedAreas,
   selectedLocations,
   selectedFleets,
-  selectedPlatforms,
   selectedUsages,
   onStatusToggle,
   onCatalogToggle,
   onAreaToggle,
   onLocationToggle,
   onFleetToggle,
-  onPlatformToggle,
   onUsageToggle,
   expanded: externalExpanded,
   onToggle,
@@ -63,9 +58,9 @@ export default function DeviceFilters({
   const [internalExpanded, setInternalExpanded] = useState(false)
   const filtersExpanded = externalExpanded !== undefined ? externalExpanded : internalExpanded
   const setFiltersExpanded = (val: boolean) => setInternalExpanded(val)
-  
-  const totalActiveFilters = selectedStatuses.length + selectedCatalogs.length + selectedAreas.length + 
-    selectedLocations.length + selectedFleets.length + selectedPlatforms.length + selectedUsages.length
+
+  const totalActiveFilters = selectedStatuses.length + selectedCatalogs.length + selectedAreas.length +
+    selectedLocations.length + selectedFleets.length + selectedUsages.length
 
   return (
     <div className="border-b border-gray-200 dark:border-gray-700">
@@ -116,28 +111,6 @@ export default function DeviceFilters({
                 ))}
               </div>
             </div>
-
-            {/* Platform Filter - When available */}
-            {filterOptions.platforms.length > 0 && (
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Platform</div>
-                <div className="flex flex-wrap gap-2">
-                  {filterOptions.platforms.map(platform => (
-                    <button
-                      key={platform}
-                      onClick={() => onPlatformToggle(platform)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                        selectedPlatforms.includes(platform)
-                          ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200 border-orange-300 dark:border-orange-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {platform}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
 
             {/* Usage Filter - When available */}
             {filterOptions.usages.length > 0 && (
@@ -233,7 +206,7 @@ export default function DeviceFilters({
           {filterOptions.locations.length > 0 && (
             <div className="mt-4">
               <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Location</div>
-              <div className="flex flex-wrap gap-2 items-center">
+              <div className="flex flex-wrap gap-2 items-center max-h-32 overflow-y-auto">
                 {filterOptions.locations.map(location => {
                   const count = locationCounts?.[location] ?? 0
                   const maxCount = locationCounts ? Math.max(...Object.values(locationCounts), 1) : 1

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -205,28 +205,29 @@ export default function DeviceFilters({
               </div>
             )}
 
-            {/* Area Filter - When available */}
-            {filterOptions.areas.length > 0 && (
-              <div>
-                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
-                <div className="flex flex-wrap gap-2">
-                  {filterOptions.areas.map(area => (
-                    <button
-                      key={area}
-                      onClick={() => onAreaToggle(area)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
-                        selectedAreas.includes(area)
-                          ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {area}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
           </div>
+
+          {/* Area Filter - Full width row above Location */}
+          {filterOptions.areas.length > 0 && (
+            <div className="mt-4">
+              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Area</div>
+              <div className="flex flex-wrap gap-2">
+                {filterOptions.areas.map(area => (
+                  <button
+                    key={area}
+                    onClick={() => onAreaToggle(area)}
+                    className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                      selectedAreas.includes(area)
+                        ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border-purple-300 dark:border-purple-700'
+                        : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    {area}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Location Filter - Full width due to many options */}
           {filterOptions.locations.length > 0 && (

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -26,7 +26,8 @@ interface DeviceFiltersProps {
   onLocationToggle: (location: string) => void
   onFleetToggle: (fleet: string) => void
   onUsageToggle: (usage: string) => void
-  onClearAll: () => void
+  /** When provided, renders a Clear button in the accordion header that resets every dimension at once. */
+  onClearAll?: () => void
   searchQuery: string
   onSearchChange: (query: string) => void
   /** Optional external control of expanded state (for scroll-collapse integration) */
@@ -51,6 +52,7 @@ export default function DeviceFilters({
   onLocationToggle,
   onFleetToggle,
   onUsageToggle,
+  onClearAll,
   expanded: externalExpanded,
   onToggle,
   locationCounts
@@ -77,14 +79,28 @@ export default function DeviceFilters({
             </span>
           )}
         </div>
-        <svg 
-          className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${filtersExpanded ? 'rotate-90' : 'rotate-180'}`} 
-          fill="none" 
-          stroke="currentColor" 
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
+        <div className="flex items-center gap-3">
+          {totalActiveFilters > 0 && onClearAll && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => { e.stopPropagation(); onClearAll() }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onClearAll() } }}
+              className="px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/30 rounded-full hover:bg-red-200 dark:hover:bg-red-900/50 cursor-pointer transition-colors"
+              title="Clear all selections"
+            >
+              Clear
+            </span>
+          )}
+          <svg
+            className={`w-5 h-5 text-gray-400 transition-transform duration-200 ${filtersExpanded ? 'rotate-90' : 'rotate-180'}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
       </button>
       
       {/* Accordion Content */}

--- a/src/hooks/useScrollCollapse.ts
+++ b/src/hooks/useScrollCollapse.ts
@@ -8,7 +8,7 @@ interface AccordionStates {
 }
 
 interface UseScrollCollapseOptions {
-  /** Scroll threshold in px before collapsing (default: 30) */
+  /** Scroll threshold in px before collapsing (default: 150) */
   threshold?: number
   /** Whether the hook is active (disable during loading etc.) */
   enabled?: boolean
@@ -43,7 +43,7 @@ export function useScrollCollapse(
   manualStates: AccordionStates,
   options: UseScrollCollapseOptions = {}
 ): UseScrollCollapseReturn {
-  const { threshold = 30, enabled = true } = options
+  const { threshold = 150, enabled = true } = options
   const tableContainerRef = useRef<HTMLDivElement>(null!)
 
   // Track the current element for callback ref pattern


### PR DESCRIPTION
## Summary

End-to-end rework of the `/devices/applications` report builder and the resulting versions / usage views, plus the single-app drill-down at `/devices/applications/usage/[appName]`. Most user-visible behavior on this page changed, but the rework is self-contained -- the shared `DeviceFilters` component now drives Selections across every `/devices/*` page (already on main), and this PR finishes wiring the applications page into that pattern.

The thread running through every change: **what the user picks in the chip cloud is what the report shows.** Substring + alias matching that previously merged unrelated apps (e.g. `Final Cut Pro` request pulling in `Final Cut Pro Creator Studio` or `Motion` pulling in `MotionBuilder` + Maya plugin processes) is gone; exact-match SQL plus a placeholder for zero-data picks keep the chip cloud and the table in lockstep.

## What changed

**Report builder**
- Migrate Selections to shared `DeviceFilters` (area, fleet, location, usage, catalog dimensions; case-insensitive pill matching)
- Hide the 78k-app inventory picker once a report is generated -- the in-report chip cloud is the only Applications control while a report is open
- Auto-collapse Selections and auto-expand Widgets when a report loads
- Search input pinned top-right above the action button row with `flex-shrink-0` so buttons stay flush right when the Period dropdown widens the row in usage mode

**Report view**
- New `UsageReportAppFilter` chip-cloud accordion: every app in the current report as a togglable chip with search + Select All + Clear. Toggling narrows both the data table and the widget device-set without re-fetching, so users can focus on one or several apps in real time.
- Widget grid (multi-app + single-app drill-down):
  - Launches / Hours metric toggle, default Launches
  - Row layout: \`Usage | Catalog | Distribution\` then \`Fleet | Area | Location\`
  - List-style widgets (Area, Location) use a 3-col grid so labels are fully legible
  - Filter \`Unknown\` / null / N/A buckets, hide empty widgets entirely
- Table inventory columns reordered to drill-down order: \`Usage | Catalog | Area | Location | Device\`. CSV export matches.
- \"No data\" status badge + dimmed row for picker selections that have zero usage_history rows in the lookback window

**Filter integration**
- handleLoadVersionsReport / handleLoadUtilization pass platform, areas, fleets, rooms, locations, usages, catalogs to the API
- Re-fetch when the global platform filter flips
- Row limit raised to 5000 when no application names are selected so area-scoped versions reports surface enough apps
- 45-day period option added to both report views

**Shared**
- `useScrollCollapse` threshold bumped 30 -> 150px so widgets and filters don't snap closed at the slightest table scroll

## Test plan

- [ ] /devices/applications -> Generate Report (versions) with multiple apps selected -> table rows = exactly the picked apps; widgets reflect the device set; CSV columns are Usage | Catalog | Area | Location | Device
- [ ] Same flow but with one of the picked apps having no usage in the past 30 days -> the row appears with a \"No data\" badge and dimmed styling
- [ ] /devices/applications -> Generate Report (usage), toggle a chip off -> table row disappears, Widgets header device count updates, no API refetch
- [ ] /devices/applications/usage/[appName] -> 45-day period -> widget metric toggle Launches/Hours -> Unknown buckets gone -> empty widgets hidden
- [ ] Flip the global platform pill (Mac <-> Windows) on a loaded usage report -> report re-fetches and rescopes
- [ ] Deep link with ?type=versions&areas=Animation -> report auto-generates scoped to area
- [ ] Confirm pill highlight works on /devices/installs and /devices/applications (case-insensitive)