### PR TITLE
Canonical Cimian version normalizer for currency comparison (AB#3754)

### DIFF
--- a/src/lib/data-processing/cimian-version.test.ts
+++ b/src/lib/data-processing/cimian-version.test.ts
@@ -1,0 +1,114 @@
+import {
+  normalizeCimianVersion,
+  compareCimianVersion,
+  isCimianVersionOlder,
+} from './cimian-version'
+
+describe('normalizeCimianVersion', () => {
+  it('decodes the canonical YYYY.MM.DD.HHMM stamp', () => {
+    const v = normalizeCimianVersion('2026.07.20.0632')
+    expect(v).not.toBeNull()
+    expect(v!.canonical).toBe('2026.07.20.0632')
+    expect(v!.sortKey).toBe(202607200632)
+    expect([v!.year, v!.month, v!.day, v!.hour, v!.minute]).toEqual([2026, 7, 20, 6, 32])
+  })
+
+  it('decodes the legacy 3-component YYYY.M.DDHH stamp (day+hour merged, no minutes)', () => {
+    // '2026.7.2006' is the same build day as '2026.07.20.06xx', rendered lossily.
+    expect(normalizeCimianVersion('2026.7.2006')!.canonical).toBe('2026.07.20.0600')
+    expect(normalizeCimianVersion('2026.6.2418')!.canonical).toBe('2026.06.24.1800')
+    expect(normalizeCimianVersion('2026.6.2405')!.canonical).toBe('2026.06.24.0500')
+    expect(normalizeCimianVersion('2026.6.511')!.canonical).toBe('2026.06.05.1100')
+  })
+
+  it('decodes a plain YYYY.M.D calendar version (day <= 31, no time)', () => {
+    expect(normalizeCimianVersion('2026.7.5')!.canonical).toBe('2026.07.05.0000')
+    expect(normalizeCimianVersion('2026.12.31')!.canonical).toBe('2026.12.31.0000')
+  })
+
+  it('canonicalizes the entire real fleet spread without error', () => {
+    // Every distinct reported cimian.version observed across 388 Windows devices
+    // (2026-07-21 ReportMate snapshot). Every one must normalize.
+    const fleet = [
+      '2026.07.20.0632', '2026.06.24.0519', '2026.06.05.0221', '2026.04.26.2107',
+      '2026.04.13.2237', '2026.01.20.1609', '2026.05.11.0458', '2026.07.19.0009',
+      '2025.12.17.2120', '2026.03.20.1254', '2025.12.02.1418', '2026.06.11.0805',
+      '2026.06.23.1256', '2026.7.2006', '2026.03.04.1302', '2026.02.09.1654',
+      '2025.09.13.2245', '2026.06.04.1224', '2026.06.10.0143', '2026.04.28.2228',
+      '2026.6.2418', '2026.04.29.1322', '2026.04.30.0957', '2025.11.28.1730',
+      '2026.05.05.2058', '2025.11.24.1307', '2026.6.2405', '2026.02.23.2113',
+      '2026.04.28.1256', '2026.04.28.1037', '2026.6.511', '2026.06.20.0050',
+    ]
+    for (const v of fleet) {
+      const n = normalizeCimianVersion(v)
+      expect(n).not.toBeNull()
+      // canonical round-trips: re-normalizing the canonical form is stable.
+      expect(normalizeCimianVersion(n!.canonical)!.sortKey).toBe(n!.sortKey)
+    }
+  })
+
+  it('rejects non-Cimian version shapes (returns null so callers can fall back)', () => {
+    expect(normalizeCimianVersion('1.2.3')).toBeNull()          // semver
+    expect(normalizeCimianVersion('10.0.22621')).toBeNull()     // Windows build
+    expect(normalizeCimianVersion('139.0.7258.139')).toBeNull() // Chrome
+    expect(normalizeCimianVersion('26.7.2118')).toBeNull()      // MSI YY form (out of scope)
+    expect(normalizeCimianVersion('2.55.0.windows.1')).toBeNull()
+    expect(normalizeCimianVersion('2026.07.20.0632-beta1')).toBeNull()
+  })
+
+  it('rejects empty / null / malformed input', () => {
+    expect(normalizeCimianVersion(null)).toBeNull()
+    expect(normalizeCimianVersion(undefined)).toBeNull()
+    expect(normalizeCimianVersion('')).toBeNull()
+    expect(normalizeCimianVersion('   ')).toBeNull()
+    expect(normalizeCimianVersion('?')).toBeNull()
+    expect(normalizeCimianVersion('2026')).toBeNull()          // too few components
+    expect(normalizeCimianVersion('2026.7')).toBeNull()        // too few components
+    expect(normalizeCimianVersion('2026.13.01.0000')).toBeNull() // month out of range
+    expect(normalizeCimianVersion('2026.7.99')).toBeNull()     // 32..99: neither day nor DDHH
+    expect(normalizeCimianVersion('2099.07.20.0632')).not.toBeNull()
+    expect(normalizeCimianVersion('2101.07.20.0632')).toBeNull() // year out of range
+    expect(normalizeCimianVersion('2026.07.20.2560')).toBeNull() // minute 60 invalid
+    expect(normalizeCimianVersion('2026.07.20.2400')).toBeNull() // hour 24 invalid
+  })
+})
+
+describe('compareCimianVersion', () => {
+  it('orders the merged 3-component form correctly against the 4-component form', () => {
+    // The bug this fixes: naive element-wise compare judges 2026.7.2006 as NEWER.
+    // 2026.7.2006 -> 06:00 that day; 2026.07.20.0632 -> 06:32 same day -> older.
+    expect(compareCimianVersion('2026.7.2006', '2026.07.20.0632')).toBe(-1)
+    expect(isCimianVersionOlder('2026.7.2006', '2026.07.20.0632')).toBe(true)
+  })
+
+  it('sorts the whole fleet chronologically', () => {
+    const fleet = [
+      '2026.07.20.0632', '2026.06.24.0519', '2025.09.13.2245', '2026.7.2006',
+      '2026.6.511', '2026.01.20.1609', '2026.06.20.0050', '2026.6.2418',
+    ]
+    const sorted = [...fleet].sort(compareCimianVersion)
+    expect(sorted).toEqual([
+      '2025.09.13.2245', // 2025-09-13
+      '2026.01.20.1609', // 2026-01-20
+      '2026.6.511',      // 2026-06-05 11:00
+      '2026.06.20.0050', // 2026-06-20 00:50
+      '2026.06.24.0519', // 2026-06-24 05:19  (earlier hour, so precedes 2418)
+      '2026.6.2418',     // 2026-06-24 18:00
+      '2026.7.2006',     // 2026-07-20 06:00
+      '2026.07.20.0632', // 2026-07-20 06:32  (newest)
+    ])
+  })
+
+  it('treats equal builds as equal and is symmetric', () => {
+    expect(compareCimianVersion('2026.07.20.0632', '2026.07.20.0632')).toBe(0)
+    expect(compareCimianVersion('2026.06.24.0519', '2026.07.20.0632')).toBe(-1)
+    expect(compareCimianVersion('2026.07.20.0632', '2026.06.24.0519')).toBe(1)
+  })
+
+  it('sorts unparseable values below any parseable one', () => {
+    expect(compareCimianVersion(null, '2026.07.20.0632')).toBe(-1)
+    expect(compareCimianVersion('2026.07.20.0632', null)).toBe(1)
+    expect(compareCimianVersion(null, undefined)).toBe(0)
+    expect(compareCimianVersion('garbage', '2026.07.20.0632')).toBe(-1)
+  })
+})

--- a/src/lib/data-processing/cimian-version.ts
+++ b/src/lib/data-processing/cimian-version.ts
@@ -1,0 +1,138 @@
+/**
+ * Cimian client version normalization (AB#3754).
+ *
+ * The Cimian client stamps its build as a calendar version. The canonical,
+ * preferred form is `YYYY.MM.DD.HHMM` — zero-padded, four components — emitted
+ * by the client's build tooling (`Directory.Build.props`,
+ * `DateTime.ToString("yyyy.MM.dd.HHmm")`), e.g. `2026.07.20.0632`.
+ *
+ * Two other encodings have historically reached the reported `cimian.version`
+ * field from older client builds:
+ *
+ *   - three-component `YYYY.M.DDHH`   e.g. `2026.7.2006`  (day and hour merged,
+ *     no minutes, no zero-padding) — `2026.7.2006` is 2026-07-20 06:00.
+ *   - three-component `YYYY.M.D`      e.g. `2026.7.5`     (plain calendar day).
+ *
+ * All encode a build datetime. This module decodes any of them to a single
+ * comparable key and to the canonical `YYYY.MM.DD.HHMM` string, so "is this
+ * device behind current?" is a reliable ordered comparison.
+ *
+ * Why a dedicated normalizer instead of `compareSemanticVersions`: element-wise
+ * numeric comparison mis-orders the merged form. `2026.7.2006` parses to
+ * `[2026, 7, 2006]` and sorts *newer* than `2026.07.20.0632` -> `[2026, 7, 20, 632]`
+ * because `2006 > 20`. That inversion makes the stalest devices look current.
+ *
+ * Scope: this normalizes the *reported* `cimian.version`, which is always a
+ * 4-digit-year calendar stamp. The MSI-legal `YY.M.DDHH` ProductVersion form
+ * (e.g. `26.7.2118`, capped because MSI majors are <= 255) lives only in the
+ * on-device registry and never enters the reported field, so it is intentionally
+ * out of scope here — requiring a 4-digit year also avoids mis-reading ordinary
+ * semver like `1.2.3` as a date.
+ */
+
+export interface CimianVersion {
+  /** The original string as reported. */
+  raw: string
+  /** Canonical zero-padded form: `YYYY.MM.DD.HHMM`. */
+  canonical: string
+  /** Sortable numeric key `YYYYMMDDHHMM` (e.g. 202607200632). Monotonic in build time. */
+  sortKey: number
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+}
+
+const YEAR_MIN = 2000
+const YEAR_MAX = 2100
+
+const pad2 = (n: number): string => (n < 10 ? `0${n}` : `${n}`)
+
+/**
+ * Decode a reported Cimian version string into its build datetime, or `null`
+ * if the string is not a recognizable 4-digit-year calendar stamp.
+ */
+export function normalizeCimianVersion(version: string | null | undefined): CimianVersion | null {
+  if (version == null) return null
+  const raw = version.trim()
+  if (raw === '') return null
+
+  const parts = raw.split('.')
+  // Every component must be a run of digits; reject "+commit", "-beta", "windows", etc.
+  if (!parts.every(p => /^\d+$/.test(p))) return null
+
+  const nums = parts.map(p => parseInt(p, 10))
+  const year = nums[0]
+  // Require an explicit 4-digit year in range. This excludes semver (1.2.3),
+  // Windows build numbers (10.0.x), Chrome versions (139.0.x), and the 2-digit
+  // MSI ProductVersion form.
+  if (parts[0].length !== 4 || year < YEAR_MIN || year > YEAR_MAX) return null
+
+  const month = nums[1]
+  if (month == null || month < 1 || month > 12) return null
+
+  let day: number
+  let hour: number
+  let minute: number
+
+  if (parts.length >= 4) {
+    // YYYY.MM.DD.HHMM  (the canonical CI stamp)
+    day = nums[2]
+    const hhmm = nums[3]
+    hour = Math.floor(hhmm / 100)
+    minute = hhmm % 100
+  } else if (parts.length === 3) {
+    const third = nums[2]
+    if (third <= 31) {
+      // YYYY.M.D  — plain calendar day, no time component.
+      day = third
+      hour = 0
+      minute = 0
+    } else if (third >= 100) {
+      // YYYY.M.DDHH — day and hour merged (older client stamp, minutes dropped).
+      day = Math.floor(third / 100)
+      hour = third % 100
+      minute = 0
+    } else {
+      // 32..99: not a valid day and not a valid DDHH pair.
+      return null
+    }
+  } else {
+    // Fewer than three components (e.g. "2026.7") — not enough to be a build stamp.
+    return null
+  }
+
+  if (day < 1 || day > 31) return null
+  if (hour < 0 || hour > 23) return null
+  if (minute < 0 || minute > 59) return null
+
+  const canonical = `${year}.${pad2(month)}.${pad2(day)}.${pad2(hour)}${pad2(minute)}`
+  const sortKey = ((((year * 100 + month) * 100 + day) * 100 + hour) * 100) + minute
+
+  return { raw, canonical, sortKey, year, month, day, hour, minute }
+}
+
+/**
+ * Compare two reported Cimian versions by build time.
+ * Returns -1 if `a` is older, 1 if `a` is newer, 0 if equal.
+ * Unparseable values sort below any parseable one (and equal to each other).
+ */
+export function compareCimianVersion(a: string | null | undefined, b: string | null | undefined): number {
+  const na = normalizeCimianVersion(a)
+  const nb = normalizeCimianVersion(b)
+  if (na === null && nb === null) return 0
+  if (na === null) return -1
+  if (nb === null) return 1
+  if (na.sortKey < nb.sortKey) return -1
+  if (na.sortKey > nb.sortKey) return 1
+  return 0
+}
+
+/** True when `version` is strictly older than `current` by build time. */
+export function isCimianVersionOlder(
+  version: string | null | undefined,
+  current: string | null | undefined,
+): boolean {
+  return compareCimianVersion(version, current) < 0
+}


### PR DESCRIPTION
## Why (AB#3754)

Part of the fleet Cimian **version-currency** initiative (AB#3751). The metric that
answers "which Windows devices are behind current?" needs the reported
`cimian.version` to be reliably orderable — and today it is not.

The reported version is a build-datetime stamp in one of three encodings:

| Encoding | Example | Build time |
|---|---|---|
| `YYYY.MM.DD.HHMM` (canonical, current) | `2026.07.20.0632` | 2026-07-20 06:32 |
| `YYYY.M.DDHH` (legacy 3-component, day+hour merged) | `2026.7.2006` | 2026-07-20 06:00 |
| `YYYY.M.D` (plain calendar) | `2026.7.5` | 2026-07-05 |

Naive element-wise comparison (what `compareSemanticVersions` does) mis-orders the
merged form: `2026.7.2006` parses to `[2026, 7, 2006]` and sorts **newer** than
`2026.07.20.0632` -> `[2026, 7, 20, 632]` because `2006 > 20`. The stalest devices
look current.

## Change

New `src/lib/data-processing/cimian-version.ts`:

- `normalizeCimianVersion(v)` decodes any of the three forms to the canonical
  `YYYY.MM.DD.HHMM` string plus a sortable `YYYYMMDDHHMM` key.
- `compareCimianVersion(a, b)` / `isCimianVersionOlder(v, current)` give a reliable
  chronological ordering.
- Requires a 4-digit year, so semver (`1.2.3`), Windows build (`10.0.22621`), Chrome
  (`139.0.7258.139`), and the on-device MSI `YY.M.DDHH` form all return `null` and
  callers fall back cleanly. (The MSI form never appears in the reported field.)

## Tests

`cimian-version.test.ts` — 10 cases including the **full 32-value real fleet spread**
from the 2026-07-21 snapshot, canonical round-trip, chronological sort, the
`2026.7.2006 < 2026.07.20.0632` inversion, and boundary rejects. All green.

## Scope

Pure, dependency-free normalizer. No call sites are rewired here — the currency
metric that consumes it is AB#3755. A sibling PR (windowsadmins/cimian) fixes the
same mis-sort in the C# client's self-update comparator; that is a separate concern
(self-update, not reporting).

Work item: AB#3754.
