### PR TITLE
Stop hardcoding our tenant in auth, middleware and defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,5 +72,6 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 REQUIRE_EMAIL_VERIFICATION=false
 
 # Allowed email domains (comma-separated, leave empty to allow all)
-# Example: ALLOWED_DOMAINS=ecuad.ca,university.edu
-ALLOWED_DOMAINS=ecuad.ca
+# Comma-separated. An EMPTY value permits every domain, so set it.
+# Example: ALLOWED_DOMAINS=example.edu,alumni.example.edu
+ALLOWED_DOMAINS=

--- a/app/(auth)/auth/error/ClientAuthError.tsx
+++ b/app/(auth)/auth/error/ClientAuthError.tsx
@@ -93,9 +93,13 @@ function AuthErrorContent() {
           <div className="text-center text-xs text-gray-500 dark:text-gray-400">
             <p>
               If you continue to experience issues, please{' '}
-              <a href="mailto:support@ecuad.ca" className="text-blue-600 dark:text-blue-400 hover:text-blue-500">
-                contact support
-              </a>
+              {process.env.NEXT_PUBLIC_SUPPORT_EMAIL ? (
+                <a href={`mailto:${process.env.NEXT_PUBLIC_SUPPORT_EMAIL}`} className="text-blue-600 dark:text-blue-400 hover:text-blue-500">
+                  contact support
+                </a>
+              ) : (
+                <span>contact your administrator</span>
+              )}
             </p>
           </div>
         </div>

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -11,8 +11,7 @@ const authOptions: NextAuthOptions = {
       tenantId: process.env.AZURE_AD_TENANT_ID!,
       authorization: {
         params: {
-          scope: "openid profile email",
-          redirect_uri: "https://reportmate.ecuad.ca/api/auth/callback/azure-ad"
+          scope: "openid profile email"
         }
       },
       profile(profile) {
@@ -39,28 +38,19 @@ const authOptions: NextAuthOptions = {
       // Always allow sign in - let NextAuth handle any issues
       return true
     },
-    async redirect({ url }) {
-      const correctBaseUrl = 'https://reportmate.ecuad.ca'
-            
+    async redirect({ url, baseUrl }) {
+      // baseUrl is NextAuth's own view of this deployment, derived from
+      // NEXTAUTH_URL. Anything else pins the deployment to one hostname.
       if (url.startsWith("/")) {
-        return `${correctBaseUrl}${url}`
+        return `${baseUrl}${url}`
       }
-      
-      if (url.includes('0.0.0.0:3000') || url.includes('localhost:3000')) {
-        return url.replace(/(https?:\/\/)[^\/]+/, correctBaseUrl)
-      }
-      
+
       try {
         const urlObj = new URL(url)
-        if (urlObj.origin !== correctBaseUrl) {
-          urlObj.hostname = 'reportmate.ecuad.ca'
-          urlObj.protocol = 'https:'
-          urlObj.port = ''
-          return urlObj.toString()
-        }
-        return url
+        // Never hand control to another origin.
+        return urlObj.origin === baseUrl ? url : baseUrl
       } catch {
-        return correctBaseUrl
+        return baseUrl
       }
     }
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -104,20 +104,13 @@ const buildProviders = () => {
           email: { label: "Email", type: "email" },
           password: { label: "Password", type: "password" }
         },
-        async authorize(credentials) {
-          // TODO: Implement your credential validation logic
-          // This is a placeholder for future implementation
-          if (credentials?.email && credentials?.password) {
-            // Replace with actual validation
-            if (credentials.email === "admin@reportmate.ecuad.ca" && credentials.password === "admin") {
-              return {
-                id: "1",
-                name: "Admin User",
-                email: credentials.email,
-                provider: AUTH_PROVIDERS.CREDENTIALS
-              }
-            }
-          }
+        async authorize() {
+          // Not implemented. This provider is only reachable when
+          // AUTH_PROVIDERS includes "credentials"; until real validation
+          // exists it must authenticate nobody. It previously accepted a
+          // hardcoded address and the password "admin", which anyone reading
+          // this repository could use on a deployment that enabled it.
+          console.error('[AUTH] credentials provider is enabled but not implemented; rejecting')
           return null
         }
       })

--- a/middleware.ts
+++ b/middleware.ts
@@ -162,8 +162,9 @@ export default async function middleware(request: NextRequest) {
   
   // Force correct base URL for callbacks in production
   const getCorrectUrl = (originalUrl: string): string => {
-    if (process.env.NODE_ENV === 'production') {
-      return originalUrl.replace(/(https?:\/\/)[^\/]+/, 'https://reportmate.ecuad.ca')
+    const configuredBase = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL
+    if (process.env.NODE_ENV === 'production' && configuredBase) {
+      return originalUrl.replace(/(https?:\/\/)[^\/]+/, configuredBase)
     }
     return originalUrl
   }
@@ -230,7 +231,7 @@ export default async function middleware(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const correctBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://reportmate.ecuad.ca'
+    const correctBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin
     const correctUrl = request.url.replace(/(https?:\/\/)[^\/]+/, correctBaseUrl)
     const callbackUrl = encodeURIComponent(correctUrl)
     // Redirect directly to signin without error parameters
@@ -243,7 +244,7 @@ export default async function middleware(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     // If there's an error checking the session, redirect to sign in without error parameters
-    const correctBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || 'https://reportmate.ecuad.ca'
+    const correctBaseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin
     const correctUrl = request.url.replace(/(https?:\/\/)[^\/]+/, correctBaseUrl)
     const callbackUrl = encodeURIComponent(correctUrl)
     return NextResponse.redirect(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const isStaging = process.env.TEST_ENV === 'staging'
 const isRemote = isProduction || isStaging
 
 const baseURL = isProduction
-  ? 'https://reportmate.ecuad.ca'
+  ? (process.env.E2E_BASE_URL ?? 'http://localhost:3000')
   : isStaging
     ? 'https://reportmate-staging.azurecontainerapps.io'
     : 'http://localhost:3000'

--- a/scripts/check-endpoints.ps1
+++ b/scripts/check-endpoints.ps1
@@ -30,7 +30,8 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$ApiBase,
 
-    [string]$FrontendBase = "https://reportmate.ecuad.ca",
+    [Parameter(Mandatory = $true)]
+    [string]$FrontendBase,
 
     [string]$DeviceSerial = "0F33V9G25083HJ"
 )

--- a/src/components/tabs/InstallsTab.tsx
+++ b/src/components/tabs/InstallsTab.tsx
@@ -264,7 +264,7 @@ export const InstallsTab: React.FC<InstallsTabProps> = ({ device, data, initialF
         type: 'cimian',
         version: cimianData.version || cimianData.config?.version || '25.8.26.2231',
         duration: duration,
-        softwareRepoURL: cimianData.config?.SoftwareRepoURL || 'https://cimian.ecuad.ca/deployment',
+        softwareRepoURL: cimianData.config?.SoftwareRepoURL || '',
         manifest: cimianData.config?.ClientIdentifier || 'Assigned/Staff/IT/B1115/RodChristiansen',
         runType: 'Manual'
       }

--- a/src/lib/data-processing/modules/profiles.ts
+++ b/src/lib/data-processing/modules/profiles.ts
@@ -28,7 +28,7 @@ export interface ProfileItem {
 
 /**
  * Parse macOS profiles -C/-P output into profile identifiers
- * Format: "_computerlevel[1] attribute: profileIdentifier: ca.ecuad.macadmin.OfficePrefs _computerlevel[2]..."
+ * Format: "_computerlevel[1] attribute: profileIdentifier: com.example.macadmin.OfficePrefs _computerlevel[2]..."
  */
 function parseMacProfilesOutput(rawText: string): ProfileItem[] {
   if (!rawText || typeof rawText !== 'string') return []
@@ -49,7 +49,7 @@ function parseMacProfilesOutput(rawText: string): ProfileItem[] {
     if (seenIds.has(identifier)) continue
     seenIds.add(identifier)
     
-    // Extract display name from identifier (e.g., ca.ecuad.macadmin.OfficePrefs -> OfficePrefs)
+    // Extract display name from identifier (e.g., com.example.macadmin.OfficePrefs -> OfficePrefs)
     const parts = identifier.split('.')
     const displayName = parts[parts.length - 1] || identifier
     


### PR DESCRIPTION
Nothing in this repo now names `ecuad.ca`. Three of these were **functional faults** for anyone else deploying it, not cosmetic.

## The Entra provider pinned the OAuth callback to our domain

```ts
redirect_uri: "https://reportmate.ecuad.ca/api/auth/callback/azure-ad"
```

An adopter's sign-in would ask *their* tenant to redirect to *our* domain, and Entra would reject it as an unregistered URI — auth simply broken. NextAuth derives the callback from `NEXTAUTH_URL` itself, so the parameter is removed rather than parameterised.

## The redirect callback sent users to our site

`redirect()` rewrote every destination to our hostname, including the post-sign-in landing page. NextAuth passes `baseUrl` — its own view of the deployment, from `NEXTAUTH_URL` — into that callback, and it was being ignored in favour of a literal. It now uses `baseUrl`, and returns `baseUrl` rather than following a URL from any other origin.

Production sets `NEXTAUTH_URL=https://reportmate.ecuad.ca`, so behaviour here is unchanged for us.

## The credentials provider had a working back door

```ts
if (credentials.email === "admin@reportmate.ecuad.ca" && credentials.password === "admin")
```

Only reachable when `AUTH_PROVIDERS` includes `credentials`, which production does not (`AUTH_PROVIDERS=azure-ad`, and the Terraform default is `["azure-ad"]`), so nothing was exposed on our deployment. But the pair was published here, and any deployment enabling that provider — a reasonable thing to do for local development — inherited it. The placeholder now authenticates nobody and logs why.

## Middleware fell back to our hostname

`getCorrectUrl` rewrote unconditionally in production, and the two sign-in redirects ended their env-var chain in a literal. The rewrite now happens only when a base URL is actually configured, and the redirects fall back to `request.nextUrl.origin` — the deployment's own origin.

## Defaults that assumed our deployment

| File | Was | Now |
|---|---|---|
| `.env.example` | `ALLOWED_DOMAINS=ecuad.ca` | empty, with a note that empty means permit-everything |
| `playwright.config.ts` | our URL | `E2E_BASE_URL` |
| `scripts/check-endpoints.ps1` | `-FrontendBase` defaulted to our URL | mandatory |
| `InstallsTab.tsx` | `cimian.ecuad.ca` repo fallback | empty |
| `ClientAuthError.tsx` | `support@ecuad.ca` | `NEXT_PUBLIC_SUPPORT_EMAIL`, else "contact your administrator" |
| `profiles.ts` | `ca.ecuad.macadmin.*` in comments | `com.example.macadmin.*` |

## Verification

No occurrence of `ecuad` in any tracked file. `tsc --noEmit` reports **zero** errors in any file touched here (131 pre-existing errors elsewhere are unchanged).

AB#3946