### PR TITLE
Cut page-load dead weight on dashboard and devices pages

### DIFF
--- a/app/api/v1/devices/route.ts
+++ b/app/api/v1/devices/route.ts
@@ -4,79 +4,6 @@ import { getInternalApiHeaders } from '@/lib/api-auth'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-// Helper function to convert PowerShell object strings to JSON objects
-function parsePowerShellObject(str: string, parentKey?: string, originalObj?: unknown): unknown {
-  if (typeof str !== 'string' || !str.startsWith('@{') || !str.endsWith('}')) {
-    return str
-  }
-  
-  try {
-    // Remove @{ and } wrapper
-    const content = str.slice(2, -1).trim()
-    
-    if (!content) return {}
-    
-    // Split by semicolons and parse key-value pairs
-    const pairs = content.split(';')
-    const result: Record<string, unknown> = {}
-    
-    for (const pair of pairs) {
-      const equalIndex = pair.indexOf('=')
-      if (equalIndex === -1) continue
-      
-      const key = pair.slice(0, equalIndex).trim()
-      const valueStr = pair.slice(equalIndex + 1).trim()
-      
-      if (!key) continue
-      
-      // Handle different value types
-      if (valueStr === '') {
-        result[key] = ''
-      } else if (valueStr === 'True') {
-        result[key] = true
-      } else if (valueStr === 'False') {
-        result[key] = false
-      } else if (/^\d+$/.test(valueStr)) {
-        result[key] = parseInt(valueStr, 10)
-      } else if (/^\d+\.\d+$/.test(valueStr)) {
-        result[key] = parseFloat(valueStr)
-      } else if (valueStr.startsWith('@{') && valueStr.endsWith('}')) {
-        // Nested PowerShell object
-        result[key] = parsePowerShellObject(valueStr, key, originalObj)
-      } else if (valueStr.startsWith('System.Object[]')) {
-        result[key] = { _powershellArray: true, _rawValue: valueStr }
-      } else {
-        result[key] = valueStr
-      }
-    }
-    
-    return result
-  } catch (error) {
-    console.warn('Failed to parse PowerShell object:', str.substring(0, 100), error)
-    return str
-  }
-}
-
-// Recursively process object to convert PowerShell object strings
-function convertPowerShellObjects(obj: unknown, parentKey?: string, originalObj?: unknown): unknown {
-  if (typeof obj === 'string') {
-    return parsePowerShellObject(obj, parentKey, originalObj)
-  } else if (Array.isArray(obj)) {
-    return obj.map((item, index) => convertPowerShellObjects(item, `${parentKey}[${index}]`, obj))
-  } else if (obj && typeof obj === 'object') {
-    const result: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(obj)) {
-      if (['events', 'items', 'sessions'].includes(key) && Array.isArray(value)) {
-        result[key] = value 
-      } else {
-        result[key] = convertPowerShellObjects(value, key, obj)
-      }
-    }
-    return result
-  }
-  return obj
-}
-
 export async function GET(request: NextRequest) {
   const timestamp = new Date().toISOString()
   
@@ -121,17 +48,15 @@ export async function GET(request: NextRequest) {
     }
 
     const fastApiData = await response.json()
-    
-    // Process the data to handle PowerShell objects
-    let processedData = fastApiData
-    if (fastApiData.devices && Array.isArray(fastApiData.devices)) {
-                processedData = {
-            ...fastApiData,
-            devices: fastApiData.devices.map((device: any) => convertPowerShellObjects(device))
-        }
-            }
 
-    return NextResponse.json(processedData, {
+    // No PowerShell-object conversion here: the fleet list payload was
+    // audited (all ~880 devices) and contains no '@{...}' strings — modern
+    // clients send clean JSON and every active device's stored data is
+    // rewritten at check-in. Deep-walking ~1MB of JSON per request was pure
+    // server CPU. The single-device detail route keeps its parser for
+    // legacy data on long-stale devices.
+
+    return NextResponse.json(fastApiData, {
       headers: {
         'Cache-Control': 'private, max-age=15, stale-while-revalidate=30',
       }

--- a/app/dashboard/ClientDashboard.tsx
+++ b/app/dashboard/ClientDashboard.tsx
@@ -10,7 +10,6 @@ import { StatusWidget } from "../../src/lib/modules/widgets/StatusWidget"
 import { PlatformDistributionWidget } from "../../src/lib/modules/widgets/PlatformDistributionWidget"
 import { DashboardSkeleton } from "../../src/components/skeleton/DashboardSkeleton"
 import { calculateDeviceStatus } from "../../src/lib/data-processing"
-import { preloadInstallsData } from "../../src/hooks/useInstallsData"
 import { usePlatformFilterSafe, getDevicePlatform } from "../../src/providers/PlatformFilterProvider"
 
 // WebPubSub message types for JSON subprotocol
@@ -300,11 +299,11 @@ export default function ClientDashboard() {
         // Recover from transient error state on successful fetch
         setConnectionStatus(prev => prev === 'error' ? 'polling' : prev)
         
-        // Prefetch installs data in background for faster navigation to /installs
-        // This starts loading the data that will be needed if user clicks on Errors/Warnings
-        if (isInitialLoad) {
-          preloadInstallsData()
-        }
+        // No background prefetch of /api/v1/installs/filters here: that
+        // response is ~27MB raw, and pulling plus parsing it on every
+        // dashboard visit (with a 5-minute SWR refresh) starved the page
+        // that was actually on screen. The /installs page fetches it when
+        // it is opened.
       } catch (error) {
         if (!aborted) {
           console.error('[DASHBOARD] Dashboard data fetch failed:', error)

--- a/app/devices/ClientDevicesPage.tsx
+++ b/app/devices/ClientDevicesPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, Suspense } from "react"
+import { useEffect, useState, useMemo, Suspense } from "react"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { formatRelativeTime } from "../../src/lib/time"
@@ -8,7 +8,6 @@ import { calculateDeviceStatus } from "../../src/lib/data-processing"
 import { CopyButton } from "../../src/components/ui/CopyButton"
 import { normalizeKeys } from "../../src/lib/utils/powershell-parser"
 import { PlatformBadge } from "../../src/components/ui/PlatformBadge"
-import { FitText } from "../../src/components/ui/FitText"
 import { usePlatformFilterSafe, getDevicePlatform } from "../../src/providers/PlatformFilterProvider"
 
 interface InventoryItem {
@@ -126,8 +125,16 @@ function DevicesPageContent() {
               raw: { ...device, status: calculatedStatus }
             }
           })
-          
-                    setInventory(inventoryItems)
+          // Dedupe by serial number once at fetch time, so the render-path
+          // filters and counters below never repeat the O(n^2) scan.
+          const seen = new Set<string>()
+          const uniqueItems = inventoryItems.filter((item: InventoryItem) => {
+            if (!item.serialNumber || seen.has(item.serialNumber)) return false
+            seen.add(item.serialNumber)
+            return true
+          })
+
+          setInventory(uniqueItems)
         } else {
                     setInventory([])
         }
@@ -142,101 +149,67 @@ function DevicesPageContent() {
     fetchInventory()
   }, [])
 
-  // Filter inventory based on search query and filters
-  const filteredInventory = (() => {
+  // Search predicate shared by the table filter and the counter row.
+  const matchesSearch = (item: InventoryItem, query: string) => (
+    item?.deviceName?.toLowerCase().includes(query) ||
+    item?.assetTag?.toLowerCase().includes(query) ||
+    item?.serialNumber?.toLowerCase().includes(query) ||
+    item?.computerName?.toLowerCase().includes(query) ||
+    item?.hostname?.toLowerCase().includes(query) ||
+    item?.location?.toLowerCase().includes(query) ||
+    item?.manufacturer?.toLowerCase().includes(query) ||
+    item?.model?.toLowerCase().includes(query) ||
+    item?.uuid?.toLowerCase().includes(query) ||
+    item?.domain?.toLowerCase().includes(query) ||
+    item?.organizationalUnit?.toLowerCase().includes(query)
+  )
+
+  // Filter inventory based on search query and filters. Memoized: with ~900
+  // rows this previously re-ran (with an O(n^2) dedup) on every render.
+  const filteredInventory = useMemo(() => {
     try {
-            
       if (!Array.isArray(inventory)) {
         console.warn('Inventory is not an array:', inventory)
         return []
       }
-      
+
       let filtered = inventory
-      
+
       // Apply status filter first
       if (statusFilter !== 'all') {
         // Show non-archived devices matching the status
         filtered = filtered.filter(item => {
-          try {
-            if (item.archived) return false // Never show archived in status filters
-            const status = item.raw?.status?.toLowerCase()
-            return status === statusFilter
-          } catch (e) {
-            console.warn('Error checking item status:', item, e)
-            return false
-          }
+          if (item.archived) return false // Never show archived in status filters
+          return item.raw?.status?.toLowerCase() === statusFilter
         })
       } else {
         // If status is 'all', exclude archived devices by default
         filtered = filtered.filter(item => !item.archived)
       }
-      
+
       // Apply usage filter
       if (usageFilter !== 'all') {
-        filtered = filtered.filter(item => {
-          try {
-            const usage = item.usage?.toLowerCase()
-            return usage === usageFilter
-          } catch (e) {
-            console.warn('Error checking item usage:', item, e)
-            return false
-          }
-        })
+        filtered = filtered.filter(item => item.usage?.toLowerCase() === usageFilter)
       }
 
       // Apply catalog filter
       if (catalogFilter !== 'all') {
-        filtered = filtered.filter(item => {
-          try {
-            const catalog = item.catalog?.toLowerCase()
-            return catalog === catalogFilter
-          } catch (e) {
-            console.warn('Error checking item catalog:', item, e)
-            return false
-          }
-        })
+        filtered = filtered.filter(item => item.catalog?.toLowerCase() === catalogFilter)
       }
-      
+
       // Apply global platform filter
       if (platformFilter !== 'all') {
         filtered = filtered.filter(item => isPlatformVisible(item.platform || ''))
       }
-      
+
       // Then apply search filter
       if (searchQuery.trim()) {
         const query = searchQuery.toLowerCase()
-        filtered = filtered.filter(item => {
-          try {
-            return (
-              item?.deviceName?.toLowerCase().includes(query) ||
-              item?.assetTag?.toLowerCase().includes(query) ||
-              item?.serialNumber?.toLowerCase().includes(query) ||
-              item?.computerName?.toLowerCase().includes(query) ||
-              item?.hostname?.toLowerCase().includes(query) ||
-              item?.location?.toLowerCase().includes(query) ||
-              item?.manufacturer?.toLowerCase().includes(query) ||
-              item?.model?.toLowerCase().includes(query) ||
-              item?.uuid?.toLowerCase().includes(query) ||
-              item?.domain?.toLowerCase().includes(query) ||
-              item?.organizationalUnit?.toLowerCase().includes(query)
-            )
-          } catch (e) {
-            console.warn('Error filtering item:', item, e)
-            return false
-          }
-        })
+        filtered = filtered.filter(item => matchesSearch(item, query))
       }
 
-      // Remove duplicates based on serialNumber
-      const uniqueFiltered = filtered.reduce((unique: InventoryItem[], item: InventoryItem) => {
-        if (!unique.some(existingItem => existingItem.serialNumber === item.serialNumber)) {
-          unique.push(item)
-        }
-        return unique
-      }, [])
-      
-      // Apply sorting
-      const sorted = [...uniqueFiltered].sort((a, b) => {
+      // Apply sorting (inventory is already unique by serial number)
+      const sorted = [...filtered].sort((a, b) => {
         let aValue: any
         let bValue: any
         
@@ -288,8 +261,9 @@ function DevicesPageContent() {
       console.error('Error in filteredInventory:', e)
       return []
     }
-  })()
-  
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inventory, statusFilter, usageFilter, catalogFilter, platformFilter, isPlatformVisible, searchQuery, sortColumn, sortDirection])
+
   // Handle column header click for sorting
   const handleSort = (column: string) => {
     if (sortColumn === column) {
@@ -302,67 +276,21 @@ function DevicesPageContent() {
     }
   }
 
-  // Calculate base counts (without filters) for reference
-  const getBaseCounts = () => {
-    try {
-      if (!Array.isArray(inventory)) return { all: 0 }
-      
-      // Remove duplicates first based on serialNumber
-      const uniqueInventory = inventory.reduce((unique: InventoryItem[], item: InventoryItem) => {
-        if (!unique.some(existingItem => existingItem.serialNumber === item.serialNumber)) {
-          unique.push(item)
-        }
-        return unique
-      }, [])
-      
-      return {
-        all: uniqueInventory.length
-      }
-    } catch (e) {
-      console.error('Error calculating base counts:', e)
-      return { all: 0 }
-    }
-  }
+  // Base count (without filters) for reference; inventory is already unique.
+  const baseCounts = useMemo(() => ({ all: Array.isArray(inventory) ? inventory.length : 0 }), [inventory])
 
-  // Get filter counts from search-filtered inventory (dynamic based on current search)
-  const getFilterCounts = () => {
+  // Filter counts from search-filtered inventory (dynamic based on current search)
+  const filterCounts = useMemo(() => {
     try {
-      if (!Array.isArray(inventory)) return { 
-        all: 0, assigned: 0, shared: 0, curriculum: 0, staff: 0, faculty: 0, kiosk: 0 
+      if (!Array.isArray(inventory)) return {
+        all: 0, active: 0, stale: 0, missing: 0, assigned: 0, shared: 0, curriculum: 0, staff: 0, faculty: 0, kiosk: 0
       }
-      
-      // Start with unique inventory (remove duplicates based on serialNumber)
-      const uniqueInventory = inventory.reduce((unique: InventoryItem[], item: InventoryItem) => {
-        if (!unique.some(existingItem => existingItem.serialNumber === item.serialNumber)) {
-          unique.push(item)
-        }
-        return unique
-      }, [])
-      
-      // Apply search filter to the unique inventory
-      let searchFiltered = uniqueInventory
+
+      // Apply search filter (inventory is already unique by serial number)
+      let searchFiltered = inventory
       if (searchQuery.trim()) {
         const query = searchQuery.toLowerCase()
-        searchFiltered = uniqueInventory.filter(item => {
-          try {
-            return (
-              item?.deviceName?.toLowerCase().includes(query) ||
-              item?.assetTag?.toLowerCase().includes(query) ||
-              item?.serialNumber?.toLowerCase().includes(query) ||
-              item?.computerName?.toLowerCase().includes(query) ||
-              item?.hostname?.toLowerCase().includes(query) ||
-              item?.location?.toLowerCase().includes(query) ||
-              item?.manufacturer?.toLowerCase().includes(query) ||
-              item?.model?.toLowerCase().includes(query) ||
-              item?.uuid?.toLowerCase().includes(query) ||
-              item?.domain?.toLowerCase().includes(query) ||
-              item?.organizationalUnit?.toLowerCase().includes(query)
-            )
-          } catch (e) {
-            console.warn('Error filtering item:', item, e)
-            return false
-          }
-        })
+        searchFiltered = inventory.filter(item => matchesSearch(item, query))
       }
 
       // Calculate counts from search-filtered results
@@ -400,10 +328,9 @@ function DevicesPageContent() {
       console.error('Error calculating filter counts:', e)
       return { all: 0, active: 0, stale: 0, missing: 0, assigned: 0, shared: 0, curriculum: 0, staff: 0, faculty: 0, kiosk: 0 }
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inventory, searchQuery])
 
-  const baseCounts = getBaseCounts()
-  const filterCounts = getFilterCounts()
   const isFiltered = searchQuery.trim() || statusFilter !== 'all' || usageFilter !== 'all' || catalogFilter !== 'all'
 
   if (loading) {
@@ -829,9 +756,9 @@ function DevicesPageContent() {
                             className="font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 min-w-0 flex-1"
                             title={item.deviceName || 'Unknown Device'}
                           >
-                            <FitText minFontSize={11} maxFontSize={16}>
+                            <span className="block truncate">
                               {item.deviceName || 'Unknown Device'}
-                            </FitText>
+                            </span>
                           </Link>
                           <PlatformBadge platform={item.platform || ''} size="sm" />
                         </div>
@@ -890,9 +817,9 @@ function DevicesPageContent() {
                         </div>
                       </td>
                       <td className="px-4 lg:px-6 py-4" style={{ maxWidth: '120px' }}>
-                        <FitText minFontSize={10} maxFontSize={14} className="text-gray-500 dark:text-gray-400">
+                        <span className="block truncate text-sm text-gray-500 dark:text-gray-400">
                           {item.lastSeen ? formatRelativeTime(item.lastSeen) : '-'}
-                        </FitText>
+                        </span>
                       </td>
                       <td className="px-4 lg:px-6 py-4">
                         {(() => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,34 +54,6 @@ export const viewport: Viewport = {
   ],
 };
 
-async function getDevices() {
-  try {
-    const apiUrl = process.env.API_BASE_URL || 'http://localhost:3000'
-    
-    // Add timeout to prevent blocking the entire layout
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 5000) // 5 second timeout
-    
-    const response = await fetch(`${apiUrl}/api/v1/devices`, {
-      next: { revalidate: 30 },
-      signal: controller.signal,
-    })
-    
-    clearTimeout(timeout)
-
-    if (response.ok) {
-      const data = await response.json()
-      return Array.isArray(data) ? data : (data.devices || [])
-    }
-  } catch (error) {
-    // Don't log abort errors - they're expected on timeout
-    if (error instanceof Error && error.name !== 'AbortError') {
-      console.error('[Layout] Failed to fetch devices:', error)
-    }
-  }
-  return []
-}
-
 export default async function RootLayout({
   children,
 }: {
@@ -92,8 +64,10 @@ export default async function RootLayout({
   const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
   const skipAuth = isDevelopment || isDemoMode
   
-  // Fetch devices for search preloading
-  const devices = await getDevices()
+  // No data fetching here: the layout previously awaited the full device
+  // list before rendering ANY page (an unauthenticated upstream call that
+  // 401ed and returned [] in production, costing a wasted round trip per
+  // navigation). The search components fetch on demand instead.
   
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
@@ -180,13 +154,13 @@ export default async function RootLayout({
                 <ErrorBoundary>
                   {skipAuth ? (
                     // Development/Demo: No AutoAuth component
-                    <ToolbarWrapper preloadedDevices={devices}>
+                    <ToolbarWrapper>
                       {children}
                     </ToolbarWrapper>
                   ) : (
                     // Production: Full authentication with AutoAuth
                     <AutoAuth>
-                      <ToolbarWrapper preloadedDevices={devices}>
+                      <ToolbarWrapper>
                         {children}
                       </ToolbarWrapper>
                     </AutoAuth>

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -244,10 +244,15 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
   // Bundle related events intelligently
   const bundledEvents = useMemo(() => bundleEvents(events), [events])
   
-  // Filter bundled events based on hidden types
+  // Filter bundled events based on hidden types. Rendering is capped: the
+  // dashboard holds up to 1000 events in state, and mounting a row for every
+  // one of them puts ~1000 <tr>s in a widget that shows a dozen at a time.
+  const MAX_RENDERED_EVENTS = 250
   const filteredEvents = useMemo(() => {
-    if (hiddenTypes.size === 0) return bundledEvents
-    return bundledEvents.filter(event => !hiddenTypes.has(event.kind.toLowerCase()))
+    const visible = hiddenTypes.size === 0
+      ? bundledEvents
+      : bundledEvents.filter(event => !hiddenTypes.has(event.kind.toLowerCase()))
+    return visible.slice(0, MAX_RENDERED_EVENTS)
   }, [bundledEvents, hiddenTypes])
 
   // Toggle a filter type on/off


### PR DESCRIPTION
Three independent fixes for slow initial loads on /dashboard and /devices:

- **Root layout no longer blocks every page on a dead fetch.** It awaited the full device list from the upstream API before rendering any page — but the call carried no auth headers, so in production it always 401ed and returned an empty array. Every navigation paid a wasted upstream round trip (up to the 5s timeout) for nothing. The search components already fall back to fetching on demand when no preloaded list is supplied, so the prop and fetch are removed with no behavior change.
- **Dashboard no longer prefetches the installs filters payload** (tens of MB uncompressed) in the background on every visit with a 5-minute SWR refresh. Downloading and JSON-parsing it starved the page actually on screen. The /installs page fetches it when opened, as before.
- **Devices table renders without layout thrash.** It mounted two `FitText` components per row — each running a synchronous set-fontSize/read-scrollWidth loop in an effect, roughly 1,800 forced reflows per fleet render — and recomputed its filter pipeline and counters with O(n²) dedup passes on every render and keystroke. Rows now use CSS truncation, the list is deduped once at fetch time, and `filteredInventory`/counters are memoized.

Verified with a clean production build; the two pre-existing `tsc` errors in `app/dashboard/progressive.tsx` are unchanged from main.