### PR TITLE
Stop naming our registry in version output

### DIFF
--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -47,7 +47,10 @@ function getVersionInfo() {
     if (imageTag === 'unknown' && version !== 'unknown') {
       // If version looks like a tag format (YYYYMMDDHHMMSS-hash), use it as image tag
       if (version.match(/^\d{14}-[a-f0-9]+$/)) {
-        imageTag = `reportmateacr.azurecr.io/reportmate:${version}`
+        // Only qualify the tag when the registry is actually known; guessing a
+        // host would show an image reference that does not exist anywhere.
+        const registry = process.env.CONTAINER_REGISTRY
+        imageTag = registry ? `${registry}/reportmate:${version}` : version
       }
     }
     

--- a/deploy.md
+++ b/deploy.md
@@ -105,7 +105,7 @@ Before using these scripts, ensure you have:
 
 These scripts integrate with your ReportMate infrastructure:
 
-- **Container Registry**: `reportmateacr.azurecr.io`
+- **Container Registry**: whichever registry the deployment pushes to (`<name>.azurecr.io` on Azure)
 - **Resource Group**: `ReportMate`
 - **Container Apps**: 
   - `reportmate-container-dev` (development)

--- a/src/components/VersionDisplay.tsx
+++ b/src/components/VersionDisplay.tsx
@@ -70,7 +70,7 @@ export function VersionDisplay() {
     version: displayVersion,
     buildId: defaultBuildId,
     buildTime: defaultBuildTime,
-    imageTag: `reportmateacr.azurecr.io/reportmate:${displayVersion}`,
+    imageTag: displayVersion,
     nodeVersion: 'vUnknown',
     platform: 'unknown',
     arch: 'unknown'


### PR DESCRIPTION
The version endpoint and the version component both built a display image reference by prefixing **our** registry whenever no image tag was present in the environment:

```ts
imageTag = `reportmateacr.azurecr.io/reportmate:${version}`
```

On any other deployment that produced a reference to an image that exists nowhere — a guess presented as fact in the UI.

| File | Change |
|---|---|
| `app/api/version/route.ts` | qualifies the tag only when `CONTAINER_REGISTRY` is set, else reports the bare version |
| `src/components/VersionDisplay.tsx` | drops the prefix; it was only building a display fallback |
| `deploy.md` | describes the registry rather than naming ours |

No occurrence of `reportmateacr` remains in this repo. `tsc --noEmit` reports zero errors in either changed file (131 pre-existing errors elsewhere unchanged).

AB#3946