### PR TITLE
network: stop inferring Wi-Fi/Ethernet from interface name

### DIFF
--- a/src/components/tabs/NetworkTab.tsx
+++ b/src/components/tabs/NetworkTab.tsx
@@ -277,9 +277,8 @@ export const NetworkTab: React.FC<NetworkTabProps> = ({ device, data, isLoading 
             <div className="text-2xl font-bold text-teal-600 dark:text-teal-400">
               {(() => {
                 const primary = sortedActiveInterfaces[0]
-                const isWiFi = primary.type?.toLowerCase().includes('wifi') || 
-                              primary.type?.toLowerCase().includes('wireless') ||
-                              (primary.name === 'en0' && !primary.type?.toLowerCase().includes('ethernet'))
+                const isWiFi = primary.type?.toLowerCase().includes('wifi') ||
+                              primary.type?.toLowerCase().includes('wireless')
                 return isWiFi ? 'Wireless' : 'Ethernet'
               })()}
             </div>
@@ -307,9 +306,8 @@ export const NetworkTab: React.FC<NetworkTabProps> = ({ device, data, isLoading 
           )}
           {sortedActiveInterfaces.length > 0 ? (
             sortedActiveInterfaces.map((iface: any, index: number) => {
-              const isWiFi = iface.type?.toLowerCase().includes('wifi') || 
-                            iface.type?.toLowerCase().includes('wireless') ||
-                            (iface.name === 'en0' && !iface.type?.toLowerCase().includes('ethernet'))
+              const isWiFi = iface.type?.toLowerCase().includes('wifi') ||
+                            iface.type?.toLowerCase().includes('wireless')
               return (
                 <ActiveConnectionCard
                   key={iface.name || index}

--- a/src/components/tabs/NetworkTab.tsx
+++ b/src/components/tabs/NetworkTab.tsx
@@ -196,10 +196,12 @@ export const NetworkTab: React.FC<NetworkTabProps> = ({ device, data, isLoading 
     !(iface.isActive === true || iface.status === 'Active' || iface.status === 'Connected')
   )
 
-  // Sort active interfaces: Ethernet first, then WiFi
+  // Sort active interfaces: Ethernet first, then WiFi.
+  // Rely on the type reported by the client - interface names are not reliable
+  // (en0 is Ethernet on desktop Macs, WiFi on laptops).
   const sortedActiveInterfaces = [...activeInterfaces].sort((a: any, b: any) => {
-    const aIsEthernet = a.type?.toLowerCase().includes('ethernet') || a.type?.toLowerCase().includes('wired') || a.name === 'en1'
-    const bIsEthernet = b.type?.toLowerCase().includes('ethernet') || b.type?.toLowerCase().includes('wired') || b.name === 'en1'
+    const aIsEthernet = a.type?.toLowerCase().includes('ethernet') || a.type?.toLowerCase().includes('wired')
+    const bIsEthernet = b.type?.toLowerCase().includes('ethernet') || b.type?.toLowerCase().includes('wired')
     if (aIsEthernet && !bIsEthernet) return -1
     if (!aIsEthernet && bIsEthernet) return 1
     return 0

--- a/src/lib/data-processing/modules/network.ts
+++ b/src/lib/data-processing/modules/network.ts
@@ -435,10 +435,11 @@ export function extractNetwork(deviceModules: any): NetworkInfo {
       }
       
       if (wifiDetails) {
-        // Find the WiFi interface (en0 on Mac, or type=Wireless)
-        const wifiInterface = physicalInterfaces.find((iface: NetworkInterface) => 
-          iface.name === 'en0' || 
-          iface.type === 'Wireless' || 
+        // Find the WiFi interface by the name the Wi-Fi collector reported, or by
+        // type. Never assume en0 - it is Ethernet on desktop Macs.
+        const wifiInterface = physicalInterfaces.find((iface: NetworkInterface) =>
+          (wifiDetails.interface && iface.name === wifiDetails.interface) ||
+          iface.type === 'Wireless' ||
           iface.type === 'WiFi' ||
           iface.type?.toLowerCase().includes('wifi') ||
           iface.type?.toLowerCase().includes('wireless')

--- a/src/lib/data-processing/modules/network.ts
+++ b/src/lib/data-processing/modules/network.ts
@@ -118,14 +118,12 @@ export function extractNetwork(deviceModules: any): NetworkInfo {
     const isVpnTunnel = primaryInterface?.startsWith('utun') || primaryInterface?.startsWith('ppp')
     
     if (isVpnTunnel && network.interfaces && Array.isArray(network.interfaces)) {
-      // Find the primary physical interface (en0 for Mac, or first active ethernet/wifi)
+      // Find the primary physical interface by client-reported type
       const physicalInterface = network.interfaces.find((iface: any) => {
-        const name = iface.name || iface.interface
-        const hasIP = iface.addresses?.some((addr: any) => 
+        const hasIP = iface.addresses?.some((addr: any) =>
           addr.family === 'IPv4' && addr.address && !addr.address.startsWith('127.')
         ) || (iface.address && !iface.address.startsWith('127.'))
-        const isPhysical = name === 'en0' || 
-          (iface.type === 'Ethernet' || iface.type === 'WiFi' || iface.type === 'Wireless')
+        const isPhysical = iface.type === 'Ethernet' || iface.type === 'WiFi' || iface.type === 'Wireless'
         return hasIP && isPhysical
       })
       
@@ -160,11 +158,12 @@ export function extractNetwork(deviceModules: any): NetworkInfo {
         iface.interface === networkInfo.interfaceName
       )
       
-      // If active interface is a VPN tunnel (utun*), get MAC from the primary physical interface (en0)
+      // If active interface is a VPN tunnel (utun*), get MAC from a physical interface
       if (!activeIface?.macAddress && !activeIface?.mac_address && !activeIface?.mac) {
-        // VPN tunnels don't have MAC addresses - look for en0 (primary ethernet/wifi on Mac)
-        activeIface = network.interfaces.find((iface: any) => 
-          iface.name === 'en0' || iface.interface === 'en0'
+        // VPN tunnels have no MAC - fall back to a physical interface that has one
+        activeIface = network.interfaces.find((iface: any) =>
+          (iface.macAddress || iface.mac_address || iface.mac) &&
+          (iface.type === 'Ethernet' || iface.type === 'WiFi' || iface.type === 'Wireless')
         )
       }
       


### PR DESCRIPTION
## Problem

The Network tab re-derived interface type from `en0`/`en1` names, which is wrong on desktop Macs (en0 is Ethernet there, not Wi-Fi). This caused the Wi-Fi SSID/band/channel to attach to the wrong interface card and the Ethernet-first sort to mislabel the primary connection.

Companion to reportmate/reportmate-client-mac#3, which fixes the type at the collection source.

## Fix

- `network.ts` — Wi-Fi details attach to the interface the Wi-Fi collector named (or by `type`); dropped the `name === 'en0'` match.
- `NetworkTab.tsx` — Ethernet-first sort relies on the client-reported `type`; dropped the `name === 'en1'` fallback.

## Testing

No new TypeScript errors introduced (verified against `tsc --noEmit`). Takes effect on the next container deploy.