### PR TITLE
Add module slot registry, generic renderer, and Security tab mount point

### DIFF
--- a/src/components/modules/GenericModulePanel.tsx
+++ b/src/components/modules/GenericModulePanel.tsx
@@ -1,0 +1,135 @@
+/**
+ * GenericModulePanel
+ *
+ * Default renderer for an extension module that does not ship a custom
+ * component. Turns an arbitrary module JSONB payload into a readable card:
+ * scalars become labelled rows, nested objects become subsections, and arrays
+ * of objects become compact tables. This is what makes a new module usable the
+ * day its data lands — a bespoke component is an optional upgrade, not a
+ * prerequisite.
+ */
+
+import React from 'react'
+
+interface GenericModulePanelProps {
+  moduleId: string
+  data: any
+  title?: string
+}
+
+const humanize = (key: string): string =>
+  key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim()
+
+const isScalar = (v: any): boolean =>
+  v === null || ['string', 'number', 'boolean'].includes(typeof v)
+
+const renderScalar = (v: any): string => {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'boolean') return v ? 'Yes' : 'No'
+  return String(v)
+}
+
+const DetailRow: React.FC<{ label: string; value: any }> = ({ label, value }) => (
+  <div className="flex justify-between gap-4 py-1 text-sm">
+    <span className="text-gray-500 dark:text-gray-400">{label}</span>
+    <span className="text-gray-900 dark:text-gray-100 text-right break-words">
+      {renderScalar(value)}
+    </span>
+  </div>
+)
+
+const ScalarTable: React.FC<{ rows: Record<string, any>[] }> = ({ rows }) => {
+  const columns = Array.from(
+    rows.reduce<Set<string>>((set, row) => {
+      Object.keys(row || {}).forEach((k) => set.add(k))
+      return set
+    }, new Set<string>()),
+  ).slice(0, 8)
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-gray-500 dark:text-gray-400">
+            {columns.map((c) => (
+              <th key={c} className="font-medium py-1 pr-3 whitespace-nowrap">{humanize(c)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 100).map((row, i) => (
+            <tr key={i} className="border-t border-gray-100 dark:border-gray-700">
+              {columns.map((c) => (
+                <td key={c} className="py-1 pr-3 align-top text-gray-900 dark:text-gray-100">
+                  {isScalar(row?.[c]) ? renderScalar(row?.[c]) : JSON.stringify(row?.[c])}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 100 && (
+        <div className="text-xs text-gray-400 mt-1">+{rows.length - 100} more rows</div>
+      )}
+    </div>
+  )
+}
+
+const Section: React.FC<{ label: string; value: any }> = ({ label, value }) => {
+  if (isScalar(value)) return <DetailRow label={label} value={value} />
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <DetailRow label={label} value="—" />
+    if (value.every(isScalar)) {
+      return <DetailRow label={label} value={value.map(renderScalar).join(', ')} />
+    }
+    return (
+      <div className="py-2">
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</div>
+        <ScalarTable rows={value.filter((v) => v && typeof v === 'object')} />
+      </div>
+    )
+  }
+
+  // Nested object → subsection
+  const entries = Object.entries(value || {})
+  if (entries.length === 0) return <DetailRow label={label} value="—" />
+  return (
+    <div className="py-2">
+      <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</div>
+      <div className="pl-3 border-l border-gray-200 dark:border-gray-700">
+        {entries.map(([k, v]) => (
+          <Section key={k} label={humanize(k)} value={v} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const GenericModulePanel: React.FC<GenericModulePanelProps> = ({ moduleId, data, title }) => {
+  // Some modules store a single-element array; unwrap for display.
+  const payload = Array.isArray(data) && data.length === 1 ? data[0] : data
+  const entries = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? Object.entries(payload)
+    : null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-5">
+      <div className="flex items-center gap-3 mb-4">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {title || humanize(moduleId)}
+        </h3>
+      </div>
+      <div className="space-y-1">
+        {entries
+          ? entries.map(([k, v]) => <Section key={k} label={humanize(k)} value={v} />)
+          : <Section label={humanize(moduleId)} value={payload} />}
+      </div>
+    </div>
+  )
+}
+
+export default GenericModulePanel

--- a/src/components/modules/ModuleSlot.tsx
+++ b/src/components/modules/ModuleSlot.tsx
@@ -1,0 +1,39 @@
+/**
+ * ModuleSlot
+ *
+ * Host for a named mount point. Drop `<ModuleSlot slot="device.security.cards"
+ * device={device} />` into any tab or report; it renders every registered
+ * module contribution that has data on this device — each via its custom
+ * component, or the GenericModulePanel fallback. Renders nothing when there are
+ * no contributions, so adding a slot to a host is inert until a module mounts.
+ */
+
+import React from 'react'
+
+import { getSlotContributions } from '../../lib/modules/moduleSlots'
+import { GenericModulePanel } from './GenericModulePanel'
+
+interface ModuleSlotProps {
+  slot: string
+  device: any
+}
+
+export const ModuleSlot: React.FC<ModuleSlotProps> = ({ slot, device }) => {
+  const contributions = getSlotContributions(slot, device)
+  if (contributions.length === 0) return null
+
+  return (
+    <>
+      {contributions.map((c) => {
+        const Custom = c.component
+        return Custom ? (
+          <Custom key={c.moduleId} moduleId={c.moduleId} data={c.data} device={device} />
+        ) : (
+          <GenericModulePanel key={c.moduleId} moduleId={c.moduleId} data={c.data} />
+        )
+      })}
+    </>
+  )
+}
+
+export default ModuleSlot

--- a/src/components/tabs/SecurityTab.tsx
+++ b/src/components/tabs/SecurityTab.tsx
@@ -23,6 +23,7 @@ import { DEFAULT_SECURITY_CONFIG, DEFAULT_INVENTORY_FIELDS } from '../../lib/set
 import { evaluateSecurity } from '../../lib/rules/evaluateSecurity'
 import { getDeviceInventoryContext } from '../../lib/rules/inventoryMapping'
 import type { Severity } from '../../lib/settings/types'
+import { ModuleSlot } from '../modules/ModuleSlot'
 
 interface SecurityTabProps {
   device: any
@@ -1178,6 +1179,11 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ device }) => {
         </div>
 
       </div>
+
+      {/* Security-domain extension modules contributed to this slot
+          (e.g. a managed-risk or endpoint-protection integration). Renders
+          nothing until a module mounts to 'device.security.cards'. */}
+      <ModuleSlot slot="device.security.cards" device={device} />
 
       {/* Certificates Table */}
       {(() => {

--- a/src/lib/modules/DynamicModuleLoader.ts
+++ b/src/lib/modules/DynamicModuleLoader.ts
@@ -3,6 +3,8 @@
  * Supports individual module repositories following the pattern reportmate-module-NAME
  */
 
+import type { ModuleMount } from './moduleSlots'
+
 export interface ModuleRepository {
   id: string
   name: string
@@ -49,10 +51,14 @@ export interface ModuleManifest {
   // Compatibility
   minVersion: string  // Minimum ReportMate version
   maxVersion?: string
-  
+
   // Security
   checksum?: string
   signature?: string
+
+  // Render mount points — where this module contributes in the UI. Synced into
+  // the slot registry (moduleSlots) so host components can render it.
+  mounts?: ModuleMount[]
 }
 
 export interface ModuleRuntime {

--- a/src/lib/modules/moduleSlots.ts
+++ b/src/lib/modules/moduleSlots.ts
@@ -1,0 +1,99 @@
+/**
+ * Module slot registry.
+ *
+ * Extension modules (server-attached integrations or installed add-ons) declare
+ * where they render via *mount points* — named slots that host components expose
+ * (e.g. `device.security.cards`, `report.security.widgets`). A module either
+ * ships a custom component for its slot or falls back to the GenericModulePanel,
+ * so it is usable the moment its data lands on a device.
+ *
+ * This keeps rendering source-agnostic: a module's data may arrive from a client
+ * collector or a server-side `POST /device/{serial}/module/{id}` ingress — the
+ * slot host renders it the same way.
+ */
+
+import type { ComponentType } from 'react'
+
+/** Props every slot component receives. `data` is the module's JSONB payload. */
+export interface ModuleSlotComponentProps {
+  moduleId: string
+  data: any
+  device?: any
+}
+
+export interface ModuleMount {
+  /** Named slot a host component exposes, e.g. 'device.security.cards'. */
+  slot: string
+  /** Custom renderer; omit to use the GenericModulePanel fallback. */
+  component?: ComponentType<ModuleSlotComponentProps>
+  /** Lower renders earlier within a slot. Defaults to 100. */
+  order?: number
+}
+
+interface Registration {
+  moduleId: string
+  mount: ModuleMount
+}
+
+/**
+ * Core modules render through their own dedicated tabs and must never be
+ * treated as extensions or double-rendered in a slot.
+ */
+export const CORE_MODULE_IDS: ReadonlySet<string> = new Set([
+  'system', 'hardware', 'network', 'installs', 'security', 'applications',
+  'inventory', 'management', 'peripherals', 'identity', 'events', 'profiles',
+  'displays', 'printers',
+])
+
+const _registrations: Registration[] = []
+
+/** Register a module's mount. Idempotent per (moduleId, slot). */
+export function registerModuleMount(moduleId: string, mount: ModuleMount): void {
+  const exists = _registrations.some(
+    (r) => r.moduleId === moduleId && r.mount.slot === mount.slot,
+  )
+  if (!exists) _registrations.push({ moduleId, mount })
+}
+
+/**
+ * Populate the registry from loaded module manifests. A manifest may declare
+ * `mounts: ModuleMount[]`; each becomes a registration. Safe to call repeatedly.
+ */
+export function syncMountsFromManifests(
+  manifests: Array<{ id: string; mounts?: ModuleMount[] }>,
+): void {
+  for (const manifest of manifests) {
+    for (const mount of manifest.mounts ?? []) {
+      registerModuleMount(manifest.id, mount)
+    }
+  }
+}
+
+export interface SlotContribution {
+  moduleId: string
+  data: any
+  component?: ModuleMount['component']
+  order: number
+}
+
+/**
+ * Contributions for a slot that actually have data on this device, ordered.
+ * A registered mount with no data on the device is skipped.
+ */
+export function getSlotContributions(slot: string, device: any): SlotContribution[] {
+  const modules = device?.modules || {}
+  return _registrations
+    .filter((r) => r.mount.slot === slot && modules[r.moduleId] != null)
+    .map((r) => ({
+      moduleId: r.moduleId,
+      data: modules[r.moduleId],
+      component: r.mount.component,
+      order: r.mount.order ?? 100,
+    }))
+    .sort((a, b) => a.order - b.order)
+}
+
+/** Test/hot-reload helper. */
+export function _resetModuleMounts(): void {
+  _registrations.length = 0
+}


### PR DESCRIPTION
## Summary

Adds the **rendering half** of the Module & Extension System: a mount-point (slot) registry so extension modules — server-attached integrations or installed add-ons — render **inside existing surfaces** (e.g. the Security tab) rather than as bolted-on silos. Pairs with the API `POST /device/{serial}/module/{moduleId}` ingress (terraform-azurerm-reportmate#16); together they let a module's data arrive from a client collector *or* a server poller and render identically.

## Changes

- **`src/lib/modules/moduleSlots.ts`** — slot registry. A module declares `mounts` (a named `slot` + optional custom `component` + `order`); `getSlotContributions(slot, device)` returns the registered modules that actually have data on the device. `syncMountsFromManifests()` populates it from loaded `ModuleManifest`s. Core module ids are excluded so nothing double-renders.
- **`src/components/modules/GenericModulePanel.tsx`** — default renderer. Turns an arbitrary module JSONB payload into a readable card (labelled rows, nested subsections, compact tables). A module is usable the day its data lands; a bespoke component is an optional upgrade.
- **`src/components/modules/ModuleSlot.tsx`** — host component. `<ModuleSlot slot="device.security.cards" device={device} />` renders a slot's contributions (custom component or generic fallback) and is **inert until a module mounts** to it.
- **`ModuleManifest`** gains an optional `mounts?: ModuleMount[]` field.
- **`SecurityTab`** exposes the first slot — `device.security.cards` — below the core posture grid.

## Design

This is the generic mechanism only — **no org-specific or vendor code**. A module (public-optional like an EDR integration, or a private internal one) registers its own mount via its manifest and renders through the slot; the host tabs don't need per-module edits. Security-domain sources land as cards in the Security tab per the design, not separate tabs.

Full design and rationale: `docs/MODULE_EXTENSION_SYSTEM_RFC.md` in the ReportMate superproject.

## Safety / scope

- No behaviour change for any core module — every slot is empty until a module mounts, and `ModuleSlot` renders `null` with zero contributions.
- Type-checks clean; purely additive (3 new files, 2 small edits).