### PR TITLE
Report how the identity certificate is provisioned, not whether it is SCEP

### DIFF
--- a/src/components/skeleton/DeviceDetailSkeleton.tsx
+++ b/src/components/skeleton/DeviceDetailSkeleton.tsx
@@ -822,7 +822,7 @@ export function ManagementTabSkeleton() {
             <div className="h-5 w-36 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-3"></div>
             {/* Grid of status pills */}
             <div className="grid grid-cols-2 gap-4 mb-4">
-              {['ADE Enrolled', 'User Approved', 'ADE Capable', 'SCEP Certificate'].map((label, i) => (
+              {['ADE Enrolled', 'User Approved', 'ADE Capable', 'Identity Certificate'].map((label, i) => (
                 <div key={label} className="flex items-center gap-3">
                   <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse"></div>
                   <div className="h-6 w-12 bg-green-100 dark:bg-green-900 rounded-full animate-pulse" style={{ animationDelay: `${i * 0.05}s` }}></div>
@@ -898,7 +898,7 @@ export function ManagementTabSkeleton() {
               <div className="h-4 w-32 bg-green-200 dark:bg-green-900 rounded animate-pulse"></div>
             </div>
 
-            {/* SCEP Server */}
+            {/* Certificate enrollment endpoint */}
             <div>
               <div className="h-3 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse mb-1"></div>
               <div className="h-4 w-full bg-gray-50 dark:bg-gray-900 rounded animate-pulse"></div>

--- a/src/components/tabs/ManagementTab.tsx
+++ b/src/components/tabs/ManagementTab.tsx
@@ -30,6 +30,10 @@ function parseMdmCertificate(mdmCertificate: any): {
   certificate_subject?: string
   certificate_issuer?: string
   certificate_expires?: string
+  certificate_enrollment_method?: string
+  identity_payload_type?: string
+  checkin_url?: string
+  server_url?: string
   mdm_provider?: string
 } {
   if (!mdmCertificate) return {}
@@ -56,6 +60,10 @@ function parseMdmCertificate(mdmCertificate: any): {
         certificate_subject: parsed.certificate_subject,
         certificate_issuer: parsed.certificate_issuer,
         certificate_expires: parsed.certificate_expires,
+        certificate_enrollment_method: parsed.certificate_enrollment_method,
+        identity_payload_type: parsed.identity_payload_type,
+        checkin_url: parsed.checkin_url,
+        server_url: parsed.server_url,
         mdm_provider: parsed.mdm_provider
       }
     } catch (e) {
@@ -71,6 +79,10 @@ function parseMdmCertificate(mdmCertificate: any): {
     certificate_subject: mdmCertificate.certificate_subject || mdmCertificate.certificateSubject,
     certificate_issuer: mdmCertificate.certificate_issuer || mdmCertificate.certificateIssuer,
     certificate_expires: mdmCertificate.certificate_expires || mdmCertificate.certificateExpires,
+    certificate_enrollment_method: mdmCertificate.certificate_enrollment_method || mdmCertificate.certificateEnrollmentMethod,
+    identity_payload_type: mdmCertificate.identity_payload_type || mdmCertificate.identityPayloadType,
+    checkin_url: mdmCertificate.checkin_url || mdmCertificate.checkinUrl,
+    server_url: mdmCertificate.server_url || mdmCertificate.serverUrl,
     mdm_provider: mdmCertificate.mdm_provider || mdmCertificate.mdmProvider
   }
 }
@@ -257,7 +269,31 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
   
   // Parse the MDM certificate (handles nested JSON in 'output' field)
   const mdmCertificate = parseMdmCertificate(mdmCertificateRaw)
-  
+
+  // How the device's identity certificate is provisioned. Current Intune issues
+  // over ACME rather than SCEP, so a SCEP yes/no reports "No" on a perfectly
+  // healthy device. Newer clients report the method directly; fall back to the
+  // legacy SCEP boolean for devices that have not checked in with one yet.
+  const enrollmentMethod: string | null = (() => {
+    if (mdmCertificate.certificate_enrollment_method) {
+      return mdmCertificate.certificate_enrollment_method
+    }
+    if (mdmCertificate.identity_payload_type) {
+      const tail = mdmCertificate.identity_payload_type.split('.').pop() || ''
+      if (tail) return tail.toUpperCase()
+    }
+    if (parseBool(mdmEnrollment.has_scep_payload || mdmEnrollment.hasScepPayload)) return 'SCEP'
+    return null
+  })()
+
+  // The endpoint that issues the identity certificate. Named for whatever
+  // protocol is actually in use rather than assuming SCEP.
+  const enrollmentUrlLabel = enrollmentMethod === 'ACME'
+    ? 'ACME Directory'
+    : enrollmentMethod === 'SCEP'
+      ? 'SCEP Server'
+      : 'Certificate Enrollment'
+
   // Parse enrolled status - osquery returns string "true"/"false", Windows returns boolean
   const isEnrolled = parseBool(mdmEnrollment.enrolled) || 
                      parseBool(mdmEnrollment.is_enrolled) || 
@@ -666,15 +702,15 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
                     </span>
                   </div>
 
-                  {/* SCEP Payload */}
+                  {/* Identity certificate provisioning method (ACME, SCEP, PKCS12) */}
                   <div className="flex items-center gap-3">
-                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400">SCEP Certificate</span>
+                    <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Identity Certificate</span>
                     <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                      parseBool(mdmEnrollment.has_scep_payload || mdmEnrollment.hasScepPayload)
+                      enrollmentMethod
                         ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300'
                         : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'
                     }`}>
-                      {parseBool(mdmEnrollment.has_scep_payload || mdmEnrollment.hasScepPayload) ? 'Yes' : 'No'}
+                      {enrollmentMethod ?? 'Unknown'}
                     </span>
                   </div>
                 </div>
@@ -1058,10 +1094,10 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
                       </div>
                     )}
 
-                    {/* SCEP Server URL */}
+                    {/* Certificate enrollment endpoint - ACME directory or SCEP server */}
                     {mdmCertificate.scep_url && (
                       <div>
-                        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">SCEP Server</div>
+                        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">{enrollmentUrlLabel}</div>
                         <div className="flex items-center gap-2">
                           <span className="text-xs font-mono text-gray-900 dark:text-white break-all">
                             {mdmCertificate.scep_url}

--- a/src/lib/data-processing/modules/management.ts
+++ b/src/lib/data-processing/modules/management.ts
@@ -50,7 +50,17 @@ export interface MdmEnrollmentInfo {
   depCapable?: boolean          // Mac: Device is DEP/ADE capable
   installedFromDep?: boolean    // Mac: Enrolled via ADE (formerly DEP)
   accessRights?: number         // Mac: MDM access rights bitmask
-  hasScepPayload?: boolean      // Mac: Has SCEP certificate payload
+  /**
+   * Mac: has a SCEP certificate payload. Superseded by
+   * `certificateEnrollmentMethod` - current Intune provisions the identity
+   * certificate over ACME, so this is false on healthy devices. Kept for
+   * devices that have not yet checked in with a client that reports the method.
+   */
+  hasScepPayload?: boolean
+  /** Mac: how the identity certificate is provisioned - ACME, SCEP or PKCS12 */
+  certificateEnrollmentMethod?: string
+  /** Mac: raw payload type backing the method, e.g. com.apple.security.acme */
+  identityPayloadType?: string
 }
 
 export interface DomainInfo {
@@ -278,7 +288,9 @@ function mapMdmEnrollment(mdm: any): MdmEnrollmentInfo {
     depCapable: parseBool(mdm.dep_capable || mdm.depCapable),
     installedFromDep: parseBool(mdm.installed_from_dep || mdm.installedFromDep),
     accessRights: parseInt(mdm.access_rights || mdm.accessRights) || undefined,
-    hasScepPayload: parseBool(mdm.has_scep_payload || mdm.hasScepPayload)
+    hasScepPayload: parseBool(mdm.has_scep_payload || mdm.hasScepPayload),
+    certificateEnrollmentMethod: mdm.certificate_enrollment_method || mdm.certificateEnrollmentMethod,
+    identityPayloadType: mdm.identity_payload_type || mdm.identityPayloadType
   }
 }
 


### PR DESCRIPTION
Companion to reportmate/reportmate-client-mac#25, which fixes the collector.

The management view rendered a hardcoded `SCEP Certificate` yes/no, backed by a `hasScepPayload` boolean. There was no concept of an enrollment method in the type at all, so ACME could not be expressed even if the device reported it. Current Intune provisions the device identity certificate over **ACME**, so that row reads `No` on a perfectly healthy Mac — the field asks the wrong question rather than getting the answer wrong.

This reports the method itself — ACME, SCEP or PKCS12 — from the payload type the client now resolves out of the MDM enrollment profile. The certificate enrollment endpoint is labelled for whichever protocol is actually in use (`ACME Directory` / `SCEP Server`) instead of being called a SCEP server unconditionally, and the skeleton labels match so the loading state does not flip.

## Backwards compatibility

Devices that have not yet checked in with a client reporting the method fall back to the existing `hasScepPayload` boolean and keep showing `SCEP`, rather than going blank. `hasScepPayload` is retained and documented as superseded rather than removed.

The method is resolved in this order: the reported `certificate_enrollment_method`, then the raw `identity_payload_type` (last dot-component, uppercased) as a forward-compatible fallback for payload types that do not have a friendly name yet, then the legacy boolean, then `Unknown`.

## Verification

`npx tsc --noEmit` is clean on the changed files; the only output is the pre-existing `baseUrl` deprecation warning from tsconfig.

Not yet exercised against a live payload from a merged client build. On the test device the client reports `certificate_enrollment_method: ACME` and `identity_payload_type: com.apple.security.acme`, which is what this renders.