### PR TITLE
applications: tighten Selections layout and remove duplicate "Applications" title

### DIFF
--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -441,7 +441,7 @@ function UsageReportAppFilter({
         className="w-full px-6 py-3 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
       >
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Applications</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Filter applications</span>
           <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">
             {activeCount} / {totalCount} active
           </span>

--- a/src/components/shared/DeviceFilters.tsx
+++ b/src/components/shared/DeviceFilters.tsx
@@ -110,8 +110,9 @@ export default function DeviceFilters({
       {/* Accordion Content */}
       <CollapsibleSection expanded={filtersExpanded}>
         <div className="px-6 pb-4">
-          {/* Smart Grid Layout - maximizes space usage */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-x-8 gap-y-4">
+          {/* Top row: short-pill dimensions share a single line. Catalog grows to fill the
+              empty space to the right of Status/Usage (which have only 2-3 pills each). */}
+          <div className="flex flex-wrap gap-x-8 gap-y-4">
             {/* Status Filter - When available */}
             {filterOptions.statuses.length > 0 && (
               <div>
@@ -148,7 +149,7 @@ export default function DeviceFilters({
                       <button
                         key={usage}
                         onClick={() => onUsageToggle(usage)}
-                        className={`px-3 py-1 text-xs font-medium rounded-full border transition-colors ${
+                        className={`px-3 py-1 text-xs font-medium rounded-full border whitespace-nowrap transition-colors ${
                           isSelected
                             ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border-yellow-300 dark:border-yellow-700'
                             : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
@@ -162,32 +163,31 @@ export default function DeviceFilters({
               </div>
             )}
 
-          </div>
-
-          {/* Catalog Filter - Full width row so all 6 values fit on one line */}
-          {filterOptions.catalogs.length > 0 && (
-            <div className="mt-4">
-              <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
-              <div className="flex flex-wrap gap-2">
-                {filterOptions.catalogs.map(catalog => {
-                  const isSelected = selectedCatalogs.some(s => s.toLowerCase() === catalog.toLowerCase())
-                  return (
-                    <button
-                      key={catalog}
-                      onClick={() => onCatalogToggle(catalog)}
-                      className={`px-3 py-1 text-xs font-medium rounded-full border whitespace-nowrap transition-colors ${
-                        isSelected
-                          ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
-                          : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {catalog}
-                    </button>
-                  )
-                })}
+            {/* Catalog Filter - flex-1 fills the remaining row width so its 6 pills sit on one line */}
+            {filterOptions.catalogs.length > 0 && (
+              <div className="flex-1 min-w-[260px]">
+                <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">Catalog</div>
+                <div className="flex flex-wrap gap-2">
+                  {filterOptions.catalogs.map(catalog => {
+                    const isSelected = selectedCatalogs.some(s => s.toLowerCase() === catalog.toLowerCase())
+                    return (
+                      <button
+                        key={catalog}
+                        onClick={() => onCatalogToggle(catalog)}
+                        className={`px-3 py-1 text-xs font-medium rounded-full border whitespace-nowrap transition-colors ${
+                          isSelected
+                            ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200 border-teal-300 dark:border-teal-700'
+                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {catalog}
+                      </button>
+                    )
+                  })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* Fleet Filter - Full width row (labels are long, e.g. "Digital Output Centre Print Room") */}
           {filterOptions.fleets.length > 0 && (() => {


### PR DESCRIPTION
## Summary

Two small Selections-area polish items on `/devices/applications`:

**1. Usage + Catalog share a single row (`DeviceFilters.tsx`)**
The Usage column was only 2 pills wide and left a wide empty band to its right; Catalog sitting on its own row underneath wasted vertical space. Replace the grid wrapper for the short-pill dimensions with a single `flex flex-wrap` row holding Status (when present) + Usage + Catalog. Catalog gets `flex-1 min-w-[260px]` so it expands into the empty horizontal space on wide viewports and wraps to its own line on narrow ones.

**2. Rename chip-cloud accordion to "Filter applications" (`page.tsx`)**
In the Versions report view the chip cloud was titled _Applications_ and sat directly above the _Application Versions Inventory_ table header — two redundant section titles next to each other. The chip cloud is really an interactive filter, so name it that way. The "174 / 174 active" badge still conveys include/exclude state.

## Test plan

- [ ] `/devices/applications`: Usage and Catalog share a single row; Catalog fills the right side and its six pills sit inline.
- [ ] Narrow the viewport — Catalog wraps to its own row before being squeezed.
- [ ] Generate a Versions report — the chip-cloud accordion now reads "Filter applications" and the table header below still reads "Application Versions Inventory".
- [ ] Pages that include the Status filter still render correctly with Status + Usage + Catalog on one row.