### PR TITLE
fix(ui): stop header logo rendering as a broken image (AB#3787)

### DIFF
--- a/app/(auth)/auth/signin/ClientSignIn.tsx
+++ b/app/(auth)/auth/signin/ClientSignIn.tsx
@@ -97,6 +97,8 @@ function SignInContent() {
                 height={96}
                 className="h-24 w-auto"
                 priority
+                unoptimized
+                onError={(e) => { e.currentTarget.style.display = 'none' }}
               />
             </div>
             

--- a/app/dashboard/progressive.tsx
+++ b/app/dashboard/progressive.tsx
@@ -126,12 +126,14 @@ export default function ProgressiveDashboard() {
             <div className="flex items-center gap-4">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-lg flex items-center justify-center overflow-hidden">
-                  <Image 
-                    src="/reportmate-logo.png" 
-                    alt="ReportMate" 
+                  <Image
+                    src="/reportmate-logo.png"
+                    alt="ReportMate"
                     width={40}
                     height={40}
                     className="object-contain"
+                    unoptimized
+                    onError={(e) => { e.currentTarget.style.display = 'none' }}
                   />
                 </div>
                 <div>

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -24,8 +24,8 @@ const apiNetworkOnly: RuntimeCaching = {
 // self-contained static file in public/, precached explicitly here (and its
 // logo) so the document fallback works with zero network.
 const offlineFallbacks: (PrecacheEntry | string)[] = [
-  { url: "/offline.html", revision: "20260718" },
-  { url: "/reportmate-logo.png", revision: "20260718" },
+  { url: "/offline.html", revision: "20260722" },
+  { url: "/reportmate-logo.png", revision: "20260722" },
 ]
 
 const serwist = new Serwist({
@@ -46,3 +46,23 @@ const serwist = new Serwist({
 })
 
 serwist.addEventListeners()
+
+// One-time flush of any Serwist runtime image cache that may hold a poisoned
+// entry — back when static assets were auth-gated, an asset request could be
+// answered with a sign-in HTML redirect, and the StaleWhileRevalidate
+// next-image cache stored that HTML *as the image*. The root cause is fixed,
+// but existing clients keep serving the stale bad entry until it is deleted,
+// which is why the header logo intermittently renders as a broken image.
+// Deleting the image caches on activation lets those clients self-heal; they
+// simply repopulate from the (now clean) network on the next request.
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(
+        names
+          .filter((name) => /image/i.test(name))
+          .map((name) => caches.delete(name)),
+      ),
+    ),
+  )
+})

--- a/src/components/navigation/AppToolbar.tsx
+++ b/src/components/navigation/AppToolbar.tsx
@@ -63,12 +63,14 @@ export function AppToolbar({ preloadedDevices = [] }: AppToolbarProps) {
             <Link href="/dashboard" className="flex items-center gap-4 hover:opacity-80 transition-opacity">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-lg flex items-center justify-center overflow-hidden">
-                  <Image 
-                    src="/reportmate-logo.png" 
-                    alt="ReportMate" 
-                    width={40} 
-                    height={40} 
-                    className="object-contain" 
+                  <Image
+                    src="/reportmate-logo.png"
+                    alt="ReportMate"
+                    width={40}
+                    height={40}
+                    className="object-contain"
+                    unoptimized
+                    onError={(e) => { e.currentTarget.style.display = 'none' }}
                   />
                 </div>
                 <div>


### PR DESCRIPTION
## Problem

The header logo intermittently renders as the browser's broken-image "?" glyph — recurring, per-client ("keeps happening" for some users, never for others).

## Root cause — service-worker cache poisoning

- The logo renders via `next/image`, so the browser fetches the optimizer URL `/_next/image?url=%2Freportmate-logo.png`, **not** the raw file.
- Serwist runtime-caches `/_next/image` with **StaleWhileRevalidate** (`defaultCache`'s `next-image` rule).
- Back when static assets were auth-gated, an asset request could be answered with a **sign-in HTML redirect**, and that HTML got cached *as the image*. The 2026-07-18 fix (`2b64522`) bumped only the **raw** logo's precache revision — not the runtime-cached optimizer variant the header actually uses — so already-poisoned clients keep serving the stale bad entry. StaleWhileRevalidate returns the stale copy first, which is the intermittent, per-client pattern.

## Fix

- **Render all logo `<Image>`s with `unoptimized`** — they now load the raw `/reportmate-logo.png` (governed by the precache), bypassing the poisoned `next-image` runtime cache entirely. A 40×40 (and 240×96) logo gains nothing from the optimizer.
- **`onError` fallback** (stateless) so a transient optimizer failure hides the image instead of showing the broken glyph.
- **Bump the SW precache revision** and **delete any runtime image cache on activation**, so already-poisoned clients self-heal on their next visit rather than needing a manual cache clear.

Covers all four logo usages: header (`AppToolbar`), dashboard (`progressive`), and both sign-in states (`ClientSignIn`).