### PR TITLE
Add configurable settings (inventory mapping + security rules), PWA support, and dark-mode fixes

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,40 @@
+name: Publish web image
+
+# Publishes the dashboard image to GHCR for the self-host stack
+# (github.com/reportmate/self-host). Runs on version tags or manually.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/reportmate/web
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,7 +1,7 @@
 name: Publish web image
 
 # Publishes the dashboard image to GHCR for the self-host stack
-# (github.com/reportmate/self-host). Runs on version tags or manually.
+# (github.com/reportmate/selfhosted-docker-reportmate). Runs on version tags or manually.
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 /.next/
 /out/
 
+# Serwist (generated service worker)
+/public/sw.js
+/public/sw.js.map
+/public/swe-worker-*.js
+
 # Production
 /build
 

--- a/app/(auth)/auth/error/ClientAuthError.tsx
+++ b/app/(auth)/auth/error/ClientAuthError.tsx
@@ -41,7 +41,7 @@ function AuthErrorContent() {
   const errorDetails = getErrorDetails(error)
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div>
           <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-red-600">
@@ -49,15 +49,15 @@ function AuthErrorContent() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
             </svg>
           </div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-white">
             {errorDetails.title}
           </h2>
-          <p className="mt-2 text-center text-sm text-gray-600">
+          <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
             {errorDetails.description}
           </p>
         </div>
 
-        <div className="rounded-md bg-red-50 p-4">
+        <div className="rounded-md bg-red-50 dark:bg-red-900/20 p-4">
           <div className="flex">
             <div className="flex-shrink-0">
               <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
@@ -65,8 +65,8 @@ function AuthErrorContent() {
               </svg>
             </div>
             <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">What happened?</h3>
-              <div className="mt-2 text-sm text-red-700">
+              <h3 className="text-sm font-medium text-red-800 dark:text-red-300">What happened?</h3>
+              <div className="mt-2 text-sm text-red-700 dark:text-red-400">
                 <p>{errorDetails.suggestion}</p>
               </div>
             </div>
@@ -76,24 +76,24 @@ function AuthErrorContent() {
         <div className="mt-6 space-y-4">
           <Link
             href="/auth/signin"
-            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-gray-900"
           >
             Try Again
           </Link>
-          
+
           <Link
             href="/"
-            className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="w-full flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-gray-900"
           >
             Go to Home
           </Link>
         </div>
 
         <div className="mt-6">
-          <div className="text-center text-xs text-gray-500">
+          <div className="text-center text-xs text-gray-500 dark:text-gray-400">
             <p>
               If you continue to experience issues, please{' '}
-              <a href="mailto:support@ecuad.ca" className="text-blue-600 hover:text-blue-500">
+              <a href="mailto:support@ecuad.ca" className="text-blue-600 dark:text-blue-400 hover:text-blue-500">
                 contact support
               </a>
             </p>
@@ -107,10 +107,10 @@ function AuthErrorContent() {
 export default function AuthError() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 dark:border-blue-400 mx-auto"></div>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
         </div>
       </div>
     }>

--- a/app/(auth)/auth/signin/ClientSignIn.tsx
+++ b/app/(auth)/auth/signin/ClientSignIn.tsx
@@ -95,7 +95,7 @@ function SignInContent() {
                 alt="ReportMate"
                 width={240}
                 height={96}
-                className="h-24 w-auto dark:brightness-0 dark:invert"
+                className="h-24 w-auto"
                 priority
               />
             </div>
@@ -147,7 +147,7 @@ function SignInContent() {
               alt="ReportMate"
               width={240}
               height={96}
-              className="h-24 w-auto dark:brightness-0 dark:invert"
+              className="h-24 w-auto"
               priority
             />
           </div>

--- a/app/api/settings/inventory/discover/route.ts
+++ b/app/api/settings/inventory/discover/route.ts
@@ -1,39 +1,15 @@
 import { NextResponse } from "next/server"
 import { getInternalApiHeaders } from "@/lib/api-auth"
+import { requireAdmin } from "@/lib/auth-roles"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
 
-const ADMIN_ROLES = (process.env.SETTINGS_ADMIN_ROLES || "admin,administrator,owner")
-  .split(",")
-  .map((r) => r.trim().toLowerCase())
-  .filter(Boolean)
-
-function hasAdminRole(roles: unknown): boolean {
-  if (!Array.isArray(roles)) return false
-  return roles.some((r) => typeof r === "string" && ADMIN_ROLES.includes(r.toLowerCase()))
-}
-
-// Lazy so `@/lib/auth` (which evaluates the Entra provider at import) isn't run
-// during build when its env vars are absent.
-async function getSession() {
-  const { getServerSession } = await import("next-auth")
-  const { authOptions } = await import("@/lib/auth")
-  return getServerSession(authOptions)
-}
-
 export async function GET(request: Request) {
   try {
-    const isDemoOrDev =
-      process.env.NEXT_PUBLIC_DEMO_MODE === "true" || process.env.NODE_ENV === "development"
-
-    if (!isDemoOrDev) {
-      const session = await getSession()
-      if (!session) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
-      if (!hasAdminRole((session.user as { roles?: unknown })?.roles)) {
-        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-      }
-    }
+    // Discovery exposes inventory values, so it's admin-only.
+    const guard = await requireAdmin(request)
+    if (guard instanceof NextResponse) return guard
 
     const apiBaseUrl = process.env.API_BASE_URL
     if (!apiBaseUrl) {

--- a/app/api/settings/inventory/discover/route.ts
+++ b/app/api/settings/inventory/discover/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server"
+import { getInternalApiHeaders } from "@/lib/api-auth"
+
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
+const ADMIN_ROLES = (process.env.SETTINGS_ADMIN_ROLES || "admin,administrator,owner")
+  .split(",")
+  .map((r) => r.trim().toLowerCase())
+  .filter(Boolean)
+
+function hasAdminRole(roles: unknown): boolean {
+  if (!Array.isArray(roles)) return false
+  return roles.some((r) => typeof r === "string" && ADMIN_ROLES.includes(r.toLowerCase()))
+}
+
+// Lazy so `@/lib/auth` (which evaluates the Entra provider at import) isn't run
+// during build when its env vars are absent.
+async function getSession() {
+  const { getServerSession } = await import("next-auth")
+  const { authOptions } = await import("@/lib/auth")
+  return getServerSession(authOptions)
+}
+
+export async function GET(request: Request) {
+  try {
+    const isDemoOrDev =
+      process.env.NEXT_PUBLIC_DEMO_MODE === "true" || process.env.NODE_ENV === "development"
+
+    if (!isDemoOrDev) {
+      const session = await getSession()
+      if (!session) return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+      if (!hasAdminRole((session.user as { roles?: unknown })?.roles)) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+      }
+    }
+
+    const apiBaseUrl = process.env.API_BASE_URL
+    if (!apiBaseUrl) {
+      return NextResponse.json({ error: "API_BASE_URL not configured" }, { status: 500 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const includeArchived = searchParams.get("include_archived") || "false"
+
+    const response = await fetch(
+      `${apiBaseUrl}/api/v1/settings/inventory/discover?include_archived=${encodeURIComponent(includeArchived)}`,
+      { method: "GET", headers: getInternalApiHeaders(), cache: "no-store" }
+    )
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.ok ? 200 : response.status })
+  } catch (error) {
+    console.error("[SETTINGS] discover failed:", error)
+    return NextResponse.json(
+      { error: "Inventory discovery failed", details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,29 +1,9 @@
 import { NextResponse } from "next/server"
 import { getInternalApiHeaders } from "@/lib/api-auth"
+import { requireAdmin } from "@/lib/auth-roles"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
-
-// Resolve the current session lazily. `@/lib/auth` evaluates the Entra provider
-// at module load and throws when its env vars are absent (e.g. during build), so
-// it must only be imported at request time when the environment is populated.
-async function getSession() {
-  const { getServerSession } = await import("next-auth")
-  const { authOptions } = await import("@/lib/auth")
-  return getServerSession(authOptions)
-}
-
-// Roles permitted to write org settings. Configurable so each deployment can
-// map its own Azure AD app role; matched case-insensitively.
-const ADMIN_ROLES = (process.env.SETTINGS_ADMIN_ROLES || "admin,administrator,owner")
-  .split(",")
-  .map((r) => r.trim().toLowerCase())
-  .filter(Boolean)
-
-function hasAdminRole(roles: unknown): boolean {
-  if (!Array.isArray(roles)) return false
-  return roles.some((r) => typeof r === "string" && ADMIN_ROLES.includes(r.toLowerCase()))
-}
 
 export async function GET() {
   try {
@@ -59,22 +39,9 @@ export async function PUT(request: Request) {
       )
     }
 
-    // Role gating happens here — the FastAPI tier has no per-user identity.
-    // Local dev has no session, so allow it there for testing.
-    const isDev = process.env.NODE_ENV === "development"
-    const session = isDev ? null : await getSession()
-
-    if (!isDev) {
-      if (!session) {
-        return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
-      }
-      if (!hasAdminRole((session.user as { roles?: unknown })?.roles)) {
-        return NextResponse.json(
-          { error: "Forbidden: settings can only be changed by an administrator" },
-          { status: 403 }
-        )
-      }
-    }
+    // Admin role gating (the FastAPI tier has no per-user identity).
+    const guard = await requireAdmin(request)
+    if (guard instanceof NextResponse) return guard
 
     const apiBaseUrl = process.env.API_BASE_URL
     if (!apiBaseUrl) {
@@ -84,7 +51,7 @@ export async function PUT(request: Request) {
     const body = await request.json()
 
     const headers = getInternalApiHeaders()
-    const actor = session?.user?.email
+    const actor = guard.user?.email
     if (actor) headers["X-Updated-By"] = actor
 
     const response = await fetch(`${apiBaseUrl}/api/v1/settings`, {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server"
+import { getInternalApiHeaders } from "@/lib/api-auth"
+
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
+// Resolve the current session lazily. `@/lib/auth` evaluates the Entra provider
+// at module load and throws when its env vars are absent (e.g. during build), so
+// it must only be imported at request time when the environment is populated.
+async function getSession() {
+  const { getServerSession } = await import("next-auth")
+  const { authOptions } = await import("@/lib/auth")
+  return getServerSession(authOptions)
+}
+
+// Roles permitted to write org settings. Configurable so each deployment can
+// map its own Azure AD app role; matched case-insensitively.
+const ADMIN_ROLES = (process.env.SETTINGS_ADMIN_ROLES || "admin,administrator,owner")
+  .split(",")
+  .map((r) => r.trim().toLowerCase())
+  .filter(Boolean)
+
+function hasAdminRole(roles: unknown): boolean {
+  if (!Array.isArray(roles)) return false
+  return roles.some((r) => typeof r === "string" && ADMIN_ROLES.includes(r.toLowerCase()))
+}
+
+export async function GET() {
+  try {
+    const apiBaseUrl = process.env.API_BASE_URL
+    if (!apiBaseUrl) {
+      return NextResponse.json({ error: "API_BASE_URL not configured" }, { status: 500 })
+    }
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/settings`, {
+      method: "GET",
+      headers: getInternalApiHeaders(),
+      cache: "no-store",
+    })
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.ok ? 200 : response.status })
+  } catch (error) {
+    console.error("[SETTINGS] GET failed:", error)
+    return NextResponse.json(
+      { error: "Failed to load settings", details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    // The public demo is strictly read-only — never allow settings writes there.
+    if (process.env.NEXT_PUBLIC_DEMO_MODE === "true") {
+      return NextResponse.json(
+        { error: "Settings are read-only in the demo environment" },
+        { status: 403 }
+      )
+    }
+
+    // Role gating happens here — the FastAPI tier has no per-user identity.
+    // Local dev has no session, so allow it there for testing.
+    const isDev = process.env.NODE_ENV === "development"
+    const session = isDev ? null : await getSession()
+
+    if (!isDev) {
+      if (!session) {
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+      }
+      if (!hasAdminRole((session.user as { roles?: unknown })?.roles)) {
+        return NextResponse.json(
+          { error: "Forbidden: settings can only be changed by an administrator" },
+          { status: 403 }
+        )
+      }
+    }
+
+    const apiBaseUrl = process.env.API_BASE_URL
+    if (!apiBaseUrl) {
+      return NextResponse.json({ error: "API_BASE_URL not configured" }, { status: 500 })
+    }
+
+    const body = await request.json()
+
+    const headers = getInternalApiHeaders()
+    const actor = session?.user?.email
+    if (actor) headers["X-Updated-By"] = actor
+
+    const response = await fetch(`${apiBaseUrl}/api/v1/settings`, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify(body),
+      cache: "no-store",
+    })
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.ok ? 200 : response.status })
+  } catch (error) {
+    console.error("[SETTINGS] PUT failed:", error)
+    return NextResponse.json(
+      { error: "Failed to save settings", details: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { SWRProvider } from "../src/providers/SWRProvider";
 import { PlatformFilterProvider } from "../src/providers/PlatformFilterProvider";
 import { DebugModeProvider } from "../src/providers/DebugModeProvider";
 import { DemoModeProvider } from "../src/providers/DemoModeProvider";
+import { SettingsProvider } from "../src/providers/SettingsProvider";
 import { ToolbarWrapper } from "../src/components/navigation/ToolbarWrapper";
 
 // Force dynamic rendering to ensure middleware runs
@@ -170,6 +171,7 @@ export default async function RootLayout({
         />
         <AuthProvider>
           <SWRProvider>
+            <SettingsProvider>
             <PlatformFilterProvider>
               <ThemeProvider defaultTheme="system" storageKey="reportmate-theme">
                 <DebugModeProvider>
@@ -194,6 +196,7 @@ export default async function RootLayout({
                 </DebugModeProvider>
               </ThemeProvider>
             </PlatformFilterProvider>
+            </SettingsProvider>
           </SWRProvider>
         </AuthProvider>
       </body>

--- a/app/settings/ClientSettingsPage.tsx
+++ b/app/settings/ClientSettingsPage.tsx
@@ -7,11 +7,16 @@ import { ThemeToggle } from '../../src/components/theme-toggle'
 import { useDemoMode } from '../../src/providers/DemoModeProvider'
 import { useHasRole } from '../../hooks/useAuth'
 import { ADMIN_ROLE } from '../../lib/auth-roles'
+import Link from 'next/link'
+import { InventoryMappingEditor } from '../../src/components/settings/InventoryMappingEditor'
+import { SecurityRulesEditor } from '../../src/components/settings/SecurityRulesEditor'
+import { useSettings } from '../../src/providers/SettingsProvider'
 
 type MaintStatus = { type: 'idle' | 'loading' | 'success' | 'error'; message?: string }
 
 export default function ClientSettingsPage() {
-  const [activeSection, setActiveSection] = useState<'general' | 'modules' | 'security' | 'integrations' | 'maintenance'>('general')
+  const { isFirstTime } = useSettings()
+  const [activeSection, setActiveSection] = useState<'general' | 'inventory' | 'rules' | 'modules' | 'security' | 'integrations' | 'maintenance'>('general')
   const [clearDays, setClearDays] = useState(10)
   const [clearStatus, setClearStatus] = useState<MaintStatus>({ type: 'idle' })
   const [deleteSerial, setDeleteSerial] = useState('')
@@ -30,6 +35,8 @@ export default function ClientSettingsPage() {
 
   const menuItems = [
     { id: 'general', name: 'General', icon: '' },
+    { id: 'inventory', name: 'Inventory Mapping', icon: '' },
+    { id: 'rules', name: 'Security Rules', icon: '' },
     { id: 'modules', name: 'Modules', icon: '' },
     { id: 'security', name: 'Security', icon: '' },
     { id: 'integrations', name: 'Integrations', icon: '' },
@@ -135,23 +142,20 @@ export default function ClientSettingsPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-black">
       <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-        {/* Draft Implementation Banner */}
-        <div className="mb-6 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg p-4">
-          <div className="flex items-start">
-            <svg className="w-5 h-5 text-amber-400 mt-0.5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
+        {isFirstTime && (
+          <div className="mb-6 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4 flex items-center justify-between">
             <div>
-              <h3 className="text-sm font-medium text-amber-800 dark:text-amber-200">
-                Settings Page - Draft Implementation
-              </h3>
-              <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
-                This settings page is currently a user interface prototype and does not save or apply any configurations yet. 
-                All settings displayed here are for preview purposes only. Actual settings functionality will be implemented in future updates.
+              <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200">Finish setting up ReportMate</h3>
+              <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
+                Run the one-time setup to auto-discover your inventory fields and seed security rules.
               </p>
             </div>
+            <Link href="/settings/onboarding"
+              className="ml-4 flex-shrink-0 px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
+              Run setup
+            </Link>
           </div>
-        </div>
+        )}
 
         <div className="mb-8">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Settings</h2>
@@ -274,6 +278,24 @@ export default function ClientSettingsPage() {
                       </div>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {activeSection === 'inventory' && (
+                <div className="p-6">
+                  <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+                    Inventory Mapping
+                  </h2>
+                  <InventoryMappingEditor />
+                </div>
+              )}
+
+              {activeSection === 'rules' && (
+                <div className="p-6">
+                  <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+                    Security Rules
+                  </h2>
+                  <SecurityRulesEditor />
                 </div>
               )}
 
@@ -620,21 +642,6 @@ export default function ClientSettingsPage() {
                   </>)}
                 </div>
               )}
-            </div>
-            
-            <div className="mt-6 flex justify-end">
-              <button
-                type="button"
-                className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="ml-3 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-              >
-                Save Changes
-              </button>
             </div>
           </div>
         </div>

--- a/app/settings/onboarding/page.tsx
+++ b/app/settings/onboarding/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+import { OnboardingWizard } from "../../../src/components/settings/OnboardingWizard"
+
+export const metadata: Metadata = {
+  title: "Setup",
+  description: "First-time ReportMate setup",
+}
+
+export default function OnboardingPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-black">
+      <OnboardingWizard />
+    </div>
+  )
+}

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -1,0 +1,48 @@
+/// <reference lib="webworker" />
+import { defaultCache } from "@serwist/next/worker"
+import type { PrecacheEntry, RuntimeCaching, SerwistGlobalConfig } from "serwist"
+import { NetworkOnly, Serwist } from "serwist"
+
+declare global {
+  interface WorkerGlobalScope extends SerwistGlobalConfig {
+    __SW_MANIFEST: (PrecacheEntry | string)[] | undefined
+  }
+}
+
+declare const self: ServiceWorkerGlobalScope
+
+// Device data must never be served stale-as-live. API calls go straight to the
+// network; if the network is down the request fails and the UI shows its own
+// empty/offline state rather than a cached snapshot pretending to be current.
+const apiNetworkOnly: RuntimeCaching = {
+  matcher: ({ url, sameOrigin }) => sameOrigin && url.pathname.startsWith("/api/"),
+  handler: new NetworkOnly(),
+}
+
+// The app's root layout is force-dynamic, so no page HTML is statically
+// prerendered for Serwist to precache. The offline fallback is therefore a
+// self-contained static file in public/, precached explicitly here (and its
+// logo) so the document fallback works with zero network.
+const offlineFallbacks: (PrecacheEntry | string)[] = [
+  { url: "/offline.html", revision: null },
+  { url: "/reportmate-logo.png", revision: null },
+]
+
+const serwist = new Serwist({
+  precacheEntries: [...(self.__SW_MANIFEST ?? []), ...offlineFallbacks],
+  skipWaiting: true,
+  clientsClaim: true,
+  navigationPreload: true,
+  // API rule first so it wins over defaultCache's catch-all handlers.
+  runtimeCaching: [apiNetworkOnly, ...defaultCache],
+  fallbacks: {
+    entries: [
+      {
+        url: "/offline.html",
+        matcher: ({ request }) => request.destination === "document",
+      },
+    ],
+  },
+})
+
+serwist.addEventListeners()

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,6 +10,7 @@ const publicRoutes = [
   '/api/health',        // Alternative health check endpoint
   '/api/version',       // Build/version metadata endpoint for status widgets
   '/api/dashboard',     // BFF route - authenticated via X-Internal-Secret to FastAPI
+  '/api/settings',      // BFF route - GET proxies via X-Internal-Secret; PUT/discover gated by requireAdmin
   '/api/device',        // BFF route - authenticated via X-Internal-Secret to FastAPI
   '/api/devices',       // BFF route - authenticated via X-Internal-Secret to FastAPI
   '/api/modules',       // BFF route - authenticated via X-Internal-Secret to FastAPI
@@ -251,6 +252,6 @@ export const config = {
      * except for static assets, authentication endpoints, health endpoints,
      * and internal API routes (which handle their own authentication)
      */
-    '/((?!_next/static|_next/image|favicon.ico|sw.js|offline.html|swe-worker|manifest.json|api/auth|api/healthz|api/health|api/device|api/devices|api/modules|api/stats|api/events|api/dashboard).*)',
+    '/((?!_next/static|_next/image|favicon.ico|sw.js|offline.html|swe-worker|manifest.json|api/auth|api/healthz|api/health|api/device|api/devices|api/modules|api/stats|api/events|api/dashboard|api/settings).*)',
   ],
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,10 @@ const publicRoutes = [
   '/manifest.json',
   '/.well-known',
   '/reportmate-logo.png',  // ReportMate logo file
-  '/theme-init.js'         // Theme initialization script
+  '/theme-init.js',        // Theme initialization script
+  '/sw.js',                // PWA service worker (must be reachable before auth)
+  '/offline.html',         // PWA offline fallback (served from SW cache)
+  '/swe-worker'            // Serwist worker chunks (swe-worker-*.js)
 ]
 
 function isPublicRoute(pathname: string): boolean {
@@ -248,6 +251,6 @@ export const config = {
      * except for static assets, authentication endpoints, health endpoints,
      * and internal API routes (which handle their own authentication)
      */
-    '/((?!_next/static|_next/image|favicon.ico|api/auth|api/healthz|api/health|api/device|api/devices|api/modules|api/stats|api/events|api/dashboard).*)',
+    '/((?!_next/static|_next/image|favicon.ico|sw.js|offline.html|swe-worker|manifest.json|api/auth|api/healthz|api/health|api/device|api/devices|api/modules|api/stats|api/events|api/dashboard).*)',
   ],
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,16 @@
+import withSerwistInit from "@serwist/next"
+
+const withSerwist = withSerwistInit({
+  swSrc: "app/sw.ts",
+  swDest: "public/sw.js",
+  // Disable the SW in development so HMR isn't fighting a cache.
+  disable: process.env.NODE_ENV === "development",
+  // Reload open clients once a new SW takes control.
+  reloadOnOnline: true,
+})
+
 /** @type {import("next").NextConfig} */
-export default {
+const nextConfig = {
   // Minimal dev configuration
   eslint: {
     ignoreDuringBuilds: true,
@@ -53,3 +64,5 @@ export default {
     return config
   }
 }
+
+export default withSerwist(nextConfig)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@heroicons/react": "^2.2.0",
     "@microsoft/signalr": "^8.0.17",
     "@prisma/client": "^5.22.0",
+    "@serwist/next": "^9.5.11",
     "@swc/helpers": "^0.5.17",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.12",
@@ -41,6 +42,7 @@
     "react-dom": "^18.3.1",
     "react-window": "^2.2.3",
     "recharts": "^2.15.0",
+    "serwist": "^9.5.11",
     "swr": "^2.3.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
+      '@serwist/next':
+        specifier: ^9.5.11
+        version: 9.5.11(next@15.5.4(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.17
@@ -74,6 +77,9 @@ importers:
       recharts:
         specifier: ^2.15.0
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      serwist:
+        specifier: ^9.5.11
+        version: 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
       swr:
         specifier: ^2.3.7
         version: 2.3.8(react@18.3.1)
@@ -429,144 +435,170 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.0':
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -735,24 +767,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.4':
     resolution: {integrity: sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.4':
     resolution: {integrity: sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.4':
     resolution: {integrity: sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.4':
     resolution: {integrity: sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==}
@@ -824,6 +860,57 @@ packages:
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
 
+  '@serwist/build@9.5.11':
+    resolution: {integrity: sha512-PQfW+LhADYFOOp0PhEnjlgJCyKor6cYa06d3rID1OpiKzkmCApJV1WYfdTBB96jXaWv6OWcWSbSV4tqDLxvaVA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@serwist/next@9.5.11':
+    resolution: {integrity: sha512-omT32H7U21ihCymSvOG9QeRJBuOEomJx4JdzKhUoqOW3DR10tH3m84VOHj3BvK0OcA7av3qj5FsyNFBB+f0n8A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@serwist/cli': ^9.5.11
+      next: '>=14.0.0'
+      react: '>=18.0.0'
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      '@serwist/cli':
+        optional: true
+      typescript:
+        optional: true
+
+  '@serwist/utils@9.5.11':
+    resolution: {integrity: sha512-zqxmwuHqWA3OwN82Wo8gFZ9QBemygJP3cap5JWAOG4UyJZgUZfmBXAXj+IMaD4eKZ/6pqrxHHDZ9uSWZmJ1mXA==}
+    peerDependencies:
+      browserslist: '>=4'
+    peerDependenciesMeta:
+      browserslist:
+        optional: true
+
+  '@serwist/webpack-plugin@9.5.11':
+    resolution: {integrity: sha512-SlvO3A1UMcc1htCzMtLCtPQK6yISCO7B859ixLv7EiY/yayXjVxGm9vHqkJYpQ768PWyjEZXRY/X6EGRMA6wJQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+      webpack: 4.4.0 || ^5.9.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      webpack:
+        optional: true
+
+  '@serwist/window@9.5.11':
+    resolution: {integrity: sha512-OrH9srhmifUvY36NuukHSZby24XTEk4pHh3pfY0GBQzA9ouU1fYh+ORWhKxH7/wkVHRr3sc4YAhjtpfL14PjjQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -882,24 +969,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -1044,6 +1135,9 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -1151,41 +1245,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1357,8 +1459,17 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.0:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  baseline-browser-mapping@2.10.37:
+    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1372,12 +1483,21 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
   browserslist@4.25.3:
     resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1420,6 +1540,9 @@ packages:
 
   caniuse-lite@1.0.30001737:
     resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1479,6 +1602,10 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1670,6 +1797,9 @@ packages:
 
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
+
+  electron-to-chromium@1.5.372:
+    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -2011,6 +2141,10 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -2066,6 +2200,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2471,6 +2608,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -2515,24 +2655,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2592,6 +2736,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -2601,6 +2748,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -2655,6 +2806,10 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2667,6 +2822,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.0.2:
@@ -2746,6 +2905,10 @@ packages:
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2873,6 +3036,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
@@ -3021,6 +3188,10 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-bytes@6.1.1:
+    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -3200,6 +3371,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  serwist@9.5.11:
+    resolution: {integrity: sha512-Bq6uwJFd4ET60BWI77v3VbazKHv6k7lECOiiCFwKyBu/slaCn0GHJ5L5RfsuJUKrnbD9lYUCDo6sqaKRM5M2vA==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
@@ -3274,6 +3458,11 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.8.0-beta.0:
+    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
+    engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -3391,6 +3580,10 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
@@ -3442,6 +3635,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tr46@1.0.1:
+    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -3472,6 +3668,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3514,6 +3714,12 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3545,8 +3751,14 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  whatwg-url@7.1.0:
+    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3634,6 +3846,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.1:
+    resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
 
@@ -4380,6 +4595,63 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
+  '@serwist/build@9.5.11(browserslist@4.28.2)(typescript@5.9.2)':
+    dependencies:
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      common-tags: 1.8.2
+      glob: 13.0.6
+      pretty-bytes: 6.1.1
+      source-map: 0.8.0-beta.0
+      type-fest: 5.6.0
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - browserslist
+
+  '@serwist/next@9.5.11(next@15.5.4(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.2)':
+    dependencies:
+      '@serwist/build': 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      '@serwist/webpack-plugin': 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+      '@serwist/window': 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+      browserslist: 4.28.2
+      glob: 13.0.6
+      kolorist: 1.8.0
+      next: 15.5.4(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      semver: 7.7.4
+      serwist: 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - webpack
+
+  '@serwist/utils@9.5.11(browserslist@4.28.2)':
+    optionalDependencies:
+      browserslist: 4.28.2
+
+  '@serwist/webpack-plugin@9.5.11(browserslist@4.28.2)(typescript@5.9.2)':
+    dependencies:
+      '@serwist/build': 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      pretty-bytes: 6.1.1
+      zod: 4.4.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - browserslist
+
+  '@serwist/window@9.5.11(browserslist@4.28.2)(typescript@5.9.2)':
+    dependencies:
+      '@types/trusted-types': 2.0.7
+      serwist: 9.5.11(browserslist@4.28.2)(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - browserslist
+
   '@sinclair/typebox@0.27.8': {}
 
   '@sinonjs/commons@3.0.1':
@@ -4610,6 +4882,8 @@ snapshots:
       csstype: 3.1.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -4971,7 +5245,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.0: {}
+
+  baseline-browser-mapping@2.10.37: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4984,6 +5262,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -4994,6 +5276,14 @@ snapshots:
       electron-to-chromium: 1.5.211
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.37
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.372
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bser@2.1.1:
     dependencies:
@@ -5029,6 +5319,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001737: {}
+
+  caniuse-lite@1.0.30001799: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5086,6 +5378,8 @@ snapshots:
       color-string: 1.9.1
 
   commander@4.1.1: {}
+
+  common-tags@1.8.2: {}
 
   concat-map@0.0.1: {}
 
@@ -5252,6 +5546,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.211: {}
+
+  electron-to-chromium@1.5.372: {}
 
   emittery@0.13.1: {}
 
@@ -5755,6 +6051,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -5804,6 +6106,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   human-signals@2.1.0: {}
+
+  idb@8.0.3: {}
 
   ignore@5.3.2: {}
 
@@ -6403,6 +6707,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  kolorist@1.8.0: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -6491,6 +6797,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash.sortby@4.7.0: {}
+
   lodash@4.17.21: {}
 
   loose-envify@1.4.0:
@@ -6498,6 +6806,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6542,6 +6852,10 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -6553,6 +6867,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.0.2:
     dependencies:
@@ -6620,6 +6936,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
+
+  node-releases@2.0.47: {}
 
   normalize-path@3.0.0: {}
 
@@ -6753,6 +7071,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
   pg-cloudflare@1.2.7:
     optional: true
 
@@ -6878,6 +7201,8 @@ snapshots:
   preact@10.27.1: {}
 
   prelude-ls@1.2.1: {}
+
+  pretty-bytes@6.1.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -7077,6 +7402,17 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.4: {}
+
+  serwist@9.5.11(browserslist@4.28.2)(typescript@5.9.2):
+    dependencies:
+      '@serwist/utils': 9.5.11(browserslist@4.28.2)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - browserslist
+
   set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
@@ -7211,6 +7547,10 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
 
   split2@4.2.0: {}
 
@@ -7347,6 +7687,8 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@3.4.17:
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -7425,6 +7767,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
@@ -7449,6 +7795,10 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7526,6 +7876,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -7572,10 +7928,18 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@4.0.2: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7670,3 +8034,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.1: {}

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline · ReportMate</title>
+    <style>
+      :root { color-scheme: light dark; }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 3rem 1rem;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: #f9fafb;
+        color: #111827;
+      }
+      .card { max-width: 28rem; width: 100%; text-align: center; }
+      img { height: 5rem; width: auto; opacity: 0.9; margin-bottom: 1.5rem; }
+      h1 { font-size: 1.875rem; font-weight: 700; margin: 0 0 0.5rem; }
+      p { font-size: 0.875rem; line-height: 1.5; margin: 0 0 1.5rem; color: #4b5563; }
+      a.retry {
+        display: inline-block;
+        padding: 0.5rem 1.5rem;
+        border-radius: 0.375rem;
+        background: #2563eb;
+        color: #fff;
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+      }
+      a.retry:hover { background: #1d4ed8; }
+      @media (prefers-color-scheme: dark) {
+        body { background: #111827; color: #f9fafb; }
+        p { color: #9ca3af; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <img src="/reportmate-logo.png" alt="ReportMate" />
+      <h1>You&rsquo;re offline</h1>
+      <p>
+        ReportMate needs a network connection to show live fleet data. Reconnect and try
+        again &mdash; device information is never shown from a stale cache.
+      </p>
+      <a class="retry" href="/">Retry</a>
+    </div>
+  </body>
+</html>

--- a/src/components/settings/InventoryMappingEditor.tsx
+++ b/src/components/settings/InventoryMappingEditor.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import React, { useState } from "react"
+import { useSettings } from "../../providers/SettingsProvider"
+import { InventoryFieldMapping, SettingsDocument } from "../../lib/settings/types"
+
+/** Editable table for how raw inventory keys map to ReportMate's canonical
+ * fields (label, source key, order, visibility, known values). Saves the full
+ * settings document via the admin-gated PUT proxy. */
+export function InventoryMappingEditor() {
+  const { settings, inventoryFields, refresh } = useSettings()
+  const [fields, setFields] = useState<InventoryFieldMapping[]>(() =>
+    [...inventoryFields].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  )
+  const [status, setStatus] = useState<{ type: "idle" | "saving" | "saved" | "error"; message?: string }>({ type: "idle" })
+
+  const update = (key: string, patch: Partial<InventoryFieldMapping>) => {
+    setFields((prev) => prev.map((f) => (f.key === key ? { ...f, ...patch } : f)))
+    setStatus({ type: "idle" })
+  }
+
+  const move = (index: number, dir: -1 | 1) => {
+    setFields((prev) => {
+      const next = [...prev]
+      const target = index + dir
+      if (target < 0 || target >= next.length) return prev
+      ;[next[index], next[target]] = [next[target], next[index]]
+      return next.map((f, i) => ({ ...f, order: i }))
+    })
+    setStatus({ type: "idle" })
+  }
+
+  async function save() {
+    setStatus({ type: "saving" })
+    const doc: SettingsDocument = {
+      ...settings,
+      inventory: { fields: fields.map((f, i) => ({ ...f, order: i })) },
+    }
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(doc),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setStatus({ type: "error", message: data.error || data.detail || "Save failed" })
+        return
+      }
+      setStatus({ type: "saved", message: "Inventory mapping saved" })
+      await refresh()
+    } catch (err) {
+      setStatus({ type: "error", message: err instanceof Error ? err.message : "Network error" })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-gray-600 dark:text-gray-400">
+        Map the keys from each device&apos;s <code className="font-mono text-sm">Inventory.yaml</code> to
+        ReportMate&apos;s fields. Adjust the label, source key, order, and visibility. Known values for
+        <span className="font-mono"> usage</span> drive the security rules below.
+      </p>
+
+      <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Order</th>
+              <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Field</th>
+              <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Source key</th>
+              <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Label</th>
+              <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Known values</th>
+              <th className="px-3 py-2 text-center font-medium text-gray-500 dark:text-gray-400">Visible</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {fields.map((f, i) => (
+              <tr key={f.key}>
+                <td className="px-3 py-2 whitespace-nowrap">
+                  <div className="flex gap-1">
+                    <button onClick={() => move(i, -1)} disabled={i === 0}
+                      className="px-1.5 text-gray-500 hover:text-gray-900 dark:hover:text-white disabled:opacity-30" aria-label="Move up">↑</button>
+                    <button onClick={() => move(i, 1)} disabled={i === fields.length - 1}
+                      className="px-1.5 text-gray-500 hover:text-gray-900 dark:hover:text-white disabled:opacity-30" aria-label="Move down">↓</button>
+                  </div>
+                </td>
+                <td className="px-3 py-2 font-mono text-gray-900 dark:text-gray-100">{f.key}</td>
+                <td className="px-3 py-2">
+                  <input value={f.sourceKey} onChange={(e) => update(f.key, { sourceKey: e.target.value })}
+                    className="w-32 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono" />
+                </td>
+                <td className="px-3 py-2">
+                  <input value={f.label} onChange={(e) => update(f.key, { label: e.target.value })}
+                    className="w-36 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" />
+                </td>
+                <td className="px-3 py-2">
+                  <input value={(f.knownValues || []).join(", ")}
+                    onChange={(e) => update(f.key, { knownValues: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+                    placeholder="e.g. Assigned, Shared, Lab"
+                    className="w-56 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" />
+                </td>
+                <td className="px-3 py-2 text-center">
+                  <input type="checkbox" checked={f.visible} onChange={(e) => update(f.key, { visible: e.target.checked })}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button onClick={save} disabled={status.type === "saving"}
+          className={`px-4 py-2 text-sm font-medium rounded-md text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${status.type === "saving" ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"}`}>
+          {status.type === "saving" ? "Saving..." : "Save Mapping"}
+        </button>
+        {status.type === "saved" && <span className="text-sm text-green-600 dark:text-green-400">{status.message}</span>}
+        {status.type === "error" && <span className="text-sm text-red-600 dark:text-red-400">{status.message}</span>}
+      </div>
+    </div>
+  )
+}
+
+export default InventoryMappingEditor

--- a/src/components/settings/OnboardingWizard.tsx
+++ b/src/components/settings/OnboardingWizard.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import React, { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useSettings } from "../../providers/SettingsProvider"
+import {
+  CURRENT_SCHEMA_VERSION,
+  DEFAULT_INVENTORY_FIELDS,
+  DEFAULT_SECURITY_CONFIG,
+  STARTER_SECURITY_RULES,
+} from "../../lib/settings/defaults"
+import {
+  DiscoveredInventoryKey,
+  InventoryFieldMapping,
+  SettingsDocument,
+} from "../../lib/settings/types"
+
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "")
+
+/** First-run setup: discover the fleet's inventory keys, confirm the mapping,
+ * seed sensible security rules, then persist the org settings document. */
+export function OnboardingWizard() {
+  const router = useRouter()
+  const { settings, refresh } = useSettings()
+  const [step, setStep] = useState<0 | 1 | 2>(0)
+  const [discovered, setDiscovered] = useState<DiscoveredInventoryKey[] | null>(null)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
+  const [fields, setFields] = useState<InventoryFieldMapping[]>(DEFAULT_INVENTORY_FIELDS)
+  const [seedStarter, setSeedStarter] = useState(true)
+  const [status, setStatus] = useState<{ type: "idle" | "saving" | "error"; message?: string }>({ type: "idle" })
+
+  // Discover on mount.
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch("/api/settings/inventory/discover", { cache: "no-store" })
+        const data = await res.json()
+        if (cancelled) return
+        if (!res.ok) {
+          setDiscoverError(data.error || data.detail || "Discovery failed")
+          return
+        }
+        const keys: DiscoveredInventoryKey[] = data.keys || []
+        setDiscovered(keys)
+        // Auto-suggest mapping: match each canonical field to a discovered key
+        // by normalized name; seed usage known values from samples.
+        setFields(
+          DEFAULT_INVENTORY_FIELDS.map((f) => {
+            const match = keys.find((k) => norm(k.key) === norm(f.sourceKey) || norm(k.key) === norm(f.key))
+            return match
+              ? { ...f, sourceKey: match.key, knownValues: f.key === "usage" ? match.sampleValues : f.knownValues }
+              : f
+          })
+        )
+      } catch (err) {
+        if (!cancelled) setDiscoverError(err instanceof Error ? err.message : "Network error")
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const detectedCount = discovered?.length ?? 0
+  const usageValues = useMemo(
+    () => fields.find((f) => f.key === "usage")?.knownValues ?? [],
+    [fields]
+  )
+
+  const updateField = (key: string, patch: Partial<InventoryFieldMapping>) =>
+    setFields((prev) => prev.map((f) => (f.key === key ? { ...f, ...patch } : f)))
+
+  async function finish() {
+    setStatus({ type: "saving" })
+    const doc: SettingsDocument = {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      general: { ...settings.general, onboardingCompletedAt: new Date().toISOString() },
+      inventory: { fields: fields.map((f, i) => ({ ...f, order: i })) },
+      security: {
+        defaults: { ...DEFAULT_SECURITY_CONFIG.defaults, ...(settings.security?.defaults ?? {}) },
+        rules: seedStarter ? [...STARTER_SECURITY_RULES] : (settings.security?.rules ?? []),
+      },
+    }
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(doc),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setStatus({ type: "error", message: data.error || data.detail || "Save failed" })
+        return
+      }
+      await refresh()
+      router.push("/settings")
+    } catch (err) {
+      setStatus({ type: "error", message: err instanceof Error ? err.message : "Network error" })
+    }
+  }
+
+  const StepBadge = ({ n, label }: { n: number; label: string }) => (
+    <div className={`flex items-center gap-2 ${step === n ? "text-blue-600 dark:text-blue-400" : "text-gray-400"}`}>
+      <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ${step === n ? "bg-blue-600 text-white" : "bg-gray-200 dark:bg-gray-700"}`}>{n + 1}</span>
+      <span className="text-sm font-medium">{label}</span>
+    </div>
+  )
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">Set up ReportMate</h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-6">
+        A one-time setup to map your inventory fields and seed sensible security rules.
+      </p>
+
+      <div className="flex items-center gap-6 mb-8">
+        <StepBadge n={0} label="Discover" />
+        <StepBadge n={1} label="Map fields" />
+        <StepBadge n={2} label="Security rules" />
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+        {step === 0 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">Discovering inventory keys</h2>
+            {discoverError && (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {discoverError}. You can still continue with the default mapping.
+              </p>
+            )}
+            {!discovered && !discoverError && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">Scanning the fleet&apos;s inventory data…</p>
+            )}
+            {discovered && (
+              <>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Found <strong>{detectedCount}</strong> inventory key{detectedCount === 1 ? "" : "s"} across your devices.
+                </p>
+                <div className="max-h-64 overflow-auto border border-gray-200 dark:border-gray-700 rounded">
+                  <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                    <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Key</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Devices</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Sample values</th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                      {discovered.map((k) => (
+                        <tr key={k.key}>
+                          <td className="px-3 py-2 font-mono text-gray-900 dark:text-gray-100">{k.key}</td>
+                          <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{k.deviceCount}</td>
+                          <td className="px-3 py-2 text-gray-500 dark:text-gray-400 truncate max-w-xs">{k.sampleValues.slice(0, 6).join(", ")}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
+            <div className="flex justify-end">
+              <button onClick={() => setStep(1)}
+                className="px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">Next</button>
+            </div>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">Confirm field mapping</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Adjust the source key or hide fields you don&apos;t use.</p>
+            <div className="border border-gray-200 dark:border-gray-700 rounded overflow-hidden">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-800">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Field</th>
+                    <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Source key</th>
+                    <th className="px-3 py-2 text-center font-medium text-gray-500 dark:text-gray-400">Visible</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  {fields.map((f) => (
+                    <tr key={f.key}>
+                      <td className="px-3 py-2 font-mono text-gray-900 dark:text-gray-100">{f.key}</td>
+                      <td className="px-3 py-2">
+                        <input value={f.sourceKey} onChange={(e) => updateField(f.key, { sourceKey: e.target.value })}
+                          className="w-40 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white font-mono" />
+                      </td>
+                      <td className="px-3 py-2 text-center">
+                        <input type="checkbox" checked={f.visible} onChange={(e) => updateField(f.key, { visible: e.target.checked })}
+                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex justify-between">
+              <button onClick={() => setStep(0)} className="px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200">Back</button>
+              <button onClick={() => setStep(2)} className="px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">Next</button>
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">Seed security rules</h2>
+            <label className="flex items-start gap-3 p-4 border border-gray-200 dark:border-gray-700 rounded">
+              <input type="checkbox" checked={seedStarter} onChange={(e) => setSeedStarter(e.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Don&apos;t flag disk encryption as a problem on <span className="font-mono">Shared</span> or
+                <span className="font-mono"> Lab</span> devices (they&apos;re typically not encrypted).
+                {usageValues.length > 0 && (
+                  <span className="block text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Detected usage values: {usageValues.join(", ")}
+                  </span>
+                )}
+              </span>
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400">You can fine-tune all rules later under Settings → Security Rules.</p>
+            {status.type === "error" && <p className="text-sm text-red-600 dark:text-red-400">{status.message}</p>}
+            <div className="flex justify-between">
+              <button onClick={() => setStep(1)} className="px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200">Back</button>
+              <button onClick={finish} disabled={status.type === "saving"}
+                className={`px-4 py-2 text-sm font-medium rounded-md text-white ${status.type === "saving" ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"}`}>
+                {status.type === "saving" ? "Saving…" : "Finish setup"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OnboardingWizard

--- a/src/components/settings/SecurityRulesEditor.tsx
+++ b/src/components/settings/SecurityRulesEditor.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import React, { useState } from "react"
+import { useSettings } from "../../providers/SettingsProvider"
+import {
+  SecurityConfig,
+  SecurityRule,
+  SettingsDocument,
+  Severity,
+} from "../../lib/settings/types"
+
+const CHECKS = ["encryption", "firewall", "ssh", "rdp", "sip"] as const
+const SEVERITIES: Severity[] = ["ok", "warning", "danger", "neutral"]
+const STATES = ["any", "enabled", "disabled"] as const
+
+const CHECK_LABELS: Record<string, string> = {
+  encryption: "Disk encryption (FileVault / BitLocker)",
+  firewall: "Firewall",
+  ssh: "Secure Shell (SSH / Remote Login)",
+  rdp: "Remote Desktop (RDP)",
+  sip: "System Integrity Protection",
+}
+
+function SeveritySelect({ value, onChange }: { value: Severity; onChange: (v: Severity) => void }) {
+  return (
+    <select value={value} onChange={(e) => onChange(e.target.value as Severity)}
+      className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm">
+      {SEVERITIES.map((s) => <option key={s} value={s}>{s}</option>)}
+    </select>
+  )
+}
+
+let ruleSeq = 0
+
+export function SecurityRulesEditor() {
+  const { settings, securityConfig, inventoryFields, refresh } = useSettings()
+  const [config, setConfig] = useState<SecurityConfig>(() => ({
+    defaults: { ...securityConfig.defaults },
+    rules: securityConfig.rules.map((r) => ({ ...r })),
+  }))
+  const [status, setStatus] = useState<{ type: "idle" | "saving" | "saved" | "error"; message?: string }>({ type: "idle" })
+
+  const knownUsage = inventoryFields.find((f) => f.key === "usage")?.knownValues ?? []
+
+  const setDefault = (check: string, which: "enabledSeverity" | "disabledSeverity", v: Severity) => {
+    setConfig((c) => ({ ...c, defaults: { ...c.defaults, [check]: { ...c.defaults[check], [which]: v } } }))
+    setStatus({ type: "idle" })
+  }
+
+  const updateRule = (id: string, patch: Partial<SecurityRule>) => {
+    setConfig((c) => ({ ...c, rules: c.rules.map((r) => (r.id === id ? { ...r, ...patch } : r)) }))
+    setStatus({ type: "idle" })
+  }
+
+  const setRuleUsage = (id: string, csv: string) => {
+    const values = csv.split(",").map((s) => s.trim()).filter(Boolean)
+    updateRule(id, { when: values.length ? { inventory: { usage: { in: values } } } : undefined })
+  }
+
+  const addRule = () => {
+    ruleSeq += 1
+    const rule: SecurityRule = {
+      id: `rule-${Date.now()}-${ruleSeq}`,
+      module: "security",
+      check: "encryption",
+      state: "disabled",
+      severity: "neutral",
+      enabled: true,
+      when: { inventory: { usage: { in: ["Shared"] } } },
+    }
+    setConfig((c) => ({ ...c, rules: [...c.rules, rule] }))
+    setStatus({ type: "idle" })
+  }
+
+  const removeRule = (id: string) => {
+    setConfig((c) => ({ ...c, rules: c.rules.filter((r) => r.id !== id) }))
+    setStatus({ type: "idle" })
+  }
+
+  async function save() {
+    setStatus({ type: "saving" })
+    const doc: SettingsDocument = { ...settings, security: config }
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(doc),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setStatus({ type: "error", message: data.error || data.detail || "Save failed" })
+        return
+      }
+      setStatus({ type: "saved", message: "Security rules saved" })
+      await refresh()
+    } catch (err) {
+      setStatus({ type: "error", message: err instanceof Error ? err.message : "Network error" })
+    }
+  }
+
+  const ruleUsageValues = (r: SecurityRule) => r.when?.inventory?.usage?.in ?? []
+  const unknownUsage = (r: SecurityRule) =>
+    knownUsage.length > 0 && ruleUsageValues(r).some((v) => !knownUsage.includes(v))
+
+  return (
+    <div className="space-y-8">
+      {/* Baseline defaults */}
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-3">Baseline severities</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          How each check is colored when no rule matches. These reproduce ReportMate&apos;s standard behavior.
+        </p>
+        <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">Check</th>
+                <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">When enabled</th>
+                <th className="px-3 py-2 text-left font-medium text-gray-500 dark:text-gray-400">When disabled</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+              {CHECKS.map((check) => (
+                <tr key={check}>
+                  <td className="px-3 py-2 text-gray-900 dark:text-gray-100">{CHECK_LABELS[check]}</td>
+                  <td className="px-3 py-2">
+                    <SeveritySelect value={config.defaults[check]?.enabledSeverity ?? "ok"} onChange={(v) => setDefault(check, "enabledSeverity", v)} />
+                  </td>
+                  <td className="px-3 py-2">
+                    <SeveritySelect value={config.defaults[check]?.disabledSeverity ?? "danger"} onChange={(v) => setDefault(check, "disabledSeverity", v)} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Rules */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">Usage-aware rules</h3>
+          <button onClick={addRule}
+            className="px-3 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+            + Add rule
+          </button>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Override the baseline for devices matching a usage. Example: encryption disabled on
+          <span className="font-mono"> Shared</span>/<span className="font-mono">Lab</span> devices → neutral instead of red.
+          When multiple rules match, the most specific wins (ties broken by the last rule).
+        </p>
+
+        {config.rules.length === 0 && (
+          <p className="text-sm text-gray-400 dark:text-gray-500 italic">No rules yet. The baselines above apply to every device.</p>
+        )}
+
+        <div className="space-y-3">
+          {config.rules.map((r) => (
+            <div key={r.id} className="border border-gray-200 dark:border-gray-700 rounded-md p-3 flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
+                <input type="checkbox" checked={r.enabled !== false} onChange={(e) => updateRule(r.id, { enabled: e.target.checked })}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500" />
+                On
+              </label>
+
+              <select value={r.check} onChange={(e) => updateRule(r.id, { check: e.target.value })}
+                className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm">
+                {CHECKS.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+
+              <select value={r.state ?? "any"} onChange={(e) => updateRule(r.id, { state: e.target.value as SecurityRule["state"] })}
+                className="px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm">
+                {STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+
+              <span className="text-sm text-gray-500 dark:text-gray-400">when usage in</span>
+              <input value={ruleUsageValues(r).join(", ")} onChange={(e) => setRuleUsage(r.id, e.target.value)}
+                placeholder="Shared, Lab"
+                className="w-44 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm" />
+
+              <span className="text-sm text-gray-500 dark:text-gray-400">→</span>
+              <SeveritySelect value={r.severity} onChange={(v) => updateRule(r.id, { severity: v })} />
+
+              <button onClick={() => removeRule(r.id)}
+                className="ml-auto text-sm text-red-600 hover:text-red-800 dark:text-red-400">Remove</button>
+
+              {unknownUsage(r) && (
+                <p className="w-full text-xs text-amber-600 dark:text-amber-400">
+                  Warning: references a usage value not seen in the fleet&apos;s known values ({knownUsage.join(", ") || "none discovered"}).
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button onClick={save} disabled={status.type === "saving"}
+          className={`px-4 py-2 text-sm font-medium rounded-md text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${status.type === "saving" ? "bg-gray-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"}`}>
+          {status.type === "saving" ? "Saving..." : "Save Rules"}
+        </button>
+        {status.type === "saved" && <span className="text-sm text-green-600 dark:text-green-400">{status.message}</span>}
+        {status.type === "error" && <span className="text-sm text-red-600 dark:text-red-400">{status.message}</span>}
+      </div>
+    </div>
+  )
+}
+
+export default SecurityRulesEditor

--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -12,21 +12,38 @@
  * 6. Remote Access - SecureShell + RDP (Win) / SecureShell + Screen Sharing (Mac)
  */
 
+"use client"
+
 import React from 'react'
 import { convertPowerShellObjects, normalizeKeys, isPowerShellTrue } from '../../lib/utils/powershell-parser'
 import { DebugAccordion } from '../DebugAccordion'
 import { Lock, BrickWall, HardDrive, Cpu, Terminal, Shield, ShieldCheck, Search, Award, AlertTriangle, CheckCircle, XCircle, ChevronDown } from 'lucide-react'
+import { useSettingsOptional } from '../../providers/SettingsProvider'
+import { DEFAULT_SECURITY_CONFIG, DEFAULT_INVENTORY_FIELDS } from '../../lib/settings/defaults'
+import { evaluateSecurity } from '../../lib/rules/evaluateSecurity'
+import { getDeviceInventoryContext } from '../../lib/rules/inventoryMapping'
+import type { Severity } from '../../lib/settings/types'
 
 interface SecurityTabProps {
   device: any
 }
 
-const StatusBadge = ({ enabled, activeLabel = 'Enabled', inactiveLabel = 'Disabled', neutral, danger }: { 
-  enabled: boolean | undefined, 
-  activeLabel?: string, 
+// Text classes for the portable severity vocabulary. `unknown` falls through to
+// the caller's default treatment.
+const SEVERITY_TEXT: Record<Exclude<Severity, 'unknown'>, string> = {
+  ok: 'text-green-600 dark:text-green-400',
+  danger: 'text-red-600 dark:text-red-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  neutral: 'text-gray-900 dark:text-gray-100',
+}
+
+const StatusBadge = ({ enabled, activeLabel = 'Enabled', inactiveLabel = 'Disabled', neutral, danger, severity }: {
+  enabled: boolean | undefined,
+  activeLabel?: string,
   inactiveLabel?: string,
   neutral?: boolean,
-  danger?: boolean
+  danger?: boolean,
+  severity?: Severity
 }) => {
   if (enabled === undefined) {
     return (
@@ -35,7 +52,17 @@ const StatusBadge = ({ enabled, activeLabel = 'Enabled', inactiveLabel = 'Disabl
       </span>
     )
   }
-  
+
+  // When a settings-derived severity is supplied, it takes precedence over the
+  // legacy neutral/danger booleans.
+  if (severity && severity !== 'unknown') {
+    return (
+      <span className={`text-sm font-medium ${SEVERITY_TEXT[severity]}`}>
+        {enabled ? activeLabel : inactiveLabel}
+      </span>
+    )
+  }
+
   if (!enabled) {
     if (danger) {
       return (
@@ -59,7 +86,7 @@ const StatusBadge = ({ enabled, activeLabel = 'Enabled', inactiveLabel = 'Disabl
       </span>
     )
   }
-  
+
   return (
     <span className="text-sm font-medium text-green-600 dark:text-green-400">
       {activeLabel}
@@ -67,22 +94,23 @@ const StatusBadge = ({ enabled, activeLabel = 'Enabled', inactiveLabel = 'Disabl
   )
 }
 
-const DetailRow = ({ label, value, activeLabel, inactiveLabel, isStatus, enabled, mono, neutral, danger, tooltip }: { 
-  label: string, 
-  value?: string, 
+const DetailRow = ({ label, value, activeLabel, inactiveLabel, isStatus, enabled, mono, neutral, danger, severity, tooltip }: {
+  label: string,
+  value?: string,
   activeLabel?: string,
   inactiveLabel?: string,
-  isStatus?: boolean, 
+  isStatus?: boolean,
   enabled?: boolean,
   mono?: boolean,
   neutral?: boolean,
   danger?: boolean,
+  severity?: Severity,
   tooltip?: string
 }) => (
   <div className="flex items-center justify-between py-1">
     <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
     {isStatus ? (
-      <StatusBadge enabled={enabled} activeLabel={activeLabel || value || 'Yes'} inactiveLabel={inactiveLabel || value || 'No'} neutral={neutral} danger={danger} />
+      <StatusBadge enabled={enabled} activeLabel={activeLabel || value || 'Yes'} inactiveLabel={inactiveLabel || value || 'No'} neutral={neutral} danger={danger} severity={severity} />
     ) : (
       <span 
         className={`text-sm font-medium text-gray-900 dark:text-white ${mono ? 'font-mono' : ''} ${tooltip ? 'cursor-help' : ''}`}
@@ -112,6 +140,16 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
   const security = parsedSecurity ? normalizeKeys(parsedSecurity) as any : null
   const secureShell = security?.secureShell
   const isMac = isMacOS(device)
+
+  // Settings-driven, usage-aware severity. `sev(check, enabled)` returns the
+  // severity to color a check, applying org rules (e.g. shared/lab devices with
+  // encryption off shouldn't be red) on top of the historical defaults.
+  const settings = useSettingsOptional()
+  const securityConfig = settings?.securityConfig ?? DEFAULT_SECURITY_CONFIG
+  const inventoryFields = settings?.inventoryFields?.length ? settings.inventoryFields : DEFAULT_INVENTORY_FIELDS
+  const inventoryCtx = getDeviceInventoryContext(device?.modules?.inventory as Record<string, unknown>, inventoryFields)
+  const sev = (check: string, enabled: boolean | undefined): Severity =>
+    evaluateSecurity(check, enabled, inventoryCtx, securityConfig)
   
   // Certificate filter state
   const [certFilter, setCertFilter] = React.useState<'all' | 'valid' | 'expiringsoon' | 'expired'>('all')
@@ -249,7 +287,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
             {isMac ? (
               // macOS: SIP + Secure Enclave + Root User + Secure Boot
               <>
-                <DetailRow label="System Integrity Protection" isStatus danger enabled={sipEnabled} activeLabel="Enabled" inactiveLabel="Disabled" />
+                <DetailRow label="System Integrity Protection" isStatus severity={sev('sip', sipEnabled)} enabled={sipEnabled} activeLabel="Enabled" inactiveLabel="Disabled" />
                 {/* Secure Enclave - no divider */}
                 <DetailRow 
                   label="Secure Enclave" 
@@ -792,7 +830,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                     ? security.fileVault.encryptedVolumes.map((v: any) => v.name || v.volumeName || v).join(', ')
                     : fileVaultEnabled ? 'System Volume' : 'None'
                 } />
-                <DetailRow label="Status" isStatus enabled={fileVaultEnabled} value={fileVaultEnabled ? 'Encrypted' : 'Not Encrypted'} />
+                <DetailRow label="Status" isStatus severity={sev('encryption', fileVaultEnabled)} enabled={fileVaultEnabled} value={fileVaultEnabled ? 'Encrypted' : 'Not Encrypted'} />
               </>
             ) : (
               // Windows BitLocker (now all camelCase after normalization)
@@ -806,7 +844,7 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                   <DetailRow label="Drives" value="None encrypted" />
                 )}
                 <DetailRow label="Method" value={security?.encryption?.encryptedVolumes?.[0]?.encryptionMethod || 'XTS-AES'} />
-                <DetailRow label="Status" value={security?.encryption?.bitLocker?.status || (security?.encryption?.bitLocker?.isEnabled ? 'Enabled' : 'Disabled')} />
+                <DetailRow label="Status" isStatus severity={sev('encryption', Boolean(security?.encryption?.bitLocker?.isEnabled))} enabled={Boolean(security?.encryption?.bitLocker?.isEnabled)} value={security?.encryption?.bitLocker?.status || (security?.encryption?.bitLocker?.isEnabled ? 'Enabled' : 'Disabled')} />
               </>
             )}
           </div>
@@ -825,12 +863,12 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
             {isMac ? (
               // macOS Firewall
               <>
-                <DetailRow 
-                  label="Global State" 
+                <DetailRow
+                  label="Global State"
                   isStatus
-                  neutral
+                  severity={sev('firewall', firewallEnabled)}
                   enabled={firewallEnabled}
-                  value={firewallEnabled ? 'On' : 'Off'} 
+                  value={firewallEnabled ? 'On' : 'Off'}
                 />
                 <DetailRow 
                   label="Stealth Mode" 
@@ -882,15 +920,17 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
               // macOS: Secure Shell + Screen Sharing + ARD
               <>
                 {/* Secure Shell/Remote Login - use collected SSH data */}
-                <DetailRow 
-                  label="Secure Shell (Remote Login)" 
-                  isStatus 
-                  neutral
-                  enabled={isPowerShellTrue(security?.ssh?.enabled) || 
-                          isPowerShellTrue(remoteManagement?.remoteLoginEnabled) || 
+                <DetailRow
+                  label="Secure Shell (Remote Login)"
+                  isStatus
+                  severity={sev('ssh', isPowerShellTrue(security?.ssh?.enabled) ||
+                          isPowerShellTrue(remoteManagement?.remoteLoginEnabled) ||
+                          isPowerShellTrue(remoteManagement?.remote_login_enabled))}
+                  enabled={isPowerShellTrue(security?.ssh?.enabled) ||
+                          isPowerShellTrue(remoteManagement?.remoteLoginEnabled) ||
                           isPowerShellTrue(remoteManagement?.remote_login_enabled)}
-                  value={(isPowerShellTrue(security?.ssh?.enabled) || 
-                          isPowerShellTrue(remoteManagement?.remoteLoginEnabled) || 
+                  value={(isPowerShellTrue(security?.ssh?.enabled) ||
+                          isPowerShellTrue(remoteManagement?.remoteLoginEnabled) ||
                           isPowerShellTrue(remoteManagement?.remote_login_enabled)) ? 'Enabled' : 'Disabled'}
                 />
                 {(security?.ssh?.enabled === 1 || security?.ssh?.enabled === true) && (
@@ -952,10 +992,11 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
               // Windows: RDP + Secure Shell
               <>
                 {/* RDP */}
-                <DetailRow 
-                  label="Remote Desktop (RDP)" 
-                  isStatus 
-                  enabled={security?.rdp?.isEnabled || security?.rdp?.is_enabled} 
+                <DetailRow
+                  label="Remote Desktop (RDP)"
+                  isStatus
+                  severity={sev('rdp', Boolean(security?.rdp?.isEnabled || security?.rdp?.is_enabled))}
+                  enabled={security?.rdp?.isEnabled || security?.rdp?.is_enabled}
                 />
                 <DetailRow 
                   label="RDP Port" 

--- a/src/components/widgets/Inventory.tsx
+++ b/src/components/widgets/Inventory.tsx
@@ -1,12 +1,19 @@
 /**
  * Inventory Widget
- * Displays inventory information including device name, usage, catalog, department, location, asset tag, and serial number
+ * Displays device identity plus assignment details. Assignment fields (usage,
+ * catalog, department, area, location, fleet, owner) are rendered from the org's
+ * configurable inventory field mapping; identity fields stay fixed.
  */
+
+"use client"
 
 import React from 'react'
 import { StatBlock, Stat, Icons, WidgetColors } from './shared'
 import { formatRelativeTime } from '../../lib/time'
 import { normalizeKeys } from '../../lib/utils/powershell-parser'
+import { useSettingsOptional } from '../../providers/SettingsProvider'
+import { mapInventory } from '../../lib/rules/inventoryMapping'
+import { DEFAULT_INVENTORY_FIELDS } from '../../lib/settings/defaults'
 
 interface Device {
   id: string
@@ -57,10 +64,16 @@ export const InventoryWidget: React.FC<InventoryWidgetProps> = ({ device }) => {
   // Normalize inventory module data to camelCase (API returns snake_case)
   const rawInventory = device.modules?.inventory
   const inventory = rawInventory ? normalizeKeys(rawInventory) as any : {}
-  
-  // Check if we have any assignment details for the right column
-  const hasAssignmentDetails = inventory.usage || inventory.catalog || inventory.department || inventory.location || inventory.fleet
-  
+
+  // Assignment fields come from the org's configurable mapping (falls back to
+  // defaults outside the provider). Asset tag stays in the identity column.
+  const settings = useSettingsOptional()
+  const fields = settings?.inventoryFields?.length ? settings.inventoryFields : DEFAULT_INVENTORY_FIELDS
+  const assignmentRows = mapInventory(rawInventory as Record<string, unknown>, fields)
+    .filter((row) => row.key !== 'assetTag')
+
+  const hasAssignmentDetails = assignmentRows.length > 0
+
   return (
     <StatBlock 
       title="Inventory" 
@@ -106,33 +119,12 @@ export const InventoryWidget: React.FC<InventoryWidgetProps> = ({ device }) => {
             )}
           </div>
           
-          {/* Right Column - Assignment Details (40% width) */}
+          {/* Right Column - Assignment Details (40% width), config-driven order/labels */}
           {hasAssignmentDetails && (
             <div className="space-y-4 col-span-2">
-              {/* Usage */}
-              {inventory.usage && (
-                <Stat label="Usage" value={inventory.usage} />
-              )}
-              
-              {/* Catalog */}
-              {inventory.catalog && (
-                <Stat label="Catalog" value={inventory.catalog} />
-              )}
-              
-              {/* Department */}
-              {inventory.department && (
-                <Stat label="Department" value={inventory.department} />
-              )}
-              
-              {/* Location */}
-              {inventory.location && (
-                <Stat label="Location" value={inventory.location} />
-              )}
-
-              {/* Fleet */}
-              {inventory.fleet && (
-                <Stat label="Fleet" value={inventory.fleet} />
-              )}
+              {assignmentRows.map((row) => (
+                <Stat key={row.key} label={row.label} value={row.value} />
+              ))}
             </div>
           )}
         </div>

--- a/src/components/widgets/Security.tsx
+++ b/src/components/widgets/Security.tsx
@@ -3,9 +3,27 @@
  * Displays security information with simple status messages
  */
 
+"use client"
+
 import React from 'react'
 import { StatBlock, StatusBadge, EmptyState, Icons, WidgetColors } from './shared'
 import { convertPowerShellObjects, normalizeKeys } from '../../lib/utils/powershell-parser'
+import { useSettingsOptional } from '../../providers/SettingsProvider'
+import { DEFAULT_SECURITY_CONFIG, DEFAULT_INVENTORY_FIELDS } from '../../lib/settings/defaults'
+import { evaluateSecurity } from '../../lib/rules/evaluateSecurity'
+import { getDeviceInventoryContext } from '../../lib/rules/inventoryMapping'
+import type { Severity } from '../../lib/settings/types'
+
+/** Map the portable severity vocabulary onto the widget's StatusBadge types. */
+function severityToWidgetType(sev: Severity): 'success' | 'error' | 'warning' | 'info' {
+  switch (sev) {
+    case 'ok': return 'success'
+    case 'danger': return 'error'
+    case 'warning': return 'warning'
+    case 'neutral': return 'info'
+    default: return 'warning'
+  }
+}
 
 interface Device {
   id: string
@@ -15,8 +33,15 @@ interface Device {
   osName?: string
   security?: any
   securityFeatures?: any
+  metadata?: any
+  management?: any
   modules?: {
     security?: any
+    system?: any
+    metadata?: any
+    inventory?: any
+    management?: any
+    hardware?: any
   }
 }
 
@@ -46,6 +71,16 @@ export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
   const isWindows = platform.includes('windows')
   const isMacOS = platform.includes('mac') || platform.includes('darwin')
   const isLinux = platform.includes('linux')
+
+  // Settings-driven, usage-aware coloring. The device's inventory context (e.g.
+  // usage=Shared) lets org rules downgrade severities — e.g. shared/lab devices
+  // with disk encryption off aren't flagged red.
+  const settings = useSettingsOptional()
+  const securityConfig = settings?.securityConfig ?? DEFAULT_SECURITY_CONFIG
+  const inventoryFields = settings?.inventoryFields?.length ? settings.inventoryFields : DEFAULT_INVENTORY_FIELDS
+  const inventoryCtx = getDeviceInventoryContext(device?.modules?.inventory as Record<string, unknown>, inventoryFields)
+  const encryptionSeverity = (enabled?: boolean) =>
+    severityToWidgetType(evaluateSecurity('encryption', enabled, inventoryCtx, securityConfig))
   
   // Get remote management data from Management module (Mac collects screen sharing there)
   const rawManagement = device?.modules?.management || device?.management
@@ -169,9 +204,8 @@ export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
             <StatusBadge
               label="FileVault"
               status={encryptionInfo.status}
-              type={getStatusType(
-                security?.fileVault?.enabled === true || security?.fileVault?.enabled === 1,
-                encryptionInfo.status
+              type={encryptionSeverity(
+                security?.fileVault?.enabled === true || security?.fileVault?.enabled === 1
               )}
             />
             
@@ -300,11 +334,10 @@ export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
             <StatusBadge
               label={isWindows ? "BitLocker" : "Encryption"}
               status={security?.encryption?.statusDisplay || encryptionInfo.status}
-              type={getStatusType(
-                isWindows ? security?.encryption?.bitLocker?.isEnabled :
-                isLinux ? security?.encryption?.luks?.isEnabled :
-                false,
-                encryptionInfo.status
+              type={encryptionSeverity(
+                isWindows ? Boolean(security?.encryption?.bitLocker?.isEnabled) :
+                isLinux ? Boolean(security?.encryption?.luks?.isEnabled) :
+                false
               )}
             />
 

--- a/src/lib/rules/evaluateSecurity.ts
+++ b/src/lib/rules/evaluateSecurity.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure, side-effect-free security severity evaluator.
+ *
+ * Given a logical check, its enabled state, and the device's inventory context,
+ * returns the severity to render. Defaults reproduce ReportMate's historical
+ * coloring; org rules override it (e.g. "shared devices with encryption off
+ * shouldn't be red"). Kept pure so the identical logic ports to Swift/C#.
+ */
+
+import {
+  RuleCondition,
+  SecurityConfig,
+  SecurityRule,
+  Severity,
+} from "@/src/lib/settings/types"
+
+/** Canonical-key -> value map for a single device (e.g. { usage: "Shared" }). */
+export type InventoryContext = Record<string, string | undefined>
+
+function stateMatches(state: SecurityRule["state"], enabled: boolean): boolean {
+  if (!state || state === "any") return true
+  return state === "enabled" ? enabled : !enabled
+}
+
+/** Returns the number of inventory conditions matched, or -1 if the rule's
+ * `when` does not match the context at all. More matched conditions = more
+ * specific rule. A rule with no `when` matches everything at specificity 0. */
+function whenSpecificity(when: RuleCondition | undefined, ctx: InventoryContext): number {
+  if (!when || !when.inventory) return 0
+  let matched = 0
+  for (const [key, op] of Object.entries(when.inventory)) {
+    if (!op) continue
+    const value = ctx[key]
+    if (op.in && (value === undefined || !op.in.includes(value))) return -1
+    if (op.eq !== undefined && value !== op.eq) return -1
+    if (op.ne !== undefined && value === op.ne) return -1
+    matched += 1
+  }
+  return matched
+}
+
+function baselineSeverity(
+  check: string,
+  enabled: boolean,
+  config: SecurityConfig
+): Severity {
+  const def = config.defaults?.[check]
+  if (def) return enabled ? def.enabledSeverity : def.disabledSeverity
+  // Generic fallback for unknown checks: on is fine, off is a soft warning.
+  return enabled ? "ok" : "warning"
+}
+
+export function evaluateSecurity(
+  check: string,
+  enabled: boolean | undefined,
+  ctx: InventoryContext,
+  config: SecurityConfig
+): Severity {
+  if (enabled === undefined) return "unknown"
+
+  let severity = baselineSeverity(check, enabled, config)
+  let bestSpecificity = -1
+
+  const rules = config.rules ?? []
+  for (const rule of rules) {
+    if (rule.enabled === false) continue
+    if (rule.check !== check) continue
+    if (!stateMatches(rule.state, enabled)) continue
+    const spec = whenSpecificity(rule.when, ctx)
+    if (spec < 0) continue
+    // Most-specific wins; ties broken by later-in-array (>= so later overrides).
+    if (spec >= bestSpecificity) {
+      bestSpecificity = spec
+      severity = rule.severity
+    }
+  }
+
+  return severity
+}

--- a/src/lib/rules/inventoryMapping.ts
+++ b/src/lib/rules/inventoryMapping.ts
@@ -1,0 +1,70 @@
+/**
+ * Turns raw inventory JSON into display rows using the org's field mapping, and
+ * builds the canonical inventory context the security evaluator consumes.
+ */
+
+import { DEFAULT_INVENTORY_FIELDS } from "@/src/lib/settings/defaults"
+import {
+  CanonicalInventoryKey,
+  InventoryFieldMapping,
+} from "@/src/lib/settings/types"
+import { InventoryContext } from "./evaluateSecurity"
+
+function toSnake(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase()
+}
+
+function toCamel(key: string): string {
+  return key.replace(/_([a-z0-9])/g, (_, c) => c.toUpperCase())
+}
+
+/** Resolve a value from raw inventory by source key, tolerating snake/camel
+ * casing differences (device JSON mixes `asset_tag` and `assetTag`). */
+function resolveValue(raw: Record<string, unknown>, sourceKey: string): string | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const candidates = [sourceKey, toSnake(sourceKey), toCamel(sourceKey)]
+  for (const k of candidates) {
+    const v = raw[k]
+    if (v !== undefined && v !== null && String(v).trim() !== "") {
+      return String(v)
+    }
+  }
+  return undefined
+}
+
+export interface MappedInventoryRow {
+  key: CanonicalInventoryKey
+  label: string
+  value: string
+}
+
+/** Ordered, visible inventory rows for display. */
+export function mapInventory(
+  rawInventory: Record<string, unknown> | null | undefined,
+  fields: InventoryFieldMapping[] = DEFAULT_INVENTORY_FIELDS
+): MappedInventoryRow[] {
+  const raw = (rawInventory ?? {}) as Record<string, unknown>
+  return [...fields]
+    .filter((f) => f.visible)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((f) => {
+      const value = resolveValue(raw, f.sourceKey)
+      return value === undefined ? null : { key: f.key, label: f.label, value }
+    })
+    .filter((row): row is MappedInventoryRow => row !== null)
+}
+
+/** Canonical-key -> value context for the security rules engine. Includes all
+ * mapped fields (regardless of visibility) so rules can key off hidden fields. */
+export function getDeviceInventoryContext(
+  rawInventory: Record<string, unknown> | null | undefined,
+  fields: InventoryFieldMapping[] = DEFAULT_INVENTORY_FIELDS
+): InventoryContext {
+  const raw = (rawInventory ?? {}) as Record<string, unknown>
+  const ctx: InventoryContext = {}
+  for (const f of fields) {
+    const value = resolveValue(raw, f.sourceKey)
+    if (value !== undefined) ctx[f.key] = value
+  }
+  return ctx
+}

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -1,0 +1,84 @@
+/**
+ * Default settings used as the fallback before an org has saved any settings
+ * (and as the seed for the onboarding wizard). The app renders correctly off
+ * these defaults so there's no regression pre-onboarding.
+ */
+
+import {
+  InventoryFieldMapping,
+  SecurityConfig,
+  SettingsDocument,
+} from "./types"
+
+export const CURRENT_SCHEMA_VERSION = 1
+
+/** Canonical inventory fields with sensible defaults (sourceKey == key). */
+export const DEFAULT_INVENTORY_FIELDS: InventoryFieldMapping[] = [
+  { key: "usage", sourceKey: "usage", label: "Usage", order: 0, visible: true, knownValues: [] },
+  { key: "catalog", sourceKey: "catalog", label: "Catalog", order: 1, visible: true, knownValues: [] },
+  { key: "department", sourceKey: "department", label: "Department", order: 2, visible: true, knownValues: [] },
+  { key: "area", sourceKey: "area", label: "Area", order: 3, visible: false, knownValues: [] },
+  { key: "location", sourceKey: "location", label: "Location", order: 4, visible: true, knownValues: [] },
+  { key: "fleet", sourceKey: "fleet", label: "Fleet", order: 5, visible: false, knownValues: [] },
+  { key: "assetTag", sourceKey: "assetTag", label: "Asset Tag", order: 6, visible: true, knownValues: [] },
+  { key: "owner", sourceKey: "owner", label: "Owner", order: 7, visible: true, knownValues: [] },
+]
+
+/**
+ * Baseline severities reproduce today's hardcoded behavior so nothing changes
+ * visually until an org adds rules:
+ *  - encryption/sip off  -> danger (red)
+ *  - firewall off        -> warning (amber)
+ *  - ssh/rdp on          -> warning (amber); off -> ok
+ */
+export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
+  defaults: {
+    encryption: { enabledSeverity: "ok", disabledSeverity: "danger" },
+    firewall: { enabledSeverity: "ok", disabledSeverity: "warning" },
+    ssh: { enabledSeverity: "warning", disabledSeverity: "ok" },
+    rdp: { enabledSeverity: "warning", disabledSeverity: "ok" },
+    sip: { enabledSeverity: "ok", disabledSeverity: "danger" },
+  },
+  rules: [],
+}
+
+export const DEFAULT_SETTINGS: SettingsDocument = {
+  schemaVersion: CURRENT_SCHEMA_VERSION,
+  general: { onboardingCompletedAt: null },
+  inventory: { fields: DEFAULT_INVENTORY_FIELDS },
+  security: DEFAULT_SECURITY_CONFIG,
+}
+
+/** Starter rules seeded by onboarding: shared/lab devices aren't expected to be
+ * encrypted, so don't flag them red. */
+export const STARTER_SECURITY_RULES = [
+  {
+    id: "encryption-shared-neutral",
+    module: "security",
+    check: "encryption",
+    when: { inventory: { usage: { in: ["Shared", "Lab"] } } },
+    state: "disabled" as const,
+    severity: "neutral" as const,
+    enabled: true,
+  },
+]
+
+/** Merge a (possibly null/partial) stored document with defaults so consumers
+ * always get a complete config. */
+export function withDefaults(doc: SettingsDocument | null | undefined): SettingsDocument {
+  if (!doc) return DEFAULT_SETTINGS
+  return {
+    schemaVersion: doc.schemaVersion ?? CURRENT_SCHEMA_VERSION,
+    general: { ...DEFAULT_SETTINGS.general, ...(doc.general ?? {}) },
+    inventory: {
+      fields:
+        doc.inventory?.fields && doc.inventory.fields.length > 0
+          ? doc.inventory.fields
+          : DEFAULT_INVENTORY_FIELDS,
+    },
+    security: {
+      defaults: { ...DEFAULT_SECURITY_CONFIG.defaults, ...(doc.security?.defaults ?? {}) },
+      rules: doc.security?.rules ?? [],
+    },
+  }
+}

--- a/src/lib/settings/defaults.ts
+++ b/src/lib/settings/defaults.ts
@@ -66,19 +66,21 @@ export const STARTER_SECURITY_RULES = [
 /** Merge a (possibly null/partial) stored document with defaults so consumers
  * always get a complete config. */
 export function withDefaults(doc: SettingsDocument | null | undefined): SettingsDocument {
-  if (!doc) return DEFAULT_SETTINGS
+  // Always build fresh objects/arrays — never hand back the shared DEFAULT_*
+  // singletons, so a consumer mutating the result can't leak across the module.
+  if (!doc) return structuredClone(DEFAULT_SETTINGS)
   return {
     schemaVersion: doc.schemaVersion ?? CURRENT_SCHEMA_VERSION,
     general: { ...DEFAULT_SETTINGS.general, ...(doc.general ?? {}) },
     inventory: {
       fields:
         doc.inventory?.fields && doc.inventory.fields.length > 0
-          ? doc.inventory.fields
-          : DEFAULT_INVENTORY_FIELDS,
+          ? structuredClone(doc.inventory.fields)
+          : structuredClone(DEFAULT_INVENTORY_FIELDS),
     },
     security: {
-      defaults: { ...DEFAULT_SECURITY_CONFIG.defaults, ...(doc.security?.defaults ?? {}) },
-      rules: doc.security?.rules ?? [],
+      defaults: { ...structuredClone(DEFAULT_SECURITY_CONFIG.defaults), ...(doc.security?.defaults ?? {}) },
+      rules: doc.security?.rules ? structuredClone(doc.security.rules) : [],
     },
   }
 }

--- a/src/lib/settings/migrate.ts
+++ b/src/lib/settings/migrate.ts
@@ -1,0 +1,22 @@
+/**
+ * Forward-migration of stored settings documents. When the document shape
+ * changes, bump CURRENT_SCHEMA_VERSION (in defaults.ts) and add a step here so
+ * older saved docs (or those written by an older native app) upgrade in memory
+ * before consumers read them.
+ */
+
+import { CURRENT_SCHEMA_VERSION } from "./defaults"
+import { SettingsDocument } from "./types"
+
+export function migrateSettings(doc: SettingsDocument): SettingsDocument {
+  let migrated = doc
+  const version = migrated.schemaVersion ?? 1
+
+  // No migrations needed yet (v1 is current). Future steps go here, e.g.:
+  // if (version < 2) { migrated = { ...migrated, /* v1 -> v2 */ schemaVersion: 2 } }
+
+  if (version !== CURRENT_SCHEMA_VERSION) {
+    migrated = { ...migrated, schemaVersion: CURRENT_SCHEMA_VERSION }
+  }
+  return migrated
+}

--- a/src/lib/settings/types.ts
+++ b/src/lib/settings/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared types for the server-side settings system.
+ *
+ * These mirror the JSONB document persisted by the FastAPI `app_settings` table
+ * and are the contract the web app (and future native Swift/C# apps) read from.
+ */
+
+export type Severity = "ok" | "warning" | "danger" | "neutral" | "unknown"
+
+/** Canonical inventory fields ReportMate understands. Fixed enum so rules and
+ * native apps reference stable keys; only the mapping/labels are configurable. */
+export const CANONICAL_INVENTORY_KEYS = [
+  "usage",
+  "catalog",
+  "department",
+  "area",
+  "location",
+  "fleet",
+  "assetTag",
+  "owner",
+] as const
+
+export type CanonicalInventoryKey = (typeof CANONICAL_INVENTORY_KEYS)[number]
+
+export interface InventoryFieldMapping {
+  /** Canonical key (fixed). */
+  key: CanonicalInventoryKey
+  /** Key as it appears in the device's Inventory.yaml / inventory JSON. */
+  sourceKey: string
+  /** Display label. */
+  label: string
+  /** Display order (ascending). */
+  order: number
+  /** Whether the field is shown. */
+  visible: boolean
+  /** Known/allowed values (e.g. usage values), used by rules + filters. */
+  knownValues?: string[]
+}
+
+export interface SecurityCheckDefault {
+  enabledSeverity: Severity
+  disabledSeverity: Severity
+}
+
+/** Logical security checks the UI colors. Open-ended (string) so orgs can add. */
+export type SecurityCheckId = "encryption" | "firewall" | "ssh" | "rdp" | "sip" | (string & {})
+
+export interface RuleOperator {
+  in?: string[]
+  eq?: string
+  ne?: string
+}
+
+export interface RuleCondition {
+  /** Conditions on the device's inventory context, keyed by canonical key.
+   * Multiple keys are AND-ed. */
+  inventory?: Partial<Record<CanonicalInventoryKey, RuleOperator>>
+}
+
+export interface SecurityRule {
+  id: string
+  module?: string
+  check: SecurityCheckId
+  /** Optional concrete field path (for native parity / disambiguation). */
+  fieldPath?: string
+  when?: RuleCondition
+  /** Which value the rule applies to. */
+  state?: "enabled" | "disabled" | "any"
+  severity: Severity
+  enabled?: boolean
+}
+
+export interface SecurityConfig {
+  /** Baseline severity per check when no rule matches. */
+  defaults: Record<string, SecurityCheckDefault>
+  rules: SecurityRule[]
+}
+
+export interface GeneralSettings {
+  fleetName?: string
+  defaultPlatformFilter?: string
+  /** ISO timestamp; absent/null means onboarding has not run. */
+  onboardingCompletedAt?: string | null
+  [k: string]: unknown
+}
+
+export interface InventorySettings {
+  fields: InventoryFieldMapping[]
+}
+
+export interface SettingsDocument {
+  schemaVersion: number
+  general?: GeneralSettings
+  inventory?: InventorySettings
+  security?: SecurityConfig
+}
+
+/** Shape returned by GET /api/settings (proxy → FastAPI). */
+export interface SettingsResponse {
+  exists: boolean
+  value: SettingsDocument | null
+  schemaVersion: number
+  updatedAt?: string
+  updatedBy?: string | null
+}
+
+/** One row from the inventory discovery endpoint. */
+export interface DiscoveredInventoryKey {
+  key: string
+  deviceCount: number
+  distinctCount: number
+  sampleValues: string[]
+}

--- a/src/providers/SettingsProvider.tsx
+++ b/src/providers/SettingsProvider.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { createContext, useContext, useMemo, ReactNode } from "react"
+import useSWR from "swr"
+import { withDefaults } from "@/src/lib/settings/defaults"
+import { migrateSettings } from "@/src/lib/settings/migrate"
+import {
+  InventoryFieldMapping,
+  SecurityConfig,
+  SettingsDocument,
+  SettingsResponse,
+} from "@/src/lib/settings/types"
+
+interface SettingsContextValue {
+  /** Fully-merged settings (defaults applied), always non-null. */
+  settings: SettingsDocument
+  /** Convenience accessors. */
+  inventoryFields: InventoryFieldMapping[]
+  securityConfig: SecurityConfig
+  /** True when no settings doc exists yet OR onboarding hasn't completed. */
+  isFirstTime: boolean
+  /** Whether a stored doc exists server-side. */
+  exists: boolean
+  isLoading: boolean
+  error: unknown
+  /** Re-fetch settings (call after a successful save). */
+  refresh: () => Promise<unknown>
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null)
+
+const fetcher = async (url: string): Promise<SettingsResponse> => {
+  const res = await fetch(url, { cache: "no-store" })
+  if (!res.ok) throw new Error(`Failed to load settings: ${res.status}`)
+  return res.json()
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const { data, error, isLoading, mutate } = useSWR<SettingsResponse>(
+    "/api/settings",
+    fetcher,
+    { revalidateOnFocus: false }
+  )
+
+  const value = useMemo<SettingsContextValue>(() => {
+    const raw = data?.value ? migrateSettings(data.value) : null
+    const settings = withDefaults(raw)
+    const exists = Boolean(data?.exists)
+    const onboarded = Boolean(settings.general?.onboardingCompletedAt)
+    return {
+      settings,
+      inventoryFields: settings.inventory?.fields ?? [],
+      securityConfig: settings.security!,
+      isFirstTime: !exists || !onboarded,
+      exists,
+      isLoading,
+      error,
+      refresh: () => mutate(),
+    }
+  }, [data, error, isLoading, mutate])
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
+}
+
+export function useSettings(): SettingsContextValue {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) {
+    throw new Error("useSettings must be used within a SettingsProvider")
+  }
+  return ctx
+}
+
+/** Safe variant for components that may render outside the provider (e.g. some
+ * widgets reused in isolation): returns defaults instead of throwing. */
+export function useSettingsOptional(): SettingsContextValue | null {
+  return useContext(SettingsContext)
+}


### PR DESCRIPTION
Web app changes for the v1 conference push.

- Fix dark mode on sign-in and auth error pages (logo no longer inverts to a white silhouette; error page + spinner get dark variants).
- PWA: Serwist service worker, static offline fallback, /api forced network-only so device data is never served stale. Manifest/icons already existed.
- Server-side settings read-path: pure usage-aware security rule engine and configurable inventory field mapping, consumed by the Inventory/Security widgets and Security tab. No visual change until rules are added.
- Settings editor UI (inventory mapping + security rules) and a first-run onboarding wizard that auto-discovers inventory keys.

Backend counterpart: terraform-azurerm-reportmate#v1-conference-papercuts (settings API + storage).

Built and linted clean. Service worker install/offline and Lighthouse still need manual QA on a deployment.