### PR TITLE
ci: add build CI and fix publish tag trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+# Build validation for pushes and PRs to main.
+#
+# next.config.mjs sets typescript.ignoreBuildErrors and eslint.ignoreDuringBuilds
+# to true, so `next build` catches NEITHER type nor lint errors. This repo
+# currently has a backlog of pre-existing tsc/eslint failures, so those two
+# checks run as NON-BLOCKING report steps (continue-on-error) -- they surface
+# the debt in the run summary without red-flagging every PR. The blocking gate
+# is the full production build, which is exactly what ships in the Docker image.
+#
+# TODO: once the tsc + eslint backlog is cleared, drop continue-on-error so they
+# become hard gates.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck (report-only)
+        continue-on-error: true
+        run: pnpm exec tsc --noEmit
+
+      - name: Lint (report-only)
+        continue-on-error: true
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -5,7 +5,11 @@ name: Publish web image
 
 on:
   push:
-    tags: ["v*"]
+    tags:
+      # Accept both v-prefixed tags and the YYYY.MM.DD.HHMM datestamp tags the
+      # client repos ship with, so the same tag convention triggers a publish.
+      - 'v*'
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9].[0-9][0-9][0-9][0-9]*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml`: `pnpm install --frozen-lockfile` + `pnpm build` as the blocking gate, with `tsc --noEmit` and `pnpm lint` as non-blocking report steps. The repo had no CI at all before this — every PR to `main` was ungated.
- Fix `ghcr-publish.yml` tag trigger: was `v*` only; now also fires on `YYYY.MM.DD.HHMM` datestamp tags to match the convention the client repos ship with.

## Why build-gated rather than typecheck-gated

`next.config.mjs` has `typescript.ignoreBuildErrors: true` and `eslint.ignoreDuringBuilds: true`, so `pnpm build` already silences both. Running `tsc --noEmit` on current `main` surfaces ~20 pre-existing errors; `pnpm lint --max-warnings=0` surfaces 9 errors + 28 warnings. Making those hard gates would red-flag every PR on day one. They run as `continue-on-error: true` steps so the debt is visible in every run summary — a TODO comment marks them for promotion to hard gates once the backlog is cleared.

## Test plan

- [ ] Confirm CI run triggers on this PR and `pnpm build` step passes
- [ ] Confirm `tsc` and `lint` steps appear in the run (even if they show failures, they should not block)
- [ ] After merge, push a datestamp-format tag and confirm `Publish web image` fires