### PR TITLE
applications: clean up fleet filter pills, table overflow, and chart legends

### DIFF
--- a/app/api/devices/applications/filters/route.ts
+++ b/app/api/devices/applications/filters/route.ts
@@ -189,7 +189,11 @@ export async function GET(request: Request) {
       locations: data.locations || [],
       rooms: data.rooms || [],
       areas: data.areas || [],
-      fleets: data.fleets || [],
+      fleets: Array.from(new Set(
+        ((data.fleets || []) as string[])
+          .map(f => (typeof f === 'string' ? f.replace(/[,;]+\s*$/, '').trim() : ''))
+          .filter(Boolean)
+      )).sort(),
       devicesWithData: data.devicesWithData || 0
     }
     

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -2830,15 +2830,15 @@ function ApplicationsPageContent() {
                           />
                         ))}
                       </div>
-                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                      <div className="mt-3 flex flex-col gap-1">
                         {utilizationAggregates.byUsage.map(([name, val], i) => (
                           <div key={name} className="flex items-center gap-2 text-xs">
                             <span
                               className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                               style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
                             />
-                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                            <span className="ml-auto tabular-nums text-gray-500">
+                            <span className="text-gray-700 dark:text-gray-300 break-words min-w-0" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500 shrink-0 whitespace-nowrap">
                               {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
                             </span>
                           </div>
@@ -2863,15 +2863,15 @@ function ApplicationsPageContent() {
                           />
                         ))}
                       </div>
-                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                      <div className="mt-3 flex flex-col gap-1">
                         {utilizationAggregates.byCatalog.map(([name, val], i) => (
                           <div key={name} className="flex items-center gap-2 text-xs">
                             <span
                               className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                               style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
                             />
-                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                            <span className="ml-auto tabular-nums text-gray-500">
+                            <span className="text-gray-700 dark:text-gray-300 break-words min-w-0" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500 shrink-0 whitespace-nowrap">
                               {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
                             </span>
                           </div>
@@ -2925,15 +2925,15 @@ function ApplicationsPageContent() {
                           />
                         ))}
                       </div>
-                      <div className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1">
+                      <div className="mt-3 flex flex-col gap-1">
                         {utilizationAggregates.byFleet.map(([name, val], i) => (
                           <div key={name} className="flex items-center gap-2 text-xs">
                             <span
                               className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                               style={{ backgroundColor: widgetPalette[i % widgetPalette.length] }}
                             />
-                            <span className="truncate text-gray-700 dark:text-gray-300" title={name}>{name}</span>
-                            <span className="ml-auto tabular-nums text-gray-500">
+                            <span className="text-gray-700 dark:text-gray-300 break-words min-w-0" title={name}>{name}</span>
+                            <span className="ml-auto tabular-nums text-gray-500 shrink-0 whitespace-nowrap">
                               {fmtWidgetVal(val)} ({((val / utilizationAggregates.grandTotal) * 100).toFixed(0)}%)
                             </span>
                           </div>
@@ -3564,8 +3564,8 @@ function ApplicationsPageContent() {
                       
                       return sorted.map((app, index) => (
                         <tr key={`${app.serialNumber}-${app.name}-${index}`} className="hover:bg-gray-50 dark:hover:bg-gray-700">
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
-                            {app.name}
+                          <td className="px-6 py-4 text-sm text-gray-900 dark:text-white">
+                            <div className="truncate max-w-xs" title={app.name}>{app.name}</div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
                             v{app.version}

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -3,6 +3,10 @@
 import { useState } from 'react'
 import { CollapsibleSection } from '../ui/CollapsibleSection'
 
+// Inventory YAMLs occasionally ship values with trailing commas/semicolons
+// (e.g. "Foundation Studio,"). Strip them so pills don't render the punctuation.
+const cleanLabel = (s: string) => s.replace(/[,;]+\s*$/, '').trim()
+
 export interface FilterOptions {
   statuses: string[]
   catalogs: string[]
@@ -183,18 +187,22 @@ export default function DeviceFilters({
               </div>
             )}
 
-            {/* Fleet Filter - When available */}
-            {filterOptions.fleets.length > 0 && (
-              <div>
+          </div>
+
+          {/* Fleet Filter - Full width row (labels are long, e.g. "Digital Output Centre Print Room") */}
+          {filterOptions.fleets.length > 0 && (() => {
+            const dedupedFleets = Array.from(new Set(filterOptions.fleets.map(cleanLabel).filter(Boolean))).sort()
+            return (
+              <div className="mt-4">
                 <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Fleet</div>
                 <div className="flex flex-wrap gap-2">
-                  {filterOptions.fleets.map(fleet => {
-                    const isSelected = selectedFleets.some(s => s.toLowerCase() === fleet.toLowerCase())
+                  {dedupedFleets.map(fleet => {
+                    const isSelected = selectedFleets.some(s => cleanLabel(s).toLowerCase() === fleet.toLowerCase())
                     return (
                       <button
                         key={fleet}
                         onClick={() => onFleetToggle(fleet)}
-                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                        className={`px-3 py-1 text-xs font-medium rounded-full border whitespace-nowrap transition-colors ${
                           isSelected
                             ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-200 border-indigo-300 dark:border-indigo-700'
                             : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
@@ -206,9 +214,8 @@ export default function DeviceFilters({
                   })}
                 </div>
               </div>
-            )}
-
-          </div>
+            )
+          })()}
 
           {/* Area Filter - Full width row above Location */}
           {filterOptions.areas.length > 0 && (


### PR DESCRIPTION
## Summary

Three small UI fixes on the Applications page, all triggered by the Fleet field now populating from `Inventory.yaml`:

- **Fleet filter pills** — moved out of the narrow Selections grid into a full-width row (long fleet names like _Digital Output Centre Print Room_ were wrapping awkwardly in a ~280px column). Trailing commas/semicolons stripped at display time and pills deduped, since `Inventory.yaml` may ship values like `fleet: "Foundation Studio,"`. The Windows client deliberately preserves the raw value (commit reportmate-client-win@6b0dedf), so this is purely a display-layer fix.
- **Versions Inventory table** — long application names (e.g. `Windows Driver Package - Canon U.S.A., Inc. (WUDFRd) Camera (03/28/2025 17.58.58.404)`) were forcing horizontal scroll. Switched the Application cell to the same `truncate max-w-xs` pattern the Usage report table already uses.
- **Launches-by widget legends** — labels like _Shared_ and _Curriculum_ were being cut to _Sha…_ / _Curric…_ because the legend used a 2-column grid and `truncate` on the name span. Switched to single-column flex, `break-words` on the label, `shrink-0` on the value so neither side gets squeezed.

API route `app/api/devices/applications/filters/route.ts` also normalizes the `fleets` array defensively (strip trailing punctuation, dedupe, sort) before returning to the client.

## Test plan

- [ ] Open `/devices/applications` and verify the Selections accordion shows Fleet as a full-width row above Area, with pills like _Foundation Studio_ (no trailing comma).
- [ ] Confirm clicking a Fleet pill still filters correctly (selection comparison normalizes trailing punctuation on both sides).
- [ ] Switch to Versions report and check the Application Versions Inventory table — long app names truncate within the cell, no horizontal scroll on the row.
- [ ] Switch to Usage report and confirm the _Launches by Usage Type_ / _Catalog_ / _Fleet_ legends show the full label, never `Sha…`.