### PR TITLE
Wire Versions Report chart to /devices/applications/distribution

### DIFF
--- a/app/api/devices/applications/distribution/route.ts
+++ b/app/api/devices/applications/distribution/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+import { getInternalApiHeaders } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+/**
+ * Applications Version Distribution Proxy
+ *
+ * Proxies to the FastAPI /api/v1/devices/applications/distribution endpoint,
+ * which aggregates installed-app counts per (app, version) in SQL. Response
+ * size is bounded by distinct versions rather than fleet size, so the chart
+ * no longer needs the bulk applications endpoint (which paginates at 500).
+ */
+export async function GET(request: Request) {
+  try {
+    const timestamp = new Date().toISOString()
+    const { searchParams } = new URL(request.url)
+
+    const API_BASE_URL = process.env.API_BASE_URL || 'http://reportmate-functions-api'
+    const fastApiUrl = `${API_BASE_URL}/api/v1/devices/applications/distribution?${searchParams.toString()}`
+
+    const response = await fetch(fastApiUrl, {
+      method: 'GET',
+      headers: getInternalApiHeaders(),
+      cache: 'no-store'
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`FastAPI returned ${response.status}: ${errorText}`)
+    }
+
+    const data = await response.json()
+
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': 'private, max-age=15, stale-while-revalidate=30',
+        'X-Fetched-At': timestamp,
+        'X-Data-Source': 'fastapi-proxy'
+      }
+    })
+  } catch (error) {
+    console.error('[APPLICATIONS DISTRIBUTION PROXY] Error:', error)
+    return NextResponse.json({
+      error: 'Failed to fetch applications distribution',
+      details: error instanceof Error ? error.message : String(error),
+      timestamp: new Date().toISOString()
+    }, { status: 500 })
+  }
+}

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -545,6 +545,14 @@ function ApplicationsPageContent() {
   // Utilization report state (unified report - includes both inventory and usage data)
   const [utilizationData, setUtilizationData] = useState<UtilizationData | null>(null)
   const [utilizationDays, setUtilizationDays] = useState<number>(30)
+
+  // Server-aggregated version distribution for the versions report. Populated
+  // by /api/devices/applications/distribution, which counts in SQL and so
+  // isn't bounded by the bulk endpoint's per-page cap. Keyed by the requested
+  // app name; renderer prefers this over the client-side versionAnalysis fold
+  // when present so the chart totals match the real fleet, not just the page.
+  const [versionDistributionServer, setVersionDistributionServer] =
+    useState<{ [appName: string]: { totalDevices: number; versions: { [version: string]: number } } } | null>(null)
   const [utilizationSortColumn, setUtilizationSortColumn] = useState<'name' | 'totalHours' | 'launchCount' | 'deviceCount' | 'userCount' | 'lastUsed'>('totalHours')
   const [utilizationSortDirection, setUtilizationSortDirection] = useState<'asc' | 'desc'>('desc')
   
@@ -1258,25 +1266,63 @@ function ApplicationsPageContent() {
       if (!selectedAppsParam) inventoryParams.set('limit', '5000')
 
       const inventoryUrl = `/api/devices/applications?${inventoryParams.toString()}`
-      
-      const inventoryResponse = await fetch(inventoryUrl, {
-        cache: 'no-store',
-        headers: { 'Cache-Control': 'no-cache' }
-      })
-      
+
+      // Distribution endpoint only makes sense with explicit app picks — the
+      // server can't bucket "everything" without an O(distinct-app-names)
+      // explosion. When no apps are selected, the chart falls back to
+      // client-side fold over the bulk list (capped at 5000).
+      const distributionUrl = selectedAppsParam
+        ? (() => {
+            const dp = new URLSearchParams()
+            dp.set('applicationNames', selectedAppsParam)
+            if (selectedUsages.length) dp.set('usages', selectedUsages.join(','))
+            if (selectedCatalogs.length) dp.set('catalogs', selectedCatalogs.join(','))
+            if (selectedAreas.length) dp.set('areas', selectedAreas.join(','))
+            if (selectedFleets.length) dp.set('fleets', selectedFleets.join(','))
+            if (selectedRooms.length) dp.set('rooms', selectedRooms.join(','))
+            if (selectedLocations.length) dp.set('locations', selectedLocations.join(','))
+            if (platformFilter !== 'all') dp.set('platforms', platformFilter)
+            return `/api/devices/applications/distribution?${dp.toString()}`
+          })()
+        : null
+
+      const [inventoryResponse, distributionResponse] = await Promise.all([
+        fetch(inventoryUrl, { cache: 'no-store', headers: { 'Cache-Control': 'no-cache' } }),
+        distributionUrl
+          ? fetch(distributionUrl, { cache: 'no-store', headers: { 'Cache-Control': 'no-cache' } })
+          : Promise.resolve(null),
+      ])
+
       setLoadingProgress({ current: 60, total: 100 })
-      
+
       if (!inventoryResponse.ok) {
         throw new Error(`Failed to load version data: ${inventoryResponse.status}`)
       }
-      
+
       const inventoryData = await inventoryResponse.json()
-      
+
+      // Distribution failure is non-fatal — the chart falls back to the
+      // client-side fold (capped totals, but still functional).
+      let distributionData: typeof versionDistributionServer = null
+      if (distributionResponse && distributionResponse.ok) {
+        try {
+          const parsed = await distributionResponse.json()
+          if (parsed && typeof parsed === 'object' && !parsed.error) {
+            distributionData = parsed
+          }
+        } catch (e) {
+          console.warn('Failed to parse distribution response, falling back to client fold:', e)
+        }
+      } else if (distributionResponse) {
+        console.warn(`Distribution endpoint returned ${distributionResponse.status}, falling back to client fold`)
+      }
+
       if (Array.isArray(inventoryData)) {
         // Pin the platform the data was fetched for so the refetch-on-platform
         // effect doesn't fire immediately after this load completes.
         reportPlatformRef.current = fetchPlatform
         setApplications(inventoryData)
+        setVersionDistributionServer(distributionData)
         setReportType('versions')
         setSelectionsExpanded(false)
         setUtilizationData(null) // Clear any previous usage data
@@ -1591,6 +1637,7 @@ function ApplicationsPageContent() {
   const resetReport = () => {
     setApplications([])
     setUtilizationData(null)
+    setVersionDistributionServer(null)
     setReportType(null)
     setReportMode('has') // Reset to default mode
     setSelectedApplications([])
@@ -1691,10 +1738,23 @@ function ApplicationsPageContent() {
   }, [allDevices, baseFilteredApplications, selectedApplications, selectedUsages, selectedCatalogs, selectedLocations, selectedRooms, reportMode, missingTableSortColumn, missingTableSortDirection])
 
   // Version analysis - group by NORMALIZED application name and version
-  // Uses baseFilteredApplications (without version filter) so widgets always show all versions
+  // Uses baseFilteredApplications (without version filter) so widgets always show all versions.
+  //
+  // When the server-aggregated distribution is available (versions report with
+  // explicit app picks), prefer it: the bulk applications endpoint paginates at
+  // 500 rows, which silently truncated the chart on large fleets. The server
+  // endpoint counts per (app, version) in SQL so totals reflect the whole
+  // fleet regardless of pagination.
   const versionAnalysis = useMemo(() => {
-    const analysis: VersionAnalysis = {}
+    if (versionDistributionServer && Object.keys(versionDistributionServer).length > 0) {
+      const analysis: VersionAnalysis = {}
+      for (const [appName, bucket] of Object.entries(versionDistributionServer)) {
+        analysis[appName] = { ...bucket.versions }
+      }
+      return analysis
+    }
 
+    const analysis: VersionAnalysis = {}
     baseFilteredApplications.forEach(app => {
       // Use normalized name as the key (same as what's in filterOptions.applicationNames)
       const normalizedName = normalizeAppName(app.name)
@@ -1708,7 +1768,7 @@ function ApplicationsPageContent() {
     })
 
     return analysis
-  }, [baseFilteredApplications])
+  }, [baseFilteredApplications, versionDistributionServer])
 
   const [widgetMetric, setWidgetMetric] = useState<'hours' | 'launches'>('launches')
 

--- a/app/devices/applications/page.tsx
+++ b/app/devices/applications/page.tsx
@@ -1302,13 +1302,35 @@ function ApplicationsPageContent() {
       const inventoryData = await inventoryResponse.json()
 
       // Distribution failure is non-fatal — the chart falls back to the
-      // client-side fold (capped totals, but still functional).
+      // client-side fold (capped totals, but still functional). Validate the
+      // shape strictly so a malformed payload (e.g. an array, or buckets
+      // missing `.versions`) can't crash the version-analysis fold downstream.
       let distributionData: typeof versionDistributionServer = null
       if (distributionResponse && distributionResponse.ok) {
         try {
-          const parsed = await distributionResponse.json()
-          if (parsed && typeof parsed === 'object' && !parsed.error) {
-            distributionData = parsed
+          const parsed: unknown = await distributionResponse.json()
+          if (
+            parsed &&
+            typeof parsed === 'object' &&
+            !Array.isArray(parsed) &&
+            !('error' in (parsed as Record<string, unknown>))
+          ) {
+            const validated: NonNullable<typeof versionDistributionServer> = {}
+            for (const [appName, rawBucket] of Object.entries(parsed as Record<string, unknown>)) {
+              if (!rawBucket || typeof rawBucket !== 'object' || Array.isArray(rawBucket)) continue
+              const bucket = rawBucket as Record<string, unknown>
+              const versionsRaw = bucket.versions
+              if (!versionsRaw || typeof versionsRaw !== 'object' || Array.isArray(versionsRaw)) continue
+              const versions: { [v: string]: number } = {}
+              for (const [v, c] of Object.entries(versionsRaw as Record<string, unknown>)) {
+                if (typeof c === 'number' && Number.isFinite(c)) versions[v] = c
+              }
+              const totalDevices = typeof bucket.totalDevices === 'number' && Number.isFinite(bucket.totalDevices)
+                ? bucket.totalDevices
+                : Object.values(versions).reduce((s, n) => s + n, 0)
+              validated[appName] = { totalDevices, versions }
+            }
+            if (Object.keys(validated).length > 0) distributionData = validated
           }
         } catch (e) {
           console.warn('Failed to parse distribution response, falling back to client fold:', e)
@@ -1747,9 +1769,21 @@ function ApplicationsPageContent() {
   // fleet regardless of pagination.
   const versionAnalysis = useMemo(() => {
     if (versionDistributionServer && Object.keys(versionDistributionServer).length > 0) {
+      // Normalize server-provided keys with the same rule the client fold uses
+      // (and the downstream version-chip filter assumes): without this, an
+      // app like "Houdini Launcher" returned by the server would render under
+      // its raw name on the chart, but `selectedVersions` would store
+      // `"Houdini Launcher:21.0.440"` and the table-filter compare against
+      // `normalizeAppName(app.name)` (which yields "Houdini") would never
+      // match. Collisions sum per-version so two raw apps that normalize to
+      // the same name behave identically to the client fold.
       const analysis: VersionAnalysis = {}
       for (const [appName, bucket] of Object.entries(versionDistributionServer)) {
-        analysis[appName] = { ...bucket.versions }
+        const key = normalizeAppName(appName) || appName
+        const target = analysis[key] || (analysis[key] = {})
+        for (const [version, count] of Object.entries(bucket.versions)) {
+          target[version] = (target[version] || 0) + count
+        }
       }
       return analysis
     }

--- a/e2e/api-endpoints.spec.ts
+++ b/e2e/api-endpoints.spec.ts
@@ -149,6 +149,21 @@ test.describe('Next.js /api/devices/* Sub-Routes', () => {
       expect(res.status()).toBe(200)
     })
   }
+
+  // /distribution requires applicationNames; smoke-test with a token unlikely
+  // to match anything so the response shape (object with bucket entry) is what
+  // we assert on, not the counts.
+  test('GET /api/devices/applications/distribution?applicationNames=__nonexistent__ - responds 200', async ({ request }) => {
+    const res = await request.get('/api/devices/applications/distribution?applicationNames=__nonexistent__')
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body).toBeTruthy()
+    expect(typeof body).toBe('object')
+    expect(Array.isArray(body)).toBe(false)
+    expect(body.__nonexistent__).toBeDefined()
+    expect(typeof body.__nonexistent__.totalDevices).toBe('number')
+    expect(typeof body.__nonexistent__.versions).toBe('object')
+  })
 })
 
 test.describe('Next.js Stats Routes', () => {


### PR DESCRIPTION
## Summary
- Fetch the new server-aggregated distribution in parallel with the bulk applications list when loading the Versions Report.
- `versionAnalysis` prefers the server response when present, so chart totals reflect the whole fleet instead of the first 500 paginated rows.
- Distribution failures are non-fatal: chart silently falls back to the client-side fold over the bulk list (capped totals, but still functional).
- Add Next.js proxy route at `app/api/devices/applications/distribution/route.ts`.

## Why
The bulk `/api/devices/applications` endpoint paginates at 500 rows, so the Version Distribution chart silently truncated on large fleets. On `reportmate.ecuad.ca/devices/applications?platform=win&type=versions&apps=Google+Chrome`, the chart capped at "500 applications across 500 devices" regardless of the real install count.

A `?limit=5000` patch just defers the same problem and ships 10× more data than the chart needs — the chart only needs counts.

## Companion PR
- Backend endpoint: reportmate/terraform-azurerm-reportmate#7

## Notes
- The device drilldown table is still fed by the bulk list (capped). Separate concern — can be paginated later if needed.
- Distribution endpoint is only called when at least one app is selected (`selectedAppsParam` non-empty). Without app picks the chart still uses the client fold over the bulk list, which already has a `limit=5000` override applied for that path.

## Test plan
- [ ] Backend PR deployed first
- [ ] Visit `/devices/applications?platform=win&type=versions&apps=Google+Chrome` — header shows real device count, not 500
- [ ] Chart card "Google Chrome" total matches sum of bucket counts
- [ ] Removing the distribution endpoint (simulate 502) still renders the chart from the bulk fold without crashing
- [ ] Multi-app pick (`?apps=Google+Chrome,Microsoft+Edge`) renders one card per app with correct totals