### PR TITLE
Route identity signals to Identity tab; render security posture in Security tab

### DIFF
--- a/src/components/tabs/IdentityTab.tsx
+++ b/src/components/tabs/IdentityTab.tsx
@@ -241,8 +241,14 @@ export const IdentityTab: React.FC<IdentityTabProps> = ({ device }) => {
   const normalizedIdentity = parsedIdentity ? normalizeKeys(parsedIdentity) as any : null
   const identity: IdentityInfo = normalizedIdentity ? extractIdentity({ identity: normalizedIdentity }) : extractIdentity({})
   
-  // Extract Windows Hello data from identity module (Windows only) - migrated from security
-  const windowsHello = normalizedIdentity?.windowsHello || security?.windowsHello
+  // Windows Hello data — owned by the identity module (Windows only)
+  const windowsHello = normalizedIdentity?.windowsHello
+  // Sign-in / access posture — consolidated into the identity module
+  const uacData = identity.uac
+  const lapsData = identity.laps
+  const passwordPolicyData = identity.passwordPolicy
+  const tpmOwnershipData = identity.tpmOwnership
+  const autoLoginData = identity.autoLogin
 
   // Extract management data as fallback for Windows enrollment info (older clients)
   const rawManagement = device?.modules?.management || device?.management
@@ -565,6 +571,31 @@ export const IdentityTab: React.FC<IdentityTabProps> = ({ device }) => {
               ) : (
                 <DetailRow label="Windows Hello" value="Not configured" variant="neutral" />
               )}
+              {tpmOwnershipData && (tpmOwnershipData.isOwned != null || tpmOwnershipData.isReady != null) && (
+                <DetailRow
+                  label="TPM"
+                  value={tpmOwnershipData.isReady ? 'Owned & Ready' : tpmOwnershipData.isOwned ? 'Owned' : 'Not Owned'}
+                  variant={tpmOwnershipData.isReady ? 'success' : tpmOwnershipData.isOwned ? 'warning' : 'neutral'}
+                />
+              )}
+              {uacData && uacData.level && (
+                <DetailRow
+                  label="UAC"
+                  value={
+                    uacData.level === 'NeverNotify' ? 'Never Notify'
+                    : uacData.level === 'Disabled' ? 'Disabled'
+                    : uacData.level === 'NotifyChangesNoDim' ? 'Notify (no dim)'
+                    : uacData.level === 'NotifyChangesSecure' ? 'Notify on changes'
+                    : uacData.level === 'AlwaysNotify' ? 'Always Notify'
+                    : uacData.level
+                  }
+                  variant={
+                    (uacData.level === 'NeverNotify' || uacData.level === 'Disabled') ? 'error'
+                    : uacData.level === 'NotifyChangesNoDim' ? 'warning'
+                    : 'success'
+                  }
+                />
+              )}
             </div>
           </div>
         )}
@@ -806,20 +837,76 @@ export const IdentityTab: React.FC<IdentityTabProps> = ({ device }) => {
           </div>
         )}
 
-        {/* Failed Logins Card - Windows Only */}
-        {!isMac && summary.failedLoginsLast7Days !== undefined && (
+        {/* Login Security Card - Windows Only (failed logins + password/LAPS/auto-login posture) */}
+        {!isMac && (summary.failedLoginsLast7Days !== undefined || passwordPolicyData || lapsData || autoLoginData) && (
           <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
             <div className="flex items-center gap-2 mb-3">
               <AlertTriangle className="w-4 h-4 text-orange-600 dark:text-orange-400" />
               <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Login Security</h3>
             </div>
             <div className="space-y-1">
-              <DetailRow 
-                label="Failed Logins (7d)" 
-                value={summary.failedLoginsLast7Days}
-                variant={summary.failedLoginsLast7Days > 10 ? 'error' : summary.failedLoginsLast7Days > 5 ? 'warning' : 'success'}
-              />
-              <DetailRow label="Currently Logged In" value={summary.currentlyLoggedIn} />
+              {summary.failedLoginsLast7Days !== undefined && (
+                <>
+                  <DetailRow
+                    label="Failed Logins (7d)"
+                    value={summary.failedLoginsLast7Days}
+                    variant={summary.failedLoginsLast7Days > 10 ? 'error' : summary.failedLoginsLast7Days > 5 ? 'warning' : 'success'}
+                  />
+                  <DetailRow label="Currently Logged In" value={summary.currentlyLoggedIn} />
+                </>
+              )}
+              {passwordPolicyData && (
+                <div className={summary.failedLoginsLast7Days !== undefined ? "border-t border-gray-200 dark:border-gray-700 my-2 pt-2" : ""}>
+                  {passwordPolicyData.minPasswordLength != null && (
+                    <DetailRow
+                      label="Min Password Length"
+                      value={String(passwordPolicyData.minPasswordLength)}
+                      variant={passwordPolicyData.minPasswordLength === 0 ? 'warning' : passwordPolicyData.minPasswordLength >= 8 ? 'success' : 'neutral'}
+                    />
+                  )}
+                  {passwordPolicyData.maxPasswordAgeDays != null && (
+                    <DetailRow
+                      label="Max Password Age"
+                      value={passwordPolicyData.maxPasswordAgeDays === 0 ? 'Never expires' : `${passwordPolicyData.maxPasswordAgeDays} days`}
+                    />
+                  )}
+                  {passwordPolicyData.lockoutThreshold != null && (
+                    <DetailRow
+                      label="Lockout Threshold"
+                      value={passwordPolicyData.lockoutThreshold === 0 ? 'No lockout' : `${passwordPolicyData.lockoutThreshold} attempts`}
+                      variant={passwordPolicyData.lockoutThreshold === 0 ? 'warning' : 'neutral'}
+                    />
+                  )}
+                  {passwordPolicyData.complexityRequired != null && (
+                    <DetailRow
+                      label="Complexity"
+                      value={passwordPolicyData.complexityRequired ? 'Required' : 'Not Required'}
+                      variant={passwordPolicyData.complexityRequired ? 'success' : 'neutral'}
+                    />
+                  )}
+                </div>
+              )}
+              {lapsData && (
+                <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
+                  <DetailRow
+                    label="LAPS"
+                    value={lapsData.windowsLapsConfigured ? `Windows LAPS${lapsData.backupDirectory ? ` (${lapsData.backupDirectory})` : ''}` : lapsData.legacyLapsInstalled ? 'Legacy LAPS' : 'Not Configured'}
+                    variant={(lapsData.windowsLapsConfigured || lapsData.legacyLapsInstalled) ? 'success' : 'neutral'}
+                  />
+                </div>
+              )}
+              {autoLoginData && (
+                <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
+                  <DetailRow
+                    label="Auto Admin Logon"
+                    value={autoLoginData.autoAdminLogon ? 'Enabled' : 'Disabled'}
+                    variant={autoLoginData.autoAdminLogon ? 'error' : 'success'}
+                  />
+                  {autoLoginData.hasDefaultPassword && (
+                    <DetailRow label="Stored Password" value="Present" variant="error" />
+                  )}
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -160,6 +160,10 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
   const [showOsRoots, setShowOsRoots] = React.useState(false)
   const [cveFilter, setCveFilter] = React.useState<'all' | 'unpatched' | 'patched'>('all')
   const [expandedDetections, setExpandedDetections] = React.useState<Set<number>>(new Set())
+  // Collapse state for security posture lists (ASR rules, audit policy, exclusions)
+  const [expandedAsr, setExpandedAsr] = React.useState(false)
+  const [expandedAudit, setExpandedAudit] = React.useState(false)
+  const [expandedExclusions, setExpandedExclusions] = React.useState(false)
   
   // Get remote management data from Management module (Mac collects screen sharing there)
   const rawManagement = device?.modules?.management || device?.management
@@ -218,14 +222,9 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
 
   // === Windows Security Status ===
   // Support both snake_case (new API) and camelCase (legacy) - all normalized to camelCase now
-  // Windows Hello 
-  const windowsHello = security?.windowsHello
-  const _windowsHelloEnabled = windowsHello?.statusDisplay !== 'Disabled' && (
-    windowsHello?.credentialProviders?.pinEnabled || 
-    windowsHello?.credentialProviders?.faceRecognitionEnabled ||
-    windowsHello?.credentialProviders?.fingerprintEnabled
-  )
-  // TPM 
+  // NOTE: Windows Hello / sign-in posture now lives in the Identity tab (owned by
+  // the identity module). The Security tab keeps protection/detection signals only.
+  // TPM
   const tpm = security?.tpm
   const _tpmActive = tpm?.isPresent && tpm?.isEnabled && tpm?.isActivated
   // SSH (Windows)
@@ -339,7 +338,15 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                 <DetailRow label="Activated" isStatus enabled={tpm?.is_activated || tpm?.isActivated} />
                 <DetailRow label="Version" value={tpm?.version} />
                 <DetailRow label="Manufacturer" value={tpm?.manufacturer} />
-                
+                {security?.tamperProtection?.isTamperProtected != null && (
+                  <DetailRow
+                    label="Tamper Protection"
+                    isStatus
+                    enabled={!!security.tamperProtection.isTamperProtected}
+                    severity={sev('tamperProtection', !!security.tamperProtection.isTamperProtected)}
+                  />
+                )}
+
                 {/* Secure Boot - from security module (not health attestation) */}
                 <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
                   <DetailRow 
@@ -605,13 +612,75 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                     />
                   )}
                   {security?.deviceGuard?.exploitProtection?.cfgEnabled !== undefined && (
-                    <DetailRow 
-                      label="CFG" 
-                      isStatus 
+                    <DetailRow
+                      label="CFG"
+                      isStatus
                       enabled={security.deviceGuard.exploitProtection.cfgEnabled}
                     />
                   )}
                 </div>
+                {/* Protection posture: LSA, ASR, App Control, SmartScreen */}
+                {(security?.lsaProtection?.enabled != null || security?.lsaProtection?.mode) && (
+                  <div className="border-t border-gray-200 dark:border-gray-700 pt-2 mt-2">
+                    <DetailRow
+                      label="LSA Protection"
+                      isStatus
+                      enabled={!!security.lsaProtection.enabled}
+                      severity={sev('lsaProtection', !!security.lsaProtection.enabled)}
+                      activeLabel={security.lsaProtection.mode === 'PPLBoot' ? 'Enabled (UEFI Lock)' : 'Enabled'}
+                      inactiveLabel="Disabled"
+                    />
+                  </div>
+                )}
+                {Array.isArray(security?.asrRules) && security.asrRules.length > 0 && (() => {
+                  const rules = security.asrRules
+                  const block = rules.filter((r: any) => r.state === 'Block').length
+                  const audit = rules.filter((r: any) => r.state === 'Audit').length
+                  const warn = rules.filter((r: any) => r.state === 'Warn').length
+                  return (
+                    <>
+                      <button
+                        onClick={() => setExpandedAsr(v => !v)}
+                        className="w-full flex items-center justify-between py-1 text-left"
+                      >
+                        <span className="text-sm text-gray-500 dark:text-gray-400">Attack Surface Reduction</span>
+                        <span className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1">
+                          {block}/{rules.length} Block{audit > 0 ? `, ${audit} Audit` : ''}{warn > 0 ? `, ${warn} Warn` : ''}
+                          <ChevronDown className={`w-4 h-4 transition-transform ${expandedAsr ? 'rotate-180' : ''}`} />
+                        </span>
+                      </button>
+                      {expandedAsr && (
+                        <div className="pl-2 space-y-1 mb-1">
+                          {rules.map((r: any, i: number) => (
+                            <div key={i} className="flex items-center justify-between gap-2">
+                              <span className="text-xs text-gray-500 dark:text-gray-400 truncate" title={r.name}>{r.name}</span>
+                              <span className={`text-xs font-medium whitespace-nowrap ${r.state === 'Block' ? 'text-green-600 dark:text-green-400' : r.state === 'Audit' ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}>{r.state}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )
+                })()}
+                {security?.appLocker && (security.appLocker.wdacEnabled !== undefined || security.appLocker.policyConfigured !== undefined) && (
+                  <>
+                    <DetailRow
+                      label="App Control (WDAC)"
+                      isStatus
+                      enabled={!!security.appLocker.wdacEnabled}
+                      activeLabel={security.appLocker.wdacAuditMode ? 'Audit Mode' : 'Enforced'}
+                      inactiveLabel="Off"
+                      severity={security.appLocker.wdacEnabled ? (security.appLocker.wdacAuditMode ? 'warning' : 'ok') : 'neutral'}
+                    />
+                    <DetailRow
+                      label="AppLocker"
+                      value={security.appLocker.policyConfigured ? (security.appLocker.effectivePolicySummary || 'Configured') : 'Not Configured'}
+                    />
+                  </>
+                )}
+                {security?.smartScreen?.windowsState && (
+                  <DetailRow label="SmartScreen" value={security.smartScreen.windowsState} />
+                )}
               </>
             )}
           </div>
@@ -786,10 +855,93 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                   value={security?.antivirus?.isUpToDate ? 'Up to date' : 'Needs update'} 
                 />
                 <DetailRow label="Last Update" value={formatDate(security?.antivirus?.lastUpdate)} />
-                <DetailRow 
-                  label="Last Scan" 
-                  value={`${formatDate(security?.antivirus?.lastScan)}${security?.antivirus?.scanType ? ` (${security.antivirus.scanType})` : ''}`} 
+                <DetailRow
+                  label="Last Scan"
+                  value={`${formatDate(security?.antivirus?.lastScan)}${security?.antivirus?.scanType ? ` (${security.antivirus.scanType})` : ''}`}
                 />
+                {/* Defender engine / platform / signature versions */}
+                {security?.defenderVersions?.amEngineVersion && (
+                  <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
+                    <DetailRow label="Engine Version" value={security.defenderVersions.amEngineVersion} mono />
+                    {security.defenderVersions.amProductVersion && (
+                      <DetailRow label="Platform Version" value={security.defenderVersions.amProductVersion} mono />
+                    )}
+                    {security.defenderVersions.antivirusSignatureVersion && (
+                      <DetailRow label="Signatures" value={security.defenderVersions.antivirusSignatureVersion} mono />
+                    )}
+                  </div>
+                )}
+                {/* Defender exclusions (collapsible) */}
+                {security?.defenderExclusions && security.defenderExclusions.totalCount > 0 && (
+                  <>
+                    <button
+                      onClick={() => setExpandedExclusions(v => !v)}
+                      className="w-full flex items-center justify-between py-1 text-left"
+                    >
+                      <span className="text-sm text-gray-500 dark:text-gray-400">Defender Exclusions</span>
+                      <span className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1">
+                        {security.defenderExclusions.totalCount}
+                        <ChevronDown className={`w-4 h-4 transition-transform ${expandedExclusions ? 'rotate-180' : ''}`} />
+                      </span>
+                    </button>
+                    {expandedExclusions && (
+                      <div className="pl-2 space-y-0.5 mb-1 max-h-64 overflow-y-auto">
+                        {[
+                          ...(security.defenderExclusions.paths || []),
+                          ...(security.defenderExclusions.processes || []),
+                          ...(security.defenderExclusions.extensions || []),
+                          ...(security.defenderExclusions.ipAddresses || []),
+                        ].map((ex: string, i: number) => (
+                          <div key={i} className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate" title={ex}>{ex}</div>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
+                {/* EDR products from service/SecurityCenter2 signature map */}
+                {Array.isArray(security?.edrProducts) && security.edrProducts.length > 0 && (
+                  <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
+                    {security.edrProducts.map((edr: any, idx: number) => (
+                      <DetailRow
+                        key={idx}
+                        label={edr.name || edr.vendor || 'EDR'}
+                        isStatus
+                        enabled={edr.serviceRunning}
+                        value={edr.serviceRunning ? 'Running' : 'Stopped'}
+                        neutral={!edr.serviceRunning}
+                      />
+                    ))}
+                  </div>
+                )}
+                {/* Audit policy coverage (collapsible) */}
+                {Array.isArray(security?.auditPolicy?.categories) && security.auditPolicy.categories.length > 0 && (() => {
+                  const cats = security.auditPolicy.categories
+                  const audited = cats.filter((c: any) => c.setting && c.setting !== 'No Auditing').length
+                  return (
+                    <>
+                      <button
+                        onClick={() => setExpandedAudit(v => !v)}
+                        className="w-full flex items-center justify-between py-1 text-left border-t border-gray-200 dark:border-gray-700 mt-2 pt-2"
+                      >
+                        <span className="text-sm text-gray-500 dark:text-gray-400">Audit Policy</span>
+                        <span className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1">
+                          {audited}/{cats.length} audited
+                          <ChevronDown className={`w-4 h-4 transition-transform ${expandedAudit ? 'rotate-180' : ''}`} />
+                        </span>
+                      </button>
+                      {expandedAudit && (
+                        <div className="pl-2 space-y-0.5 mb-1 max-h-64 overflow-y-auto">
+                          {cats.map((c: any, i: number) => (
+                            <div key={i} className="flex items-center justify-between gap-2">
+                              <span className="text-xs text-gray-500 dark:text-gray-400 truncate" title={c.subcategory}>{c.subcategory}</span>
+                              <span className={`text-xs font-medium whitespace-nowrap ${c.setting === 'No Auditing' || !c.setting ? 'text-gray-400 dark:text-gray-500' : 'text-green-600 dark:text-green-400'}`}>{c.setting || '—'}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )
+                })()}
                 {/* Additional EDR products */}
                 {security?.endpointDetection && security.endpointDetection.length > 0 && (
                   <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">
@@ -1579,17 +1731,28 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                     </p>
                   </div>
                 </div>
-                {hasCves && (
+                {(hasCves || security?.pendingReboot?.required) && (
                   <div className="flex items-center gap-3">
+                    {security?.pendingReboot?.required && (
+                      <span
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+                        title="A reboot is pending to finish applying updates"
+                      >
+                        <AlertTriangle className="w-3 h-3" />
+                        Reboot Required
+                      </span>
+                    )}
                     {exploitedCount > 0 && (
                       <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400">
                         <XCircle className="w-3 h-3" />
                         {exploitedCount} Actively Exploited
                       </span>
                     )}
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
-                      {totalCveCount} total CVEs
-                    </span>
+                    {hasCves && (
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
+                        {totalCveCount} total CVEs
+                      </span>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -872,32 +872,39 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
                   </div>
                 )}
                 {/* Defender exclusions (collapsible) */}
-                {security?.defenderExclusions && security.defenderExclusions.totalCount > 0 && (
-                  <>
-                    <button
-                      onClick={() => setExpandedExclusions(v => !v)}
-                      className="w-full flex items-center justify-between py-1 text-left"
-                    >
-                      <span className="text-sm text-gray-500 dark:text-gray-400">Defender Exclusions</span>
-                      <span className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1">
-                        {security.defenderExclusions.totalCount}
-                        <ChevronDown className={`w-4 h-4 transition-transform ${expandedExclusions ? 'rotate-180' : ''}`} />
-                      </span>
-                    </button>
-                    {expandedExclusions && (
-                      <div className="pl-2 space-y-0.5 mb-1 max-h-64 overflow-y-auto">
-                        {[
-                          ...(security.defenderExclusions.paths || []),
-                          ...(security.defenderExclusions.processes || []),
-                          ...(security.defenderExclusions.extensions || []),
-                          ...(security.defenderExclusions.ipAddresses || []),
-                        ].map((ex: string, i: number) => (
-                          <div key={i} className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate" title={ex}>{ex}</div>
-                        ))}
-                      </div>
-                    )}
-                  </>
-                )}
+                {security?.defenderExclusions && (() => {
+                  const exclusions = [
+                    ...(security.defenderExclusions.paths || []),
+                    ...(security.defenderExclusions.processes || []),
+                    ...(security.defenderExclusions.extensions || []),
+                    ...(security.defenderExclusions.ipAddresses || []),
+                  ]
+                  // totalCount is optional; fall back to the summed array lengths so
+                  // exclusions are never hidden when the backend omits the count.
+                  const exCount = security.defenderExclusions.totalCount ?? exclusions.length
+                  if (exCount <= 0) return null
+                  return (
+                    <>
+                      <button
+                        onClick={() => setExpandedExclusions(v => !v)}
+                        className="w-full flex items-center justify-between py-1 text-left"
+                      >
+                        <span className="text-sm text-gray-500 dark:text-gray-400">Defender Exclusions</span>
+                        <span className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1">
+                          {exCount}
+                          <ChevronDown className={`w-4 h-4 transition-transform ${expandedExclusions ? 'rotate-180' : ''}`} />
+                        </span>
+                      </button>
+                      {expandedExclusions && (
+                        <div className="pl-2 space-y-0.5 mb-1 max-h-64 overflow-y-auto">
+                          {exclusions.map((ex: string, i: number) => (
+                            <div key={i} className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate" title={ex}>{ex}</div>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )
+                })()}
                 {/* EDR products from service/SecurityCenter2 signature map */}
                 {Array.isArray(security?.edrProducts) && security.edrProducts.length > 0 && (
                   <div className="border-t border-gray-200 dark:border-gray-700 my-2 pt-2">

--- a/src/lib/data-processing/modules/identity.ts
+++ b/src/lib/data-processing/modules/identity.ts
@@ -29,7 +29,56 @@ export interface IdentityInfo {
   enrollmentInfo: EnrollmentInfo | null  // Enrollment type (Entra/Domain/Hybrid)
   sessionHistory: SessionHistoryEntry[]  // TerminalServices RDP session history
   sessionSummary: SessionSummary | null  // Aggregated session utilization stats
+  // Sign-in / access posture (Windows; consolidated from the Security module).
+  uac: UacInfo | null
+  laps: LapsInfo | null
+  passwordPolicy: PasswordPolicyInfo | null
+  tpmOwnership: TpmOwnershipInfo | null
+  autoLogin: AutoLoginInfo | null
   summary: IdentitySummary
+}
+
+// ====== Sign-in / access posture sub-objects (raw passthrough from client) ======
+
+export interface UacInfo {
+  enableLua?: boolean | null
+  consentPromptBehaviorAdmin?: number | null
+  promptOnSecureDesktop?: number | null
+  level?: string  // "AlwaysNotify" / "NotifyChangesSecure" / "NotifyChangesNoDim" / "NeverNotify" / "Disabled" / "Custom"
+}
+
+export interface LapsInfo {
+  windowsLapsConfigured?: boolean
+  legacyLapsInstalled?: boolean
+  backupDirectory?: string   // "Active Directory" / "Azure AD" / "Configured" / ""
+  adminAccountName?: string
+}
+
+export interface PasswordPolicyInfo {
+  minPasswordLength?: number | null
+  maxPasswordAgeDays?: number | null
+  minPasswordAgeDays?: number | null
+  passwordHistoryLength?: number | null
+  lockoutThreshold?: number | null
+  lockoutDurationMinutes?: number | null
+  complexityRequired?: boolean | null
+  errorMessage?: string
+}
+
+export interface TpmOwnershipInfo {
+  isOwned?: boolean | null
+  isReady?: boolean | null
+  autoProvisioning?: boolean | null
+  manufacturerIdTxt?: string
+  managedAuthLevel?: string
+}
+
+export interface AutoLoginInfo {
+  autoAdminLogon?: boolean
+  hasDefaultUserName?: boolean
+  hasDefaultPassword?: boolean       // PRESENCE ONLY — value is never read or transmitted
+  hasDefaultDomainName?: boolean
+  defaultUserName?: string
 }
 
 export interface UserAccount {
@@ -289,6 +338,12 @@ export function extractIdentity(deviceModules: any): IdentityInfo {
     enrollmentInfo: enrollmentInfo,
     sessionHistory: identity.sessionHistory ? identity.sessionHistory.map(mapSessionHistory) : [],
     sessionSummary: identity.sessionSummary ? mapSessionSummary(identity.sessionSummary) : null,
+    // Raw passthrough — device computes these in the desired shape.
+    uac: identity.uac ?? null,
+    laps: identity.laps ?? null,
+    passwordPolicy: identity.passwordPolicy ?? null,
+    tpmOwnership: identity.tpmOwnership ?? null,
+    autoLogin: identity.autoLogin ?? null,
     summary: identity.summary ? mapIdentitySummary(identity.summary) : createEmptySummary()
   }
 }
@@ -575,6 +630,11 @@ function createEmptyIdentityInfo(): IdentityInfo {
     enrollmentInfo: null,
     sessionHistory: [],
     sessionSummary: null,
+    uac: null,
+    laps: null,
+    passwordPolicy: null,
+    tpmOwnership: null,
+    autoLogin: null,
     summary: createEmptySummary()
   }
 }

--- a/src/lib/data-processing/modules/security.ts
+++ b/src/lib/data-processing/modules/security.ts
@@ -18,26 +18,21 @@ export interface SecurityInfo {
   secureShell?: SecureShellInfo
   policies: PolicyInfo[]
   summary: SecuritySummary
-  // Phase 2 — protection posture (per-device, raw passthrough; null on platforms / older clients that don't emit them)
+  // Protection posture (per-device, raw passthrough; null on platforms / older
+  // clients that don't emit them). NOTE: identity-domain signals (UAC, join
+  // state, local admins, LAPS, Windows Hello, TPM ownership, password policy,
+  // auto-login) are owned by the Identity module — see modules/identity.ts.
   lsaProtection?: LsaProtectionInfo
   tamperProtection?: TamperProtectionInfo
-  uac?: UacInfo
   pendingReboot?: PendingRebootInfo
   asrRules?: AsrRuleState[]
   defenderVersions?: DefenderVersionsInfo
   defenderExclusions?: DefenderExclusionsInfo
-  joinState?: JoinStateInfo
-  // Phase 3 — compliance / inventory
-  localAdmins?: LocalAdminMember[]
-  laps?: LapsInfo
+  // Compliance / inventory
   appLocker?: AppLockerInfo
   smartScreen?: SmartScreenInfo
   auditPolicy?: AuditPolicyInfo
   edrProducts?: EdrProductInfo[]
-  windowsHello?: WindowsHelloInfo
-  tpmOwnership?: TpmOwnershipInfo
-  passwordPolicy?: PasswordPolicyInfo
-  autoLogin?: AutoLoginInfo
 }
 
 // ====== Phase 2 — protection posture sub-objects (passthrough from client payload) ======
@@ -51,13 +46,6 @@ export interface LsaProtectionInfo {
 export interface TamperProtectionInfo {
   isTamperProtected?: boolean | null
   source?: string
-}
-
-export interface UacInfo {
-  enableLua?: boolean | null
-  consentPromptBehaviorAdmin?: number | null
-  promptOnSecureDesktop?: number | null
-  level?: string  // "AlwaysNotify" / "NotifyChangesSecure" / "NotifyChangesNoDim" / "NeverNotify" / "Disabled" / "Custom"
 }
 
 export interface PendingRebootInfo {
@@ -91,34 +79,7 @@ export interface DefenderExclusionsInfo {
   totalCount?: number
 }
 
-export interface JoinStateInfo {
-  azureAdJoined?: boolean | null
-  domainJoined?: boolean | null
-  workplaceJoined?: boolean | null
-  enterpriseJoined?: boolean | null
-  tenantName?: string
-  tenantId?: string
-  deviceId?: string
-  domainName?: string
-  raw?: Record<string, string>
-  errorMessage?: string
-}
-
-// ====== Phase 3 — compliance / inventory ======
-
-export interface LocalAdminMember {
-  name: string
-  sid?: string
-  principalSource?: string   // Local / ActiveDirectory / AzureAD
-  objectClass?: string       // User / Group
-}
-
-export interface LapsInfo {
-  windowsLapsConfigured?: boolean
-  legacyLapsInstalled?: boolean
-  backupDirectory?: string   // "Active Directory" / "Azure AD" / "Configured" / ""
-  adminAccountName?: string
-}
+// ====== Compliance / inventory ======
 
 export interface AppLockerInfo {
   serviceRunning?: boolean
@@ -153,40 +114,6 @@ export interface EdrProductInfo {
   serviceRunning?: boolean
   version?: string
   sid?: string
-}
-
-export interface WindowsHelloInfo {
-  faceSensorPresent?: boolean
-  fingerprintSensorPresent?: boolean
-  pinConfigured?: boolean | null
-  passportForWorkEnabled?: boolean | null
-}
-
-export interface TpmOwnershipInfo {
-  isOwned?: boolean | null
-  isReady?: boolean | null
-  autoProvisioning?: boolean | null
-  manufacturerIdTxt?: string
-  managedAuthLevel?: string
-}
-
-export interface PasswordPolicyInfo {
-  minPasswordLength?: number | null
-  maxPasswordAgeDays?: number | null
-  minPasswordAgeDays?: number | null
-  passwordHistoryLength?: number | null
-  lockoutThreshold?: number | null
-  lockoutDurationMinutes?: number | null
-  complexityRequired?: boolean | null
-  errorMessage?: string
-}
-
-export interface AutoLoginInfo {
-  autoAdminLogon?: boolean
-  hasDefaultUserName?: boolean
-  hasDefaultPassword?: boolean       // PRESENCE ONLY — value is never read or transmitted
-  hasDefaultDomainName?: boolean
-  defaultUserName?: string
 }
 
 export interface DetectionAlert {
@@ -339,26 +266,18 @@ export function extractSecurity(deviceModules: any): SecurityInfo {
     // Read device-calculated summary
     summary: security.summary || createEmptySummary(),
 
-    // Phase 2/3 — raw passthrough (sub-objects already arrive in the desired shape from the client).
-    // We don't normalize here because the device computes these and the schema is stable.
+    // Protection-posture sub-objects — raw passthrough (already arrive in the
+    // desired shape from the client; identity-domain signals live in identity.ts).
     lsaProtection: security.lsaProtection,
     tamperProtection: security.tamperProtection,
-    uac: security.uac,
     pendingReboot: security.pendingReboot,
     asrRules: security.asrRules,
     defenderVersions: security.defenderVersions,
     defenderExclusions: security.defenderExclusions,
-    joinState: security.joinState,
-    localAdmins: security.localAdmins,
-    laps: security.laps,
     appLocker: security.appLocker,
     smartScreen: security.smartScreen,
     auditPolicy: security.auditPolicy,
     edrProducts: security.edrProducts,
-    windowsHello: security.windowsHello,
-    tpmOwnership: security.tpmOwnership,
-    passwordPolicy: security.passwordPolicy,
-    autoLogin: security.autoLogin,
   }
 
   


### PR DESCRIPTION
## Summary
Frontend half of the Security/Identity module de-duplication. Identity-domain signals now live in the Identity tab; the Security tab renders protection/detection posture into its existing buckets.

## Changes
- **data-processing** (`security.ts` / `identity.ts`) — move UAC/LAPS/passwordPolicy/tpmOwnership/autoLogin contracts from `SecurityInfo` to `IdentityInfo`.
- **SecurityTab.tsx** — render security-only Phase 2/3 fields into the existing 8 buckets (Protection: LSA, ASR, AppLocker/WDAC, SmartScreen; Tampering: Tamper Protection; Detection: Defender versions/exclusions, audit policy, and the Windows `edrProducts` array **that was never rendered**; Vulnerabilities: pending-reboot pill). No new cards/buckets. Drop stale `security.windowsHello`.
- **IdentityTab.tsx** — UAC + TPM ownership in the Authentication card; password policy + LAPS + auto-login in Login Security; drop the `|| security?.windowsHello` cross-read.

`tsc` and ESLint clean on all four files.

## Companion PRs
- client: reportmate/reportmate-client-win (collection move)
- infra: reportmate/terraform-azurerm-reportmate (fleet bulk SQL)
