### PR TITLE
Keep profile/preference search mounted on empty results

### DIFF
--- a/src/components/tabs/ManagementTab.tsx
+++ b/src/components/tabs/ManagementTab.tsx
@@ -1285,7 +1285,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
       </div>
 
       {/* Configuration Profiles Section (Mac) - Accordion style like SystemTab Background Activity */}
-      {isMac && filteredProfiles.length > 0 && (
+      {isMac && installedProfiles.length > 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -1314,6 +1314,11 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
           
           {/* Profiles Accordion List */}
           <div className="divide-y divide-gray-200 dark:divide-gray-700">
+            {filteredProfiles.length === 0 && (
+              <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
+                No profiles match &ldquo;{profileSearch}&rdquo;.
+              </div>
+            )}
             {filteredProfiles.map((profile: any, index: number) => {
               const identifier = profile.identifier || `profile-${index}`
               const isExpanded = expandedProfiles.has(identifier)
@@ -1508,7 +1513,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
       )}
 
       {/* Managed Policies Section (Mac) - Grouped by domain */}
-      {isMac && filteredPolicies.length > 0 && (
+      {isMac && managedPolicies.length > 0 && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
           <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -1537,6 +1542,11 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
           
           {/* Managed Policies Accordion List */}
           <div className="divide-y divide-gray-200 dark:divide-gray-700">
+            {filteredPolicies.length === 0 && (
+              <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
+                No preferences match &ldquo;{policySearch}&rdquo;.
+              </div>
+            )}
             {filteredPolicies.map((policy: any, index: number) => {
               const domain = policy.domain || `domain-${index}`
               const isExpanded = expandedPolicies.has(domain)

--- a/src/components/tabs/ManagementTab.tsx
+++ b/src/components/tabs/ManagementTab.tsx
@@ -1316,7 +1316,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
           <div className="divide-y divide-gray-200 dark:divide-gray-700">
             {filteredProfiles.length === 0 && (
               <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
-                No profiles match &ldquo;{profileSearch}&rdquo;.
+                No profiles match &ldquo;{profileSearch.trim()}&rdquo;.
               </div>
             )}
             {filteredProfiles.map((profile: any, index: number) => {
@@ -1544,7 +1544,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
           <div className="divide-y divide-gray-200 dark:divide-gray-700">
             {filteredPolicies.length === 0 && (
               <div className="px-6 py-10 text-center text-sm text-gray-500 dark:text-gray-400">
-                No preferences match &ldquo;{policySearch}&rdquo;.
+                No preferences match &ldquo;{policySearch.trim()}&rdquo;.
               </div>
             )}
             {filteredPolicies.map((policy: any, index: number) => {


### PR DESCRIPTION
## Problem

On the Mac **Management** tab, searching in **Configuration Profiles** (or **Managed Preferences**) for a term that matched nothing made the entire card disappear — search box included — so there was no way to refine or clear the query. It read as a broken table rather than an empty result.

## Cause

Both sections were gated on the *filtered* list length:

```
{isMac && filteredProfiles.length > 0 && ( ... )}
{isMac && filteredPolicies.length > 0 && ( ... )}
```

A zero-match search drops the filtered length to 0, unmounting the whole section.

## Fix

- Gate each section on the **unfiltered** list (`installedProfiles.length` / `managedPolicies.length`) so the header and search box stay mounted.
- Render an explicit empty state inside the list (`No profiles match "…"` / `No preferences match "…"`) when the search returns nothing.

## Test plan

- [ ] Open a Mac device → Management tab
- [ ] Type a non-matching term in Configuration Profiles search → search box stays, shows "No profiles match …"
- [ ] Clear the search → list returns
- [ ] Repeat for Managed Preferences