### PR TITLE
Route WebPubSub negotiate through the session-gated BFF proxy

### DIFF
--- a/app/api/v1/negotiate/route.ts
+++ b/app/api/v1/negotiate/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import { getInternalApiHeaders } from '@/lib/api-auth'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+/**
+ * SignalR/WebPubSub Negotiate API Route - Proxy to FastAPI
+ * Architecture: Next.js (proxy) -> FastAPI (token mint) -> Web PubSub
+ *
+ * The upstream negotiate endpoint mints real-time access tokens, so it must
+ * never be reachable anonymously: the session gate in middleware.ts fronts
+ * this route, and the internal secret authenticates the proxy hop.
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+
+    const apiBaseUrl = process.env.API_BASE_URL
+    if (!apiBaseUrl) {
+      throw new Error('API_BASE_URL not configured')
+    }
+
+    const fastApiUrl = `${apiBaseUrl}/api/v1/negotiate?${searchParams.toString()}`
+
+    const headers = getInternalApiHeaders()
+
+    const response = await fetch(fastApiUrl, {
+      method: 'GET',
+      headers,
+      cache: 'no-store'
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`FastAPI returned ${response.status}: ${errorText}`)
+    }
+
+    const data = await response.json()
+
+    return NextResponse.json(data, {
+      headers: {
+        'Cache-Control': 'no-store'
+      }
+    })
+  } catch (error) {
+    console.error('[NEGOTIATE PROXY] failed:', error)
+    return NextResponse.json({ error: 'Negotiate failed' }, { status: 502 })
+  }
+}

--- a/app/dashboard/hooks.ts
+++ b/app/dashboard/hooks.ts
@@ -259,12 +259,7 @@ export function useLiveEvents() {
         
         // Check if WebPubSub is enabled
         const isEnabled = process.env.NEXT_PUBLIC_ENABLE_SIGNALR === "true"
-        const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL
-        
-        if (!apiBaseUrl) {
-          throw new Error('NEXT_PUBLIC_API_BASE_URL environment variable is not configured')
-        }
-        
+
         if (!isEnabled) {
           if (isActive) {
             if (progressInterval) {
@@ -276,9 +271,10 @@ export function useLiveEvents() {
           return
         }
         
-        // Get negotiate token from API with timeout
+        // Get negotiate token via the session-gated BFF proxy (same-origin,
+        // carries the auth cookie; the proxy adds the internal secret upstream)
         const negotiateResponse = await Promise.race([
-          fetch(`${apiBaseUrl}/api/v1/negotiate?device=dashboard`),
+          fetch('/api/v1/negotiate?device=dashboard'),
           new Promise((_, reject) => 
             setTimeout(() => reject(new Error('Negotiate timeout')), 10000)
           )


### PR DESCRIPTION
Prereq for authenticating the API's `/api/v1/negotiate` (which currently mints Web PubSub tokens for anonymous callers — the live fleet event stream is listenable by anyone).

- New BFF route `app/api/v1/negotiate/route.ts`: same pattern as the module proxies (session gate via middleware, `getInternalApiHeaders()` upstream, no-store).
- `hooks.ts` negotiates against same-origin `/api/v1/negotiate` instead of `NEXT_PUBLIC_API_BASE_URL` (cookie rides along; no client-side env dependency).

Deploy order: this ships first (works against the still-open API endpoint), then the API-side auth requirement lands.

`pnpm build` green.