### PR TITLE
Read Platform SSO from the identity module and pick the registered user

### DIFF
--- a/src/components/tabs/IdentityTab.tsx
+++ b/src/components/tabs/IdentityTab.tsx
@@ -94,6 +94,11 @@ const DetailRow = ({
   </div>
 )
 
+// Boolean-ish flags arrive from the collectors as true, 1, "1" or "true" depending on the
+// module, so every read of one goes through here rather than comparing against one shape.
+const isTruthyFlag = (value: unknown): boolean =>
+  value === true || value === 1 || value === '1' || value === 'true'
+
 // Platform detection helper - enhanced to detect macOS from module data
 const isMacOS = (device: any): boolean => {
   // Check explicit platform field
@@ -226,8 +231,18 @@ export const IdentityTab: React.FC<IdentityTabProps> = ({ device }) => {
   const rawSecurity = device?.modules?.security || device?.security
   const security = rawSecurity ? normalizeKeys(convertPowerShellObjects(rawSecurity)) as any : null
   
-  // Platform SSO data
-  const platformSSO = security?.platformSSO
+  // Platform SSO data. Collected by the identity module, not security - it is an
+  // identity concern, and the mac client no longer emits security.platformSSO.
+  const rawPlatformSSO = device?.modules?.identity?.platformSSOUsers || device?.identity?.platformSSOUsers
+  const platformSSO = rawPlatformSSO ? normalizeKeys(convertPowerShellObjects(rawPlatformSSO)) as any : null
+
+  // The account that actually holds the SSO registration. Never index users[0]: the list
+  // is every local account in directory order, so the first entry is typically a local
+  // admin that is exempt from Platform SSO and has no token - which rendered as a
+  // permanent "Missing" regardless of the real state.
+  const platformSSOUser = platformSSO?.users?.find((u: any) => isTruthyFlag(u?.tokensPresent))
+    || platformSSO?.users?.find((u: any) => isTruthyFlag(u?.registered))
+    || null
   
   // Activation Lock / Find My Mac
   const activationLock = security?.activationLock
@@ -736,25 +751,29 @@ export const IdentityTab: React.FC<IdentityTabProps> = ({ device }) => {
                     label="Platform SSO" 
                     value={platformSSO.provider || 'Not configured'}
                   />
-                  <DetailRow 
-                    label="Registration" 
-                    value={(platformSSO.registered === true || platformSSO.registered === 1 || platformSSO.registered === '1') ? 'Registered' : 'Not Registered'}
-                    variant={(platformSSO.registered === true || platformSSO.registered === 1 || platformSSO.registered === '1') ? 'success' : 'warning'}
+                  <DetailRow
+                    label="Registration"
+                    value={isTruthyFlag(platformSSO.deviceRegistered) ? 'Registered' : 'Not Registered'}
+                    variant={isTruthyFlag(platformSSO.deviceRegistered) ? 'success' : 'warning'}
                   />
-                  {/* SSO Token - check if tokens present using truthy check */}
-                  {platformSSO.users?.[0] !== undefined && (
-                    <DetailRow 
-                      label="SSO Token" 
-                      value={(() => {
-                        const user = platformSSO.users[0];
-                        const hasToken = user.tokensPresent === true || user.tokensPresent === 1 || user.tokensPresent === '1' || user.tokensPresent === 'true';
-                        return hasToken ? 'Present' : 'Missing';
-                      })()}
-                      variant={(() => {
-                        const user = platformSSO.users[0];
-                        const hasToken = user.tokensPresent === true || user.tokensPresent === 1 || user.tokensPresent === '1' || user.tokensPresent === 'true';
-                        return hasToken ? 'success' : 'warning';
-                      })()}
+                  {platformSSOUser && (
+                    <DetailRow
+                      label="SSO User"
+                      value={platformSSOUser.userPrincipalName || platformSSOUser.loginUserName || platformSSOUser.username}
+                    />
+                  )}
+                  {platformSSO.users?.length > 0 && (
+                    <DetailRow
+                      label="SSO Token"
+                      value={isTruthyFlag(platformSSOUser?.tokensPresent) ? 'Present' : 'Missing'}
+                      variant={isTruthyFlag(platformSSOUser?.tokensPresent) ? 'success' : 'warning'}
+                    />
+                  )}
+                  {isTruthyFlag(platformSSOUser?.tokensPresent) && platformSSOUser?.tokenExpiration && (
+                    <DetailRow
+                      label="Token Expires"
+                      value={platformSSOUser.tokenExpiration}
+                      variant={isTruthyFlag(platformSSOUser.tokenExpired) ? 'warning' : 'success'}
                     />
                   )}
                 </>

--- a/src/components/widgets/Security.tsx
+++ b/src/components/widgets/Security.tsx
@@ -49,6 +49,11 @@ interface SecurityWidgetProps {
   device: Device
 }
 
+// Boolean-ish flags arrive from the collectors as true, 1, "1" or "true" depending on the
+// module, so every read of one goes through here rather than comparing against one shape.
+const isTruthyFlag = (value: unknown): boolean =>
+  value === true || value === 1 || value === '1' || value === 'true'
+
 export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
   // Access security data from device object, prioritizing the modules structure
   const rawSecurity = device?.modules?.security || device?.security || device?.securityFeatures
@@ -56,7 +61,19 @@ export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
   // Parse PowerShell objects and normalize keys to camelCase
   const parsedSecurity = convertPowerShellObjects(rawSecurity)
   const security = parsedSecurity ? normalizeKeys(parsedSecurity) as any : null
-  
+
+  // Platform SSO is collected by the identity module, not security - the mac client no
+  // longer emits security.platformSSO.
+  const rawPlatformSSO = device?.modules?.identity?.platformSSOUsers || device?.identity?.platformSSOUsers
+  const platformSSO = rawPlatformSSO ? normalizeKeys(convertPowerShellObjects(rawPlatformSSO)) as any : null
+
+  // The account holding the registration. users[0] is whichever local account came first
+  // in directory order - typically a Platform-SSO-exempt local admin with no token, which
+  // showed as a permanent "Missing".
+  const platformSSOUser = platformSSO?.users?.find((u: any) => isTruthyFlag(u?.tokensPresent))
+    || platformSSO?.users?.find((u: any) => isTruthyFlag(u?.registered))
+    || null
+
   // Detect platform for platform-aware display - check multiple locations
   const operatingSystem = device?.modules?.system?.operatingSystem || device?.modules?.system?.operating_system
   const platform = device?.platform?.toLowerCase() || 
@@ -232,25 +249,25 @@ export const SecurityWidget: React.FC<SecurityWidgetProps> = ({ device }) => {
             )}
 
             {/* Platform SSO - at the bottom, formatted like Windows Hello */}
-            {security?.platformSSO && (
+            {platformSSO && (
               <div className="space-y-2 mt-3">
                 <StatusBadge
                   label="Platform SSO"
-                  status={(security.platformSSO.registered === true || security.platformSSO.registered === 1) ? 'Registered' : 'Not Registered'}
-                  type={getStatusType(security.platformSSO.registered === true || security.platformSSO.registered === 1)}
+                  status={isTruthyFlag(platformSSO.deviceRegistered) ? 'Registered' : 'Not Registered'}
+                  type={getStatusType(isTruthyFlag(platformSSO.deviceRegistered))}
                 />
                 <div className="ml-4 space-y-2">
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-gray-600 dark:text-gray-400">Token:</span>
                     <StatusBadge
                       label=""
-                      status={security.platformSSO.users?.[0]?.tokensPresent === true || security.platformSSO.users?.[0]?.tokensPresent === 1 ? 'Present' : 'Missing'}
-                      type={getStatusType(security.platformSSO.users?.[0]?.tokensPresent === true || security.platformSSO.users?.[0]?.tokensPresent === 1)}
+                      status={isTruthyFlag(platformSSOUser?.tokensPresent) ? 'Present' : 'Missing'}
+                      type={getStatusType(isTruthyFlag(platformSSOUser?.tokensPresent))}
                     />
                   </div>
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-gray-600 dark:text-gray-400">Method:</span>
-                    <span className="text-gray-900 dark:text-white">{security.platformSSO.method || 'Unknown'}</span>
+                    <span className="text-gray-900 dark:text-white">{platformSSO.method || 'Unknown'}</span>
                   </div>
                 </div>
               </div>

--- a/src/lib/data-processing/modules/identity.ts
+++ b/src/lib/data-processing/modules/identity.ts
@@ -237,15 +237,38 @@ export interface SecureTokenInfo {
 export interface PlatformSSOUsersInfo {
   supported: boolean
   deviceRegistered: boolean
+  /** Identity provider, e.g. "Microsoft Entra ID" */
+  provider: string | null
+  /** Authentication method, e.g. "Secure enclave key" */
+  method: string | null
+  extensionIdentifier: string | null
+  organizationName: string | null
+  loginFrequency: number
+  offlineGracePeriod: string | null
   registeredUserCount: number
   unregisteredUserCount: number
+  tokenPresentCount: number
+  /** Accounts the payload exempts from Platform SSO */
+  nonPlatformSSOAccounts: string[]
   users: PlatformSSOUser[]
 }
 
 export interface PlatformSSOUser {
   username: string
+  uid: number | null
   registered: boolean
   userPrincipalName: string | null
+  /** Masked by macOS as "u***r@example.ca" - proves registration, not an identity */
+  loginUserName: string | null
+  state: string | null
+  lastLoginDate: string | null
+  tokensPresent: boolean
+  tokenReceived: string | null
+  tokenExpiration: string | null
+  /** null when no token is present, so "no token" stays distinct from "token valid" */
+  tokenExpired: boolean | null
+  /** ok | excluded | no-session | device-not-registered | probe-failed */
+  probeStatus: string | null
 }
 
 // MARK: - Session History (TerminalServices RDP sessions)
@@ -559,16 +582,37 @@ function mapSecureTokenInfo(st: any): SecureTokenInfo {
   }
 }
 
+// Collectors emit booleans as true, 1, "1" or "true" depending on the serializer.
+const toFlag = (value: unknown): boolean =>
+  value === true || value === 1 || value === '1' || value === 'true'
+
 function mapPlatformSSOUsers(psso: any): PlatformSSOUsersInfo {
   return {
-    supported: psso.supported || false,
-    deviceRegistered: psso.deviceRegistered || psso.device_registered || false,
+    supported: toFlag(psso.supported),
+    deviceRegistered: toFlag(psso.deviceRegistered ?? psso.device_registered),
+    provider: psso.provider || null,
+    method: psso.method || null,
+    extensionIdentifier: psso.extensionIdentifier || psso.extension_identifier || null,
+    organizationName: psso.organizationName || psso.organization_name || null,
+    loginFrequency: psso.loginFrequency || psso.login_frequency || 0,
+    offlineGracePeriod: psso.offlineGracePeriod || psso.offline_grace_period || null,
     registeredUserCount: psso.registeredUserCount || psso.registered_user_count || 0,
     unregisteredUserCount: psso.unregisteredUserCount || psso.unregistered_user_count || 0,
+    tokenPresentCount: psso.tokenPresentCount || psso.token_present_count || 0,
+    nonPlatformSSOAccounts: psso.nonPlatformSSOAccounts || psso.non_platform_sso_accounts || [],
     users: (psso.users || []).map((u: any) => ({
       username: u.username || '',
-      registered: u.registered || false,
-      userPrincipalName: u.userPrincipalName || u.user_principal_name || null
+      uid: u.uid ?? null,
+      registered: toFlag(u.registered),
+      userPrincipalName: u.userPrincipalName || u.user_principal_name || null,
+      loginUserName: u.loginUserName || u.login_user_name || null,
+      state: u.state || null,
+      lastLoginDate: u.lastLoginDate || u.last_login_date || null,
+      tokensPresent: toFlag(u.tokensPresent ?? u.tokens_present),
+      tokenReceived: u.tokenReceived || u.token_received || null,
+      tokenExpiration: u.tokenExpiration || u.token_expiration || null,
+      tokenExpired: (u.tokenExpired ?? u.token_expired) == null ? null : toFlag(u.tokenExpired ?? u.token_expired),
+      probeStatus: u.probeStatus || u.probe_status || null
     }))
   }
 }


### PR DESCRIPTION
Companion to reportmate/reportmate-client-mac#21, which fixes Platform SSO collection on the mac client and moves it out of the security module into identity.

**Repointed to the identity module.** `IdentityTab.tsx` and `widgets/Security.tsx` read `security.platformSSO`. The mac client no longer emits it — Platform SSO is an identity concern and was being collected twice. Both now read `identity.platformSSOUsers`, mapping `registered` → `deviceRegistered`. Without this the Authentication card on IdentityTab disappears (its gate falls back to `activationLock` alone) and the Platform SSO block in the InfoTab security widget stops rendering.

**Fixed the "Missing" token.** Both files read the token from `platformSSO.users[0]`. That array is every local account in directory order, so the first entry is typically a local admin listed in `nonPlatformSSOAccounts` — exempt from Platform SSO, holding no token. On a correctly registered Mac the token row read `Missing` regardless of the real state. It now selects the account that actually holds the registration.

This is an independent cause of the reported symptom: even after the client-side collection bugs were fixed, `users[0]` on the test device was `admin`, so the UI would still have shown `Missing`.

**Flag coercion.** Booleans arrive from the collectors as `true`, `1`, `"1"` or `"true"` depending on the serializer. The two files each open-coded a different subset — the security widget checked only `true` and `1`, so a string `"1"` read as false. Both go through one helper now, as does the identity mapper.

**Types and mapper.** `PlatformSSOUsersInfo` / `PlatformSSOUser` kept three user fields and four device fields; the client emits considerably more. Both interfaces and `mapPlatformSSOUsers` now carry the full shape — provider, method, extensionIdentifier, organizationName, loginFrequency, offlineGracePeriod, tokenPresentCount, nonPlatformSSOAccounts, and per-user uid, loginUserName, state, lastLoginDate, tokensPresent, tokenReceived, tokenExpiration, tokenExpired, probeStatus.

Token expiry is surfaced on IdentityTab now that the client reports it, along with the SSO user's UPN.

## Not affected

`reportmate-api/routers/fleet.py`, `app/api/v1/identity/route.ts` and `app/identity/page.tsx` already read `identity.platformSSOUsers` and only use `deviceRegistered` / `registeredUserCount`, which are unchanged. `IdentityTab.tsx`'s use of `identity.platformSSOUsers` as a macOS-detection signal is unchanged — the payload key keeps its name.

## Verification

`npx tsc --noEmit` is clean on the changed files (the only output is a pre-existing `baseUrl` deprecation warning from tsconfig).

Not yet exercised against a live payload — that needs the client PR merged and a device checked in.
