### PR TITLE
security: fold Firmware Password into Tampering, drop dedicated widget

### DIFF
--- a/app/devices/security/page.tsx
+++ b/app/devices/security/page.tsx
@@ -593,12 +593,15 @@ function SecurityPageContent() {
       d.encryptionEnabled ? 'Encrypted' : 'Not Encrypted',
       esc(d.antivirusName), d.antivirusEnabled ? (d.antivirusUpToDate ? 'Current' : 'Out of Date') : 'Disabled',
       d.detectionCount != null ? (d.detectionCount > 0 ? `${d.detectionCount} threat${d.detectionCount !== 1 ? 's' : ''}` : 'Clean') : '',
-      esc(
-        (isWin(d) ? `TPM ${d.tpmPresent && d.tpmEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}` : `SIP ${d.sipEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}`)
-        + (d.firmwarePassword?.statusDisplay === 'Set' || d.firmwarePassword?.statusDisplay === 'Not Set'
-            ? ` / FW PW ${d.firmwarePassword.statusDisplay}`
-            : '')
-      ),
+      esc((() => {
+        const main = isWin(d)
+          ? `TPM ${d.tpmPresent && d.tpmEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}`
+          : `SIP ${d.sipEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}`
+        const fwStatus = d.firmwarePassword?.statusDisplay
+        if (fwStatus === 'Set') return `${main} / FW PW On`
+        if (fwStatus === 'Not Set') return `${main} / FW PW Off`
+        return main
+      })()),
       d.firewallEnabled ? 'On' : 'Off',
       [d.secureShell?.isServiceRunning ? 'SSH' : '', isWin(d) && d.rdpEnabled ? 'RDP' : ''].filter(Boolean).join('+') || 'None',
       String(d.expiredCertCount), String(d.expiringSoonCertCount),
@@ -1029,11 +1032,16 @@ function SecurityPageContent() {
                                 </Badge>
                               </>
                             )}
-                            {(d.firmwarePassword?.statusDisplay === 'Set' || d.firmwarePassword?.statusDisplay === 'Not Set') && (
-                              <Badge className={d.firmwarePassword.statusDisplay === 'Set' ? greenBadge : redBadge}>
-                                FW PW {d.firmwarePassword.statusDisplay === 'Set' ? 'On' : 'Off'}
-                              </Badge>
-                            )}
+                            {(() => {
+                              const fwStatus = d.firmwarePassword?.statusDisplay
+                              if (fwStatus !== 'Set' && fwStatus !== 'Not Set') return null
+                              const isSet = fwStatus === 'Set'
+                              return (
+                                <Badge className={isSet ? greenBadge : redBadge}>
+                                  FW PW {isSet ? 'On' : 'Off'}
+                                </Badge>
+                              )
+                            })()}
                           </div>
                         </td>
                         {/* Firewall */}

--- a/app/devices/security/page.tsx
+++ b/app/devices/security/page.tsx
@@ -39,6 +39,11 @@ interface SecurityDevice {
   secureBootEnabled: boolean
   sipEnabled?: boolean
   gatekeeperEnabled: boolean
+  // Firmware password
+  firmwarePassword?: {
+    statusDisplay?: string
+    isSet?: boolean
+  } | null
   // Protection (Windows)
   memoryIntegrityEnabled: boolean
   coreIsolationEnabled: boolean
@@ -588,7 +593,12 @@ function SecurityPageContent() {
       d.encryptionEnabled ? 'Encrypted' : 'Not Encrypted',
       esc(d.antivirusName), d.antivirusEnabled ? (d.antivirusUpToDate ? 'Current' : 'Out of Date') : 'Disabled',
       d.detectionCount != null ? (d.detectionCount > 0 ? `${d.detectionCount} threat${d.detectionCount !== 1 ? 's' : ''}` : 'Clean') : '',
-      isWin(d) ? `TPM ${d.tpmPresent && d.tpmEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}` : `SIP ${d.sipEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}`,
+      esc(
+        (isWin(d) ? `TPM ${d.tpmPresent && d.tpmEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}` : `SIP ${d.sipEnabled ? 'On' : 'Off'} / SB ${d.secureBootEnabled ? 'On' : 'Off'}`)
+        + (d.firmwarePassword?.statusDisplay === 'Set' || d.firmwarePassword?.statusDisplay === 'Not Set'
+            ? ` / FW PW ${d.firmwarePassword.statusDisplay}`
+            : '')
+      ),
       d.firewallEnabled ? 'On' : 'Off',
       [d.secureShell?.isServiceRunning ? 'SSH' : '', isWin(d) && d.rdpEnabled ? 'RDP' : ''].filter(Boolean).join('+') || 'None',
       String(d.expiredCertCount), String(d.expiringSoonCertCount),
@@ -1018,6 +1028,11 @@ function SecurityPageContent() {
                                   SB {d.secureBootEnabled ? 'On' : 'Off'}
                                 </Badge>
                               </>
+                            )}
+                            {(d.firmwarePassword?.statusDisplay === 'Set' || d.firmwarePassword?.statusDisplay === 'Not Set') && (
+                              <Badge className={d.firmwarePassword.statusDisplay === 'Set' ? greenBadge : redBadge}>
+                                FW PW {d.firmwarePassword.statusDisplay === 'Set' ? 'On' : 'Off'}
+                              </Badge>
                             )}
                           </div>
                         </td>


### PR DESCRIPTION
## Summary

Supersedes #13. The previous approach added "Firmware Password" as a top-level widget *and* table column — a new category nobody asked for. Tampering already covers boot-time integrity signals (TPM, Secure Boot, SIP), so this surfaces FW PW there instead.

## Changes

- Add an "FW PW On/Off" pill inside the Tampering cell, only when status is known (`Set` / `Not Set`) — quiet on Macs and unsupported hardware
- No standalone widget, no standalone table column, no extra filter state
- CSV export folds FW PW into the Tampering summary column
- `firmwarePassword` interface field kept so the API field (from terraform-azurerm-reportmate#9) wires through

## Test plan

- [ ] After deploy, confirm Tampering cell on a Mac shows `SIP / SB / FW PW Set` (or `Off`) when the API returns the field
- [ ] Confirm Windows devices show `TPM / SB` only (no spurious FW PW pill)
- [ ] CSV export contains the combined Tampering column

## Action after merge

Close #13.