### PR TITLE
Fetch the module endpoint the page asked for, not the API root

### DIFF
--- a/src/hooks/useDeviceData.ts
+++ b/src/hooks/useDeviceData.ts
@@ -110,7 +110,7 @@ export function useDeviceData(options: UseDeviceDataOptions = {}): UseDeviceData
         const startTime = Date.now()
         console.log(`[useDeviceData] Fetching ${moduleType} module data... (attempt ${attempt}/${maxRetries})`)
         
-        const response = await fetch(`/api/v1/`, {
+        const response = await fetch(`/api/v1/${moduleType}`, {
           cache: 'no-store',
           headers: {
             'Cache-Control': 'no-cache',


### PR DESCRIPTION
The /api/modules/<type> to /api/v1/<type> BFF consolidation (#25) lost the `${moduleType}` variable in this hook's fetch URL, leaving a literal `/api/v1/` — a route that does not exist. Every report page that requests module data through `useDeviceData` (the system report, notably) got a 404, exhausted its retries, and rendered empty widgets and an empty table while the underlying API data was fine (verified: `/api/v1/system` returns 875 complete records). One-line fix restores the intended URL. Clean production build.