### PR TITLE
peripherals: guard audioDevices against non-array values

### DIFF
--- a/src/components/tabs/PeripheralsTab.tsx
+++ b/src/components/tabs/PeripheralsTab.tsx
@@ -281,19 +281,24 @@ export const PeripheralsTab: React.FC<PeripheralsTabProps> = ({ device, data }) 
   }, [device, data])
   
   // Split audio devices into outputs and microphones
-  const audioOutputs = useMemo(() => 
-    (peripherals.audioDevices || []).filter(d => d.isOutput || d.type === 'Output'),
+  const audioDevices = useMemo(() =>
+    Array.isArray(peripherals.audioDevices) ? peripherals.audioDevices : [],
     [peripherals.audioDevices]
   )
-  
-  const microphones = useMemo(() => 
-    (peripherals.audioDevices || []).filter(d => d.isInput || d.type === 'Input'),
-    [peripherals.audioDevices]
+
+  const audioOutputs = useMemo(() =>
+    audioDevices.filter(d => d.isOutput || d.type === 'Output'),
+    [audioDevices]
   )
-  
+
+  const microphones = useMemo(() =>
+    audioDevices.filter(d => d.isInput || d.type === 'Input'),
+    [audioDevices]
+  )
+
   // Filter Bluetooth devices - only actual BT peripherals, not WiFi devices like HomePods or Apple Watch
   const filteredBluetoothDevices = useMemo(() => {
-    const btDevices = peripherals.bluetoothDevices || []
+    const btDevices = Array.isArray(peripherals.bluetoothDevices) ? peripherals.bluetoothDevices : []
     return btDevices.filter(d => {
       const name = (d.name || '').toLowerCase()
       const category = (d.deviceCategory || '').toLowerCase()


### PR DESCRIPTION
## Problem

Production crash on the device detail page:

```
(m.audioDevices||[]).filter is not a function.
(In '(m.audioDevices||[]).filter(e=>e.isOutput||"Output"===e.type)')
```

`PeripheralsTab` reads `peripherals` directly from the raw module payload (`data || device.peripherals || device.modules?.peripherals || {}`), **not** from the array-normalized output of `extractPeripherals()`. The existing `|| []` guard only handles `null`/`undefined`, so when `audioDevices` arrives as a non-array value (an object, or a count), `.filter()` is undefined and the whole tab throws.

## Fix

- Normalize `audioDevices` once via `Array.isArray()` and reuse it for the output/microphone splits.
- Apply the same `Array.isArray()` guard to `bluetoothDevices`.

Defensive, reader-side only — no data-shape assumptions changed at the collection source.

## Test

Type-checks clean (the 3 unrelated pre-existing diagnostics in this file are untouched). No new deps.