### PR TITLE
Fix MDM provider detection to use active enrollment URL

### DIFF
--- a/app/devices/management/page.tsx
+++ b/app/devices/management/page.tsx
@@ -398,29 +398,30 @@ function ManagementPageContent() {
     // Enrollment Status filter
     if (enrollmentStatusFilter !== 'all' && m.enrollmentStatus !== enrollmentStatusFilter) return false
 
-    // Type filter - Automated vs Manual enrollment method
+    // Type filter - Automated vs Manual enrollment method.
+    // Mirrors the Enrollment Type widget counts (mdmBootstrapCounts) exactly so
+    // the table and the widget always agree. Platform-agnostic: an earlier
+    // version detected Mac from m.osName, which the API never populated, so
+    // every device fell through the Windows path and ADE Macs leaked into the
+    // Manual filter.
     if (typeFilter !== 'all') {
       const autopilot = m.autopilotConfig
-      const platform = m.osName || ''
-      const isMac = platform.toLowerCase().includes('macos') || platform.toLowerCase().includes('mac os')
-      
+      const et = m.enrollmentType || ''
+      const isAutomated = autopilot?.activated === true || autopilot?.activated === 'true' ||
+        et === 'Automated Device Enrollment'
+      const isUserApproved = !isAutomated && et === 'User Approved Enrollment'
+      const isManual = !isAutomated && !isUserApproved &&
+        (et === 'MDM Enrolled' ||
+          (m.enrollmentStatus === 'Enrolled' && et !== 'N/A' && et !== 'Unknown'))
+
       if (typeFilter === 'Unmanaged') {
         if (m.enrollmentType !== 'Unmanaged') return false
       } else if (typeFilter === 'Automated') {
-        if (isMac) {
-          if (m.enrollmentType !== 'Automated Device Enrollment') return false
-        } else {
-          if (!(autopilot?.activated === true || autopilot?.activated === 'true')) return false
-        }
+        if (!isAutomated) return false
       } else if (typeFilter === 'User Approved') {
-        if (m.enrollmentType !== 'User Approved Enrollment') return false
+        if (!isUserApproved) return false
       } else if (typeFilter === 'Manual') {
-        if (isMac) {
-          if (m.enrollmentType !== 'MDM Enrolled') return false
-        } else {
-          if (autopilot?.activated === true || autopilot?.activated === 'true') return false
-          if (!m.enrollmentStatus || m.enrollmentStatus === 'Not Enrolled') return false
-        }
+        if (!isManual) return false
       } else {
         // Other filter value
         return false

--- a/app/devices/management/page.tsx
+++ b/app/devices/management/page.tsx
@@ -256,7 +256,7 @@ function ManagementPageContent() {
           const status = calculateDeviceStatus(mgmt.lastSeen)
           
           // Normalize provider - "Microsoft Intune (Co-managed)" -> "Microsoft Intune"
-          let provider = mgmt.provider || 'Unknown'
+          let provider = mgmt.provider || 'Unmanaged'
           if (provider.startsWith('Microsoft Intune')) {
             provider = 'Microsoft Intune'
           }
@@ -361,12 +361,13 @@ function ManagementPageContent() {
     return acc
   }, {} as Record<string, number>)
 
-  // Get unique providers with counts (filter out Unknown)
+  // Get unique providers with counts. "Unmanaged" (no provider detected) is
+  // included so it shows as its own bar in the Providers widget.
   const providers = Array.from(new Set(
-    platformFilteredManagement.map(m => m.provider).filter(p => p && p !== 'Unknown')
+    platformFilteredManagement.map(m => m.provider).filter(Boolean)
   )).sort()
 
-  // Calculate provider counts (exclude Unknown)
+  // Calculate provider counts
   const providerCounts = providers.reduce((acc, provider) => {
     acc[provider] = platformFilteredManagement.filter(m => m.provider === provider).length
     return acc

--- a/src/components/tabs/ManagementTab.tsx
+++ b/src/components/tabs/ManagementTab.tsx
@@ -75,20 +75,43 @@ function parseMdmCertificate(mdmCertificate: any): {
   }
 }
 
-// Detect MDM provider from certificate data first, then server URL
+// Detect the MDM provider for the device's CURRENT enrollment.
+// The active server/check-in URL is authoritative: the MDM identity certificate
+// lingers in the System keychain after a device migrates between MDMs, so its
+// issuer can name a provider the device has already left. URL wins; the
+// certificate is only a fallback.
 function detectMdmProvider(serverUrl?: string, certificateData?: ReturnType<typeof parseMdmCertificate>): string | undefined {
-  // PRIORITY 1: Explicit provider from certificate (most reliable)
+  // PRIORITY 1: Active enrollment server/check-in URL (reflects the live MDM)
+  if (serverUrl) {
+    const url = serverUrl.toLowerCase()
+    // Open-source MDMs first - check for explicit micromdm/nanomdm in URL
+    if (url.includes('micromdm')) return 'MicroMDM'
+    if (url.includes('nanomdm')) return 'NanoMDM'
+    // Commercial MDMs - be specific with patterns
+    if (url.includes('jamf') || url.includes('jamfcloud')) return 'Jamf Pro'
+    if (url.includes('manage.microsoft.com') || url.includes('intune')) return 'Microsoft Intune'
+    if (url.includes('mosyle')) return 'Mosyle'
+    if (url.includes('kandji')) return 'Kandji'
+    if (url.includes('addigy')) return 'Addigy'
+    if (url.includes('simplemdm')) return 'SimpleMDM'
+    if (url.includes('airwatch.com') || url.includes('workspaceone')) return 'Workspace ONE'
+    if (url.includes('meraki')) return 'Cisco Meraki'
+    if (url.includes('maas360')) return 'MaaS360'
+    if (url.includes('mobileiron') || url.includes('ivanti')) return 'Ivanti'
+  }
+
+  // PRIORITY 2: Explicit provider from certificate data (set by the client)
   if (certificateData?.mdm_provider) {
     return certificateData.mdm_provider
   }
-  
-  // PRIORITY 2: Certificate issuer (very reliable for open-source MDMs)
+
+  // PRIORITY 3: Certificate issuer (fallback - can be stale after a migration)
   if (certificateData?.certificate_issuer) {
     const issuer = certificateData.certificate_issuer.toLowerCase()
     if (issuer.includes('micromdm')) return 'MicroMDM'
     if (issuer.includes('nanomdm')) return 'NanoMDM'
     if (issuer.includes('jamf')) return 'Jamf Pro'
-    if (issuer.includes('microsoft')) return 'Microsoft Intune'
+    if (issuer.includes('microsoft') || issuer.includes('intune')) return 'Microsoft Intune'
     if (issuer.includes('mosyle')) return 'Mosyle'
     if (issuer.includes('kandji')) return 'Kandji'
     if (issuer.includes('addigy')) return 'Addigy'
@@ -96,30 +119,8 @@ function detectMdmProvider(serverUrl?: string, certificateData?: ReturnType<type
     if (issuer.includes('workspace one') || issuer.includes('vmware')) return 'Workspace ONE'
     if (issuer.includes('meraki')) return 'Cisco Meraki'
   }
-  
-  // PRIORITY 3: Server URL patterns (fallback)
-  if (!serverUrl) return undefined
-  const url = serverUrl.toLowerCase()
-  
-  // Open-source MDMs first - check for explicit micromdm/nanomdm in URL
-  if (url.includes('micromdm')) return 'MicroMDM'
-  if (url.includes('nanomdm')) return 'NanoMDM'
-  
-  // Commercial MDMs - be more specific with patterns
-  if (url.includes('jamf') || url.includes('jamfcloud')) return 'Jamf Pro'
-  if (url.includes('manage.microsoft.com') || url.includes('intune')) return 'Microsoft Intune'
-  if (url.includes('mosyle')) return 'Mosyle'
-  if (url.includes('kandji')) return 'Kandji'
-  if (url.includes('addigy')) return 'Addigy'
-  if (url.includes('simplemdm')) return 'SimpleMDM'
-  // NOTE: Removed 'awsmdm' pattern - it's too generic and causes false positives
-  // Only match explicit AirWatch/Workspace ONE patterns
-  if (url.includes('airwatch.com') || url.includes('workspaceone')) return 'Workspace ONE'
-  if (url.includes('meraki')) return 'Cisco Meraki'
-  if (url.includes('maas360')) return 'MaaS360'
-  if (url.includes('mobileiron') || url.includes('ivanti')) return 'Ivanti'
-  
-  // No provider detected from URL - return undefined instead of guessing
+
+  // No provider detected - return undefined instead of guessing
   return undefined
 }
 
@@ -263,8 +264,10 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
                      parseBool(mdmEnrollment.isEnrolled) || 
                      false
   
-  // Get server URL and detect provider (certificate data takes priority)
-  const serverUrl = mdmEnrollment.server_url || mdmEnrollment.serverUrl
+  // Get server/check-in URL and detect provider (active URL takes priority
+  // over the certificate, which can be stale after an MDM migration)
+  const serverUrl = mdmEnrollment.server_url || mdmEnrollment.serverUrl ||
+                    mdmEnrollment.checkin_url || mdmEnrollment.checkinUrl
   const provider = detectMdmProvider(serverUrl, mdmCertificate) || mdmEnrollment.provider
   
   // Enrollment type - Mac uses ADE/User Approved, Windows uses Entra/Domain Join


### PR DESCRIPTION
## Problem

Macs migrated to Intune still display `MicroMDM` as their MDM provider. The active enrollment URL is unambiguously Intune (`i.manage.microsoft.com`), but the provider was read from the MDM identity certificate — and the old `MicroMDM Identity` certificate lingers in the System keychain for years after a migration.

Separately, the `/devices/management` enrollment-type filter let ADE Macs leak through the **Manual** filter.

## Changes

- **`ManagementTab.tsx`** — `detectMdmProvider()` now prefers the active server/check-in URL over the certificate. The certificate (`mdm_provider` / issuer) is a fallback only, since it goes stale after an MDM migration. `serverUrl` also falls back to `checkin_url`.
- **`devices/management/page.tsx`** — the enrollment-type filter is rewritten to mirror the `mdmBootstrapCounts` widget logic (platform-agnostic). It previously detected Mac via `m.osName`, which the API never populated, so every device fell through the Windows path and ADE Macs passed the Manual filter.

## Notes

Pairs with corresponding fixes in `terraform-azurerm-reportmate` (FastAPI) and `reportmate-client-mac`. The API fix corrects the global report immediately; the client fix corrects per-device cache after re-collection.