### PR TITLE
Show system and data_collection events on the device events tab

### DIFF
--- a/app/api/device/[deviceId]/events/route.ts
+++ b/app/api/device/[deviceId]/events/route.ts
@@ -23,8 +23,9 @@ export async function GET(
     const limit = Math.min(parseInt(searchParams.get('limit') || '1000'), 1000) // Max 1000, default 1000
     const offset = Math.max(parseInt(searchParams.get('offset') || '0'), 0)
     
-    // Valid event categories - filter out everything else
-    const VALID_EVENT_KINDS = ['system', 'info', 'error', 'warning', 'success']
+    // Valid event categories - filter out everything else.
+    // Keep in sync with app/api/events/route.ts (must include 'data_collection').
+    const VALID_EVENT_KINDS = ['system', 'info', 'error', 'warning', 'success', 'data_collection']
 
     // Use server-side API base URL configuration
     const apiBaseUrl = process.env.API_BASE_URL

--- a/src/components/DeviceEventsSimple.tsx
+++ b/src/components/DeviceEventsSimple.tsx
@@ -86,8 +86,10 @@ export default function DeviceEvents({ events }: { events: EventDto[] }) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const EVENTS_PER_LOAD = 10;
 
-  // Valid event categories - filter out everything else
-  const VALID_EVENT_KINDS = ['info', 'error', 'warning', 'success'];
+  // Valid event categories - filter out everything else.
+  // Must match the fleet /events list (app/api/events/route.ts); omitting
+  // 'system'/'data_collection' here hid system events on the device tab.
+  const VALID_EVENT_KINDS = ['system', 'info', 'error', 'warning', 'success', 'data_collection'];
   
   // Filter events to only include valid categories
   const filteredEvents = events.filter(event => 


### PR DESCRIPTION
The device Events tab dropped 'system' and 'data_collection' events: DeviceEventsSimple's VALID_EVENT_KINDS omitted both (only info/error/warning/success), and the device events API route omitted 'data_collection'. So devices whose events are system/data_collection rendered 'No Valid Events' even though the chips counted them and the fleet /events feed showed them. Both lists now match app/api/events/route.ts.