### PR TITLE
security: surface Phase 2/3 fleet signals as widgets + extractor passthrough

### DIFF
--- a/app/devices/security/page.tsx
+++ b/app/devices/security/page.tsx
@@ -59,9 +59,51 @@ interface SecurityDevice {
   certificateCount: number
   expiredCertCount: number
   expiringSoonCertCount: number
+  // Detection (Phase 1 split — active threats excludes ASR blocks)
+  activeThreatCount?: number
+  hasActiveThreats?: boolean
+  detectionsBlocked30d?: number
+  detectionsCleaned30d?: number
+  detectionsTotal30d?: number
+  lastThreatDetectedAt?: string
   // Vulnerabilities
   cveCount: number
   criticalCveCount: number
+  activelyExploitedCveCount?: number
+  // Certificates (Phase 1 split — separate user-managed from OS-bundled roots)
+  userExpiredCertCount?: number
+  osRootExpiredCertCount?: number
+  // Phase 2 — protection posture
+  lsaProtectionEnabled?: boolean
+  lsaProtectionMode?: string  // "Disabled" | "PPL" | "PPLBoot"
+  tamperProtected?: boolean | null
+  uacLevel?: string  // "AlwaysNotify" | "NotifyChangesSecure" | "NotifyChangesNoDim" | "NeverNotify" | "Disabled" | "Custom"
+  pendingReboot?: boolean
+  asrBlockRuleCount?: number
+  asrAuditRuleCount?: number
+  defenderEngineVersion?: string
+  defenderProductVersion?: string
+  defenderExclusionsCount?: number
+  entraJoined?: boolean | null
+  domainJoined?: boolean | null
+  entraTenantName?: string
+  // Phase 3 — compliance & inventory
+  localAdminCount?: number
+  lapsConfigured?: boolean
+  lapsBackupDirectory?: string
+  appLockerConfigured?: boolean
+  wdacEnabled?: boolean
+  smartScreenState?: string
+  edgeSmartScreenEnabled?: boolean | null
+  auditPolicyCount?: number
+  edrProductCount?: number
+  helloBiometricPresent?: boolean
+  tpmOwned?: boolean
+  tpmReady?: boolean
+  minPasswordLength?: number | null
+  lockoutThreshold?: number | null
+  autoAdminLogon?: boolean
+  defaultPasswordPresent?: boolean
   // Misc
   autoLoginUser?: string
   // Inventory (enriched)
@@ -283,6 +325,13 @@ function SecurityPageContent() {
   const [remoteFilter, setRemoteFilter] = useState('')
   const [certFilter, setCertFilter] = useState('')
   const [cveFilter, setCveFilter] = useState('')
+  // Phase 2/3 widget filters
+  const [postureFilter, setPostureFilter] = useState('')
+  const [rebootFilter, setRebootFilter] = useState('')
+  const [uacFilter, setUacFilter] = useState('')
+  const [joinFilter, setJoinFilter] = useState('')
+  const [lapsFilter, setLapsFilter] = useState('')
+  const [edrFilter, setEdrFilter] = useState('')
 
   // Sorting
   const [sortColumn, setSortColumn] = useState<SortColumn>('device')
@@ -306,7 +355,7 @@ function SecurityPageContent() {
   const [certSearchPerformed, setCertSearchPerformed] = useState(false)
   const [selectedCertName, setSelectedCertName] = useState<string | null>(null)
 
-  const hasActiveWidgetFilter = !!(encryptionFilter || protectionFilter || detectionFilter || firewallFilter || tamperingFilter || remoteFilter || certFilter || cveFilter)
+  const hasActiveWidgetFilter = !!(encryptionFilter || protectionFilter || detectionFilter || firewallFilter || tamperingFilter || remoteFilter || certFilter || cveFilter || postureFilter || rebootFilter || uacFilter || joinFilter || lapsFilter || edrFilter)
 
   const clearWidgetFilters = () => {
     setEncryptionFilter('')
@@ -317,6 +366,12 @@ function SecurityPageContent() {
     setRemoteFilter('')
     setCertFilter('')
     setCveFilter('')
+    setPostureFilter('')
+    setRebootFilter('')
+    setUacFilter('')
+    setJoinFilter('')
+    setLapsFilter('')
+    setEdrFilter('')
   }
 
   // ============ DATA FETCHING ============
@@ -465,9 +520,69 @@ function SecurityPageContent() {
   }
 
   const getCertLabel = (d: SecurityDevice): string => {
-    if (d.expiredCertCount > 0) return 'Has Expired'
+    // Prefer user-managed expired count (OS-root expirations are natural rotation, not a finding).
+    // Fall back to the total when the new field isn't present (old payloads).
+    const expired = d.userExpiredCertCount ?? d.expiredCertCount
+    if (expired > 0) return 'Has Expired'
     if (d.expiringSoonCertCount > 0) return 'Expiring Soon'
     return 'Valid'
+  }
+
+  // ===== Phase 2/3 widget label helpers =====
+
+  // Detection: prefer active-threat count (excludes ASR blocks which are protection working).
+  // Falls back to legacy detectionCount when activeThreatCount isn't in the payload.
+  const getDetectionLabel = (d: SecurityDevice): string => {
+    const active = d.activeThreatCount ?? d.detectionCount ?? 0
+    return active > 0 ? 'Threats Detected' : 'Clean'
+  }
+
+  // Hardening posture: combines LSA + Tamper into a 3-way bucket.
+  const getPostureLabel = (d: SecurityDevice): string => {
+    if (d.lsaProtectionEnabled === undefined && d.tamperProtected === undefined && d.tamperProtected !== null) return 'Unknown'
+    const lsa = d.lsaProtectionEnabled === true
+    const tamper = d.tamperProtected === true
+    if (lsa && tamper) return 'Hardened'
+    if (lsa || tamper) return 'Partial'
+    if (d.lsaProtectionEnabled === false && d.tamperProtected === false) return 'Weak'
+    return 'Unknown'
+  }
+
+  const getRebootLabel = (d: SecurityDevice): string => {
+    if (d.pendingReboot === undefined) return 'Unknown'
+    return d.pendingReboot ? 'Reboot Required' : 'Up to date'
+  }
+
+  const getUacLabel = (d: SecurityDevice): string => {
+    const v = d.uacLevel
+    if (!v) return 'Unknown'
+    if (v === 'Disabled' || v === 'NeverNotify') return 'Weakened'
+    if (v === 'AlwaysNotify' || v === 'NotifyChangesSecure') return 'Strict'
+    if (v === 'NotifyChangesNoDim') return 'Relaxed'
+    return 'Custom'
+  }
+
+  const getJoinLabel = (d: SecurityDevice): string => {
+    const entra = d.entraJoined === true
+    const ad = d.domainJoined === true
+    if (entra && ad) return 'Hybrid'
+    if (entra) return 'Entra Joined'
+    if (ad) return 'Domain Joined'
+    if (d.entraJoined === false && d.domainJoined === false) return 'Workgroup'
+    return 'Unknown'
+  }
+
+  const getLapsLabel = (d: SecurityDevice): string => {
+    if (d.lapsConfigured === undefined) return 'Unknown'
+    return d.lapsConfigured ? 'Configured' : 'Not Configured'
+  }
+
+  const getEdrLabel = (d: SecurityDevice): string => {
+    const n = d.edrProductCount
+    if (n === undefined) return 'Unknown'
+    if (n === 0) return 'None'
+    if (n === 1) return 'Single'
+    return 'Multiple'
   }
 
   const getCveLabel = (d: SecurityDevice): string => {
@@ -509,12 +624,19 @@ function SecurityPageContent() {
 
   const encryptionCounts = countBy(d => d.encryptionEnabled ? 'Encrypted' : 'Not Encrypted')
   const protectionCounts = countBy(getProtectionLabel)
-  const detectionCounts = countBy(d => (d.detectionCount ?? 0) > 0 ? 'Threats Detected' : 'Clean')
+  const detectionCounts = countBy(getDetectionLabel)
   const firewallCounts = countBy(d => d.firewallEnabled ? 'Enabled' : 'Disabled')
   const tamperingCounts = countBy(getTamperLabel)
   const remoteCounts = countBy(getRemoteLabel)
   const certCounts = countBy(getCertLabel)
   const cveCounts = countBy(getCveLabel)
+  // Phase 2/3 widgets
+  const postureCounts = countBy(getPostureLabel)
+  const rebootCounts = countBy(getRebootLabel)
+  const uacCounts = countBy(getUacLabel)
+  const joinCounts = countBy(getJoinLabel)
+  const lapsCounts = countBy(getLapsLabel)
+  const edrCounts = countBy(getEdrLabel)
 
   // ============ FILTER OPTIONS ============
 
@@ -548,12 +670,18 @@ function SecurityPageContent() {
     // Widget filters
     if (encryptionFilter && (d.encryptionEnabled ? 'Encrypted' : 'Not Encrypted') !== encryptionFilter) return false
     if (protectionFilter && getProtectionLabel(d) !== protectionFilter) return false
-    if (detectionFilter && ((d.detectionCount ?? 0) > 0 ? 'Threats Detected' : 'Clean') !== detectionFilter) return false
+    if (detectionFilter && getDetectionLabel(d) !== detectionFilter) return false
     if (firewallFilter && (d.firewallEnabled ? 'Enabled' : 'Disabled') !== firewallFilter) return false
     if (tamperingFilter && getTamperLabel(d) !== tamperingFilter) return false
     if (remoteFilter && getRemoteLabel(d) !== remoteFilter) return false
     if (certFilter && getCertLabel(d) !== certFilter) return false
     if (cveFilter && getCveLabel(d) !== cveFilter) return false
+    if (postureFilter && getPostureLabel(d) !== postureFilter) return false
+    if (rebootFilter && getRebootLabel(d) !== rebootFilter) return false
+    if (uacFilter && getUacLabel(d) !== uacFilter) return false
+    if (joinFilter && getJoinLabel(d) !== joinFilter) return false
+    if (lapsFilter && getLapsLabel(d) !== lapsFilter) return false
+    if (edrFilter && getEdrLabel(d) !== edrFilter) return false
     // Certificate search filter (from grouped cert results)
     if (certFilterSerials && !certFilterSerials.has(d.serialNumber)) return false
     // Search
@@ -625,6 +753,13 @@ function SecurityPageContent() {
   const remoteColors: Record<string, string> = { 'SSH + RDP': '#3b82f6', 'SSH Only': '#22c55e', 'RDP Only': '#f59e0b', 'SSH Enabled': '#22c55e', 'Disabled': '#94a3b8' }
   const certColors: Record<string, string> = { 'Valid': '#22c55e', 'Expiring Soon': '#f59e0b', 'Has Expired': '#ef4444' }
   const cveColors: Record<string, string> = { 'None': '#22c55e', 'Has CVEs': '#f59e0b', 'Critical': '#ef4444' }
+  // Phase 2/3 colors
+  const postureColors: Record<string, string> = { 'Hardened': '#22c55e', 'Partial': '#f59e0b', 'Weak': '#ef4444', 'Unknown': '#cbd5e1' }
+  const rebootColors: Record<string, string> = { 'Up to date': '#22c55e', 'Reboot Required': '#f59e0b', 'Unknown': '#cbd5e1' }
+  const uacColors: Record<string, string> = { 'Strict': '#22c55e', 'Relaxed': '#f59e0b', 'Weakened': '#ef4444', 'Custom': '#94a3b8', 'Unknown': '#cbd5e1' }
+  const joinColors: Record<string, string> = { 'Entra Joined': '#22c55e', 'Hybrid': '#3b82f6', 'Domain Joined': '#94a3b8', 'Workgroup': '#f59e0b', 'Unknown': '#cbd5e1' }
+  const lapsColors: Record<string, string> = { 'Configured': '#22c55e', 'Not Configured': '#ef4444', 'Unknown': '#cbd5e1' }
+  const edrColors: Record<string, string> = { 'Single': '#22c55e', 'Multiple': '#3b82f6', 'None': '#ef4444', 'Unknown': '#cbd5e1' }
 
   // ============ RENDER ============
 
@@ -749,6 +884,12 @@ function SecurityPageContent() {
                   <MiniDonut title="Access" data={Object.entries(remoteCounts).map(([label, value]) => ({ label, value }))} colors={remoteColors} onFilter={setRemoteFilter} activeFilter={remoteFilter} />
                   <MiniDonut title="Certificates" data={Object.entries(certCounts).map(([label, value]) => ({ label, value }))} colors={certColors} onFilter={setCertFilter} activeFilter={certFilter} />
                   <MiniDonut title="Vulnerabilities" data={Object.entries(cveCounts).map(([label, value]) => ({ label, value }))} colors={cveColors} onFilter={setCveFilter} activeFilter={cveFilter} />
+                  <MiniDonut title="Posture (LSA + Tamper)" data={Object.entries(postureCounts).map(([label, value]) => ({ label, value }))} colors={postureColors} onFilter={setPostureFilter} activeFilter={postureFilter} />
+                  <MiniDonut title="Pending Reboot" data={Object.entries(rebootCounts).map(([label, value]) => ({ label, value }))} colors={rebootColors} onFilter={setRebootFilter} activeFilter={rebootFilter} />
+                  <MiniDonut title="UAC Level" data={Object.entries(uacCounts).map(([label, value]) => ({ label, value }))} colors={uacColors} onFilter={setUacFilter} activeFilter={uacFilter} />
+                  <MiniDonut title="Join State" data={Object.entries(joinCounts).map(([label, value]) => ({ label, value }))} colors={joinColors} onFilter={setJoinFilter} activeFilter={joinFilter} />
+                  <MiniDonut title="LAPS" data={Object.entries(lapsCounts).map(([label, value]) => ({ label, value }))} colors={lapsColors} onFilter={setLapsFilter} activeFilter={lapsFilter} />
+                  <MiniDonut title="EDR Products" data={Object.entries(edrCounts).map(([label, value]) => ({ label, value }))} colors={edrColors} onFilter={setEdrFilter} activeFilter={edrFilter} />
                 </div>
               </div>
             </CollapsibleSection>

--- a/src/lib/data-processing/modules/security.ts
+++ b/src/lib/data-processing/modules/security.ts
@@ -18,6 +18,175 @@ export interface SecurityInfo {
   secureShell?: SecureShellInfo
   policies: PolicyInfo[]
   summary: SecuritySummary
+  // Phase 2 — protection posture (per-device, raw passthrough; null on platforms / older clients that don't emit them)
+  lsaProtection?: LsaProtectionInfo
+  tamperProtection?: TamperProtectionInfo
+  uac?: UacInfo
+  pendingReboot?: PendingRebootInfo
+  asrRules?: AsrRuleState[]
+  defenderVersions?: DefenderVersionsInfo
+  defenderExclusions?: DefenderExclusionsInfo
+  joinState?: JoinStateInfo
+  // Phase 3 — compliance / inventory
+  localAdmins?: LocalAdminMember[]
+  laps?: LapsInfo
+  appLocker?: AppLockerInfo
+  smartScreen?: SmartScreenInfo
+  auditPolicy?: AuditPolicyInfo
+  edrProducts?: EdrProductInfo[]
+  windowsHello?: WindowsHelloInfo
+  tpmOwnership?: TpmOwnershipInfo
+  passwordPolicy?: PasswordPolicyInfo
+  autoLogin?: AutoLoginInfo
+}
+
+// ====== Phase 2 — protection posture sub-objects (passthrough from client payload) ======
+
+export interface LsaProtectionInfo {
+  enabled?: boolean | null
+  runAsPpl?: number | null   // 0 = off, 1 = PPL, 2 = PPL with UEFI lock
+  mode?: string              // "Disabled" / "PPL" / "PPLBoot"
+}
+
+export interface TamperProtectionInfo {
+  isTamperProtected?: boolean | null
+  source?: string
+}
+
+export interface UacInfo {
+  enableLua?: boolean | null
+  consentPromptBehaviorAdmin?: number | null
+  promptOnSecureDesktop?: number | null
+  level?: string  // "AlwaysNotify" / "NotifyChangesSecure" / "NotifyChangesNoDim" / "NeverNotify" / "Disabled" / "Custom"
+}
+
+export interface PendingRebootInfo {
+  cbsServicing?: boolean
+  windowsUpdate?: boolean
+  fileRename?: boolean
+  required?: boolean
+}
+
+export interface AsrRuleState {
+  id: string
+  name: string
+  action: number  // 0=Off, 1=Block, 2=Audit, 6=Warn
+  state: string   // "Off" / "Block" / "Audit" / "Warn"
+}
+
+export interface DefenderVersionsInfo {
+  amEngineVersion?: string
+  amProductVersion?: string
+  amServiceVersion?: string
+  nisEngineVersion?: string
+  antivirusSignatureVersion?: string
+  antispywareSignatureVersion?: string
+}
+
+export interface DefenderExclusionsInfo {
+  paths?: string[]
+  extensions?: string[]
+  processes?: string[]
+  ipAddresses?: string[]
+  totalCount?: number
+}
+
+export interface JoinStateInfo {
+  azureAdJoined?: boolean | null
+  domainJoined?: boolean | null
+  workplaceJoined?: boolean | null
+  enterpriseJoined?: boolean | null
+  tenantName?: string
+  tenantId?: string
+  deviceId?: string
+  domainName?: string
+  raw?: Record<string, string>
+  errorMessage?: string
+}
+
+// ====== Phase 3 — compliance / inventory ======
+
+export interface LocalAdminMember {
+  name: string
+  sid?: string
+  principalSource?: string   // Local / ActiveDirectory / AzureAD
+  objectClass?: string       // User / Group
+}
+
+export interface LapsInfo {
+  windowsLapsConfigured?: boolean
+  legacyLapsInstalled?: boolean
+  backupDirectory?: string   // "Active Directory" / "Azure AD" / "Configured" / ""
+  adminAccountName?: string
+}
+
+export interface AppLockerInfo {
+  serviceRunning?: boolean
+  serviceStartType?: string
+  policyConfigured?: boolean
+  effectivePolicySummary?: string
+  wdacEnabled?: boolean
+  wdacAuditMode?: boolean
+}
+
+export interface SmartScreenInfo {
+  windowsState?: string
+  edgeEnabled?: boolean | null
+  edgePuaProtection?: boolean | null
+}
+
+export interface AuditPolicyInfo {
+  categories?: AuditCategorySetting[]
+  errorMessage?: string
+}
+
+export interface AuditCategorySetting {
+  category: string
+  subcategory: string
+  setting: string
+}
+
+export interface EdrProductInfo {
+  name: string
+  vendor?: string
+  source?: string
+  serviceRunning?: boolean
+  version?: string
+  sid?: string
+}
+
+export interface WindowsHelloInfo {
+  faceSensorPresent?: boolean
+  fingerprintSensorPresent?: boolean
+  pinConfigured?: boolean | null
+  passportForWorkEnabled?: boolean | null
+}
+
+export interface TpmOwnershipInfo {
+  isOwned?: boolean | null
+  isReady?: boolean | null
+  autoProvisioning?: boolean | null
+  manufacturerIdTxt?: string
+  managedAuthLevel?: string
+}
+
+export interface PasswordPolicyInfo {
+  minPasswordLength?: number | null
+  maxPasswordAgeDays?: number | null
+  minPasswordAgeDays?: number | null
+  passwordHistoryLength?: number | null
+  lockoutThreshold?: number | null
+  lockoutDurationMinutes?: number | null
+  complexityRequired?: boolean | null
+  errorMessage?: string
+}
+
+export interface AutoLoginInfo {
+  autoAdminLogon?: boolean
+  hasDefaultUserName?: boolean
+  hasDefaultPassword?: boolean       // PRESENCE ONLY — value is never read or transmitted
+  hasDefaultDomainName?: boolean
+  defaultUserName?: string
 }
 
 export interface DetectionAlert {
@@ -166,9 +335,30 @@ export function extractSecurity(deviceModules: any): SecurityInfo {
     
     // Read policy compliance
     policies: security.policies ? security.policies.map(mapPolicy) : [],
-    
+
     // Read device-calculated summary
-    summary: security.summary || createEmptySummary()
+    summary: security.summary || createEmptySummary(),
+
+    // Phase 2/3 — raw passthrough (sub-objects already arrive in the desired shape from the client).
+    // We don't normalize here because the device computes these and the schema is stable.
+    lsaProtection: security.lsaProtection,
+    tamperProtection: security.tamperProtection,
+    uac: security.uac,
+    pendingReboot: security.pendingReboot,
+    asrRules: security.asrRules,
+    defenderVersions: security.defenderVersions,
+    defenderExclusions: security.defenderExclusions,
+    joinState: security.joinState,
+    localAdmins: security.localAdmins,
+    laps: security.laps,
+    appLocker: security.appLocker,
+    smartScreen: security.smartScreen,
+    auditPolicy: security.auditPolicy,
+    edrProducts: security.edrProducts,
+    windowsHello: security.windowsHello,
+    tpmOwnership: security.tpmOwnership,
+    passwordPolicy: security.passwordPolicy,
+    autoLogin: security.autoLogin,
   }
 
   


### PR DESCRIPTION
## Summary

Frontend reader for the security-audit work. Wires up the fields the Windows client (reportmate-client-win#17) collects and the bulk SQL (reportmate/terraform-azurerm-reportmate #9, #10, #11) exposes.

## /devices/security page

- `SecurityDevice` gains 33 optional fields covering Phase 2 (LSA Protection, Tamper Protection, UAC, Pending Reboot, ASR enforcement, Defender versions/exclusions, join state) and Phase 3 (local admins, LAPS, AppLocker/WDAC, SmartScreen, audit policy, EDR inventory, Windows Hello biometrics, TPM ownership, password policy, auto-login).
- 6 new click-to-filter MiniDonut widgets: **Posture (LSA + Tamper)**, **Pending Reboot**, **UAC Level**, **Join State**, **LAPS**, **EDR Products**.
- 7 label helpers (`getPostureLabel`, `getRebootLabel`, …) so widgets and the filter chain share the same bucketing.
- Detection widget now keys off `activeThreatCount` (excludes ASR rule blocks, which are protection working) with a fallback to `detectionCount` for old payloads.

## Data-processing extractor

- 18 new TypeScript interfaces matching the C# models (`LsaProtectionInfo`, `WindowsHelloPresenceInfo`, `LapsInfo`, `EdrProductInfo`, etc.).
- `extractSecurity()` passes them through raw — the device already computes the buckets, no client-side normalization needed.

## Compatibility

- All new fields are optional/back-compat — older payloads render exactly as before.
- No firmware-password widget here; that data is folded into the existing Tampering cell as a `FW PW On/Off` pill (landed in #14).

## Test plan

- [ ] Hard-refresh `/devices/security` and confirm the 6 new widgets render with sensible distributions
- [ ] Click each widget to verify filter wires through
- [ ] Confirm Tampering cell still shows TPM/SB/FW PW pills (no regression)
- [ ] CSV export contains the same columns (no firmware-password column reintroduced)
- [ ] Older devices with no Phase 2/3 data fall into the "Unknown" bucket cleanly