### PR TITLE
Label the transport rejection reasons on the failures view

### DIFF
--- a/app/events/failures/ClientFailuresPage.tsx
+++ b/app/events/failures/ClientFailuresPage.tsx
@@ -38,6 +38,9 @@ const REASON_LABELS: Record<string, string> = {
   invalid_internal_secret: 'Wrong internal secret',
   missing_credentials: 'No credentials',
   insufficient_scope: 'Missing scope',
+  upload_aborted: 'Upload aborted',
+  body_unreadable: 'Body unreadable',
+  empty_body: 'Empty body',
   malformed_json: 'Malformed JSON',
   invalid_payload: 'Invalid payload',
   empty_serial: 'Empty serial',
@@ -45,6 +48,8 @@ const REASON_LABELS: Record<string, string> = {
   short_serial: 'Serial too short',
   hostname_serial: 'Hostname as serial',
   letters_only_serial: 'Hostname-like serial',
+  serial_equals_hostname: 'Serial matches hostname',
+  usage_out_of_bounds: 'Usage out of bounds',
 }
 
 const HOURS_OPTIONS = [


### PR DESCRIPTION
reportmate/reportmate-api#40 splits ingest rejections that were all being filed under `malformed_json` into `upload_aborted`, `body_unreadable`, `empty_body` and `malformed_json`, so the failures view can tell a network problem from a client-serializer problem.

`reasonLabel` falls through to the raw code for anything unmapped, so the new codes would render as `upload_aborted`. This adds the three, plus `serial_equals_hostname` and `usage_out_of_bounds`, which the API already emits today and which have been rendering raw for the same reason.
