### PR TITLE
Make the Selections accordion consistent across reports and rebuild the peripherals table

### DIFF
--- a/app/devices/ClientDevicesPage.tsx
+++ b/app/devices/ClientDevicesPage.tsx
@@ -359,75 +359,78 @@ function DevicesPageContent() {
           {/* Content skeleton */}
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-4 sm:pb-8 pt-4 sm:pt-8">
             <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-              {/* Header section skeleton */}
+              {/* Header section skeleton — title, subtitle, search box */}
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-                <div>
-                  <div className="h-5 bg-gray-300 dark:bg-gray-600 rounded w-24 mb-2"></div>
-                  <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-48"></div>
+                <div className="space-y-2">
+                  <div className="h-6 bg-gray-300 dark:bg-gray-600 rounded w-64"></div>
+                  <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-72"></div>
                 </div>
-                <div className="h-10 bg-gray-300 dark:bg-gray-600 rounded w-64"></div>
-              </div>
-              
-              {/* Selections accordion skeleton */}
-              <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-3 flex items-center justify-between">
-                <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
-                <div className="h-4 w-4 bg-gray-300 dark:bg-gray-600 rounded"></div>
+                <div className="h-9 bg-gray-300 dark:bg-gray-600 rounded-lg w-64"></div>
               </div>
 
-              {/* Table skeleton */}
+              {/* Selections accordion skeleton — collapsed, matching the real header bar */}
+              <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-3 flex items-center justify-between">
+                <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
+                <div className="h-5 w-5 bg-gray-300 dark:bg-gray-600 rounded"></div>
+              </div>
+
+              {/* Table skeleton — same eight columns the loaded table renders */}
               <div className="overflow-auto max-h-[calc(100vh-16rem)] table-scrollbar">
                 <table className="w-full relative">
                   <thead className="bg-gray-50 dark:bg-gray-700 sticky top-0 z-10 shadow-sm">
                     <tr>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-16"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-24"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-12"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-14"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-16"></div>
-                      </th>
-                      <th className="px-4 lg:px-6 py-3">
-                        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-12"></div>
-                      </th>
+                      {['w-24', 'w-16', 'w-24', 'w-12', 'w-14', 'w-16', 'w-16', 'w-12'].map((width, i) => (
+                        <th key={i} className="px-4 lg:px-6 py-3 text-left">
+                          <div className={`h-3 bg-gray-300 dark:bg-gray-600 rounded ${width}`}></div>
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                    {[...Array(8)].map((_, i) => (
+                    {/* Enough rows to fill a typical viewport, so the card does not
+                        visibly grow when the real rows arrive */}
+                    {[...Array(15)].map((_, i) => (
                       <tr key={i}>
+                        {/* Device name + platform badge */}
                         <td className="px-4 lg:px-6 py-4">
-                          <div className="space-y-2">
+                          <div className="flex items-center gap-2">
                             <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-32"></div>
-                            <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-24"></div>
+                            <div className="h-4 w-4 bg-gray-300 dark:bg-gray-600 rounded flex-shrink-0"></div>
                           </div>
                         </td>
+                        {/* Asset tag + copy button */}
+                        <td className="px-4 lg:px-6 py-4">
+                          <div className="flex items-center gap-2">
+                            <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
+                            <div className="h-3 w-3 bg-gray-300 dark:bg-gray-600 rounded flex-shrink-0"></div>
+                          </div>
+                        </td>
+                        {/* Serial number + copy button */}
+                        <td className="px-4 lg:px-6 py-4">
+                          <div className="flex items-center gap-2">
+                            <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-24"></div>
+                            <div className="h-3 w-3 bg-gray-300 dark:bg-gray-600 rounded flex-shrink-0"></div>
+                          </div>
+                        </td>
+                        {/* Usage pill */}
+                        <td className="px-4 lg:px-6 py-4">
+                          <div className="h-5 bg-gray-300 dark:bg-gray-600 rounded-full w-16"></div>
+                        </td>
+                        {/* Catalog pill */}
+                        <td className="px-4 lg:px-6 py-4">
+                          <div className="h-5 bg-gray-300 dark:bg-gray-600 rounded-full w-20"></div>
+                        </td>
+                        {/* Location */}
+                        <td className="px-4 lg:px-6 py-4">
+                          <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-12"></div>
+                        </td>
+                        {/* Last seen */}
                         <td className="px-4 lg:px-6 py-4">
                           <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
                         </td>
+                        {/* Status */}
                         <td className="px-4 lg:px-6 py-4">
-                          <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-28"></div>
-                        </td>
-                        <td className="px-4 lg:px-6 py-4">
-                          <div className="h-6 bg-gray-300 dark:bg-gray-600 rounded-full w-16"></div>
-                        </td>
-                        <td className="px-4 lg:px-6 py-4">
-                          <div className="h-6 bg-gray-300 dark:bg-gray-600 rounded-full w-18"></div>
-                        </td>
-                        <td className="px-4 lg:px-6 py-4">
-                          <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-24"></div>
-                        </td>
-                        <td className="px-4 lg:px-6 py-4">
-                          <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-8"></div>
+                          <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-12"></div>
                         </td>
                       </tr>
                     ))}

--- a/app/devices/ClientDevicesPage.tsx
+++ b/app/devices/ClientDevicesPage.tsx
@@ -9,6 +9,8 @@ import { CopyButton } from "../../src/components/ui/CopyButton"
 import { normalizeKeys } from "../../src/lib/utils/powershell-parser"
 import { PlatformBadge } from "../../src/components/ui/PlatformBadge"
 import { usePlatformFilterSafe, getDevicePlatform } from "../../src/providers/PlatformFilterProvider"
+import DeviceFilters, { FilterOptions } from "../../src/components/shared/DeviceFilters"
+import { useScrollCollapse } from "../../src/hooks/useScrollCollapse"
 
 interface InventoryItem {
   id: string
@@ -22,6 +24,9 @@ interface InventoryItem {
   location?: string
   usage?: string
   catalog?: string
+  department?: string
+  area?: string
+  fleet?: string
   computerName?: string
   hostname?: string
   domain?: string
@@ -34,41 +39,72 @@ interface InventoryItem {
   raw?: any
 }
 
+// Case-insensitive membership test — selections come from URL params and from
+// inventory values that differ in casing between platforms.
+const includesCI = (list: string[], value?: string | null) =>
+  list.some(v => v.toLowerCase() === (value || '').toLowerCase())
+
 function DevicesPageContent() {
   const [inventory, setInventory] = useState<InventoryItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
-  const [statusFilter, setStatusFilter] = useState<string>('all')
-  const [usageFilter, setUsageFilter] = useState<string>('all')
-  const [catalogFilter, setCatalogFilter] = useState<string>('all')
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([])
+  const [selectedUsages, setSelectedUsages] = useState<string[]>([])
+  const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
+  const [selectedAreas, setSelectedAreas] = useState<string[]>([])
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([])
+  const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const [filtersExpanded, setFiltersExpanded] = useState(false)
   const [sortColumn, setSortColumn] = useState<string>('deviceName')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
   const searchParams = useSearchParams()
   const { platformFilter, isPlatformVisible } = usePlatformFilterSafe()
 
-  // Initialize search query and filters from URL parameters
+  const { tableContainerRef, effectiveFiltersExpanded } = useScrollCollapse(
+    { filters: filtersExpanded },
+    { enabled: !loading }
+  )
+
+  const toggleIn = (setter: React.Dispatch<React.SetStateAction<string[]>>) => (value: string) =>
+    setter(prev => (includesCI(prev, value) ? prev.filter(v => v.toLowerCase() !== value.toLowerCase()) : [...prev, value]))
+
+  const toggleStatus = toggleIn(setSelectedStatuses)
+  const toggleUsage = toggleIn(setSelectedUsages)
+  const toggleCatalog = toggleIn(setSelectedCatalogs)
+  const toggleArea = toggleIn(setSelectedAreas)
+  const toggleLocation = toggleIn(setSelectedLocations)
+  const toggleFleet = toggleIn(setSelectedFleets)
+
+  const clearAllSelections = () => {
+    setSelectedStatuses([]); setSelectedUsages([]); setSelectedCatalogs([])
+    setSelectedAreas([]); setSelectedLocations([]); setSelectedFleets([])
+  }
+
+  // Initialize search query and selections from URL parameters. Each dimension
+  // accepts a comma-separated list so deep links can preselect more than one pill.
   useEffect(() => {
     try {
       const urlSearch = searchParams.get('search')
       if (urlSearch) {
         setSearchQuery(urlSearch)
       }
-      
-      const urlStatus = searchParams.get('status')
-      if (urlStatus && ['active', 'stale', 'missing'].includes(urlStatus.toLowerCase())) {
-        setStatusFilter(urlStatus.toLowerCase())
-      }
-      
-      const urlUsage = searchParams.get('usage')
-      if (urlUsage && ['assigned', 'shared'].includes(urlUsage.toLowerCase())) {
-        setUsageFilter(urlUsage.toLowerCase())
-      }
 
-      const urlCatalog = searchParams.get('catalog')
-      if (urlCatalog && ['curriculum', 'staff', 'faculty', 'kiosk'].includes(urlCatalog.toLowerCase())) {
-        setCatalogFilter(urlCatalog.toLowerCase())
-      }
+      const list = (key: string) =>
+        (searchParams.get(key) || '').split(',').map(v => v.trim()).filter(Boolean)
+
+      const status = list('status')
+      if (status.length) setSelectedStatuses(status)
+      const usage = list('usage')
+      if (usage.length) setSelectedUsages(usage)
+      const catalog = list('catalog')
+      if (catalog.length) setSelectedCatalogs(catalog)
+      const area = list('area')
+      if (area.length) setSelectedAreas(area)
+      const location = list('location')
+      if (location.length) setSelectedLocations(location)
+      const fleet = list('fleet')
+      if (fleet.length) setSelectedFleets(fleet)
     } catch (e) {
       console.warn('Failed to get search params:', e)
     }
@@ -112,6 +148,10 @@ function DevicesPageContent() {
               usage: inventory.usage,
               catalog: inventory.catalog,
               department: inventory.department,
+              // Area is a distinct inventory dimension where collected; every
+              // other report falls back to department, so match that here.
+              area: inventory.area || inventory.department,
+              fleet: inventory.fleet,
               owner: inventory.owner,
               computerName: inventory.deviceName,
               hostname: device.hostname || device.modules?.network?.hostname,
@@ -173,28 +213,28 @@ function DevicesPageContent() {
         return []
       }
 
-      let filtered = inventory
+      // Archived devices are never listed here regardless of selections
+      let filtered = inventory.filter(item => !item.archived)
 
-      // Apply status filter first
-      if (statusFilter !== 'all') {
-        // Show non-archived devices matching the status
-        filtered = filtered.filter(item => {
-          if (item.archived) return false // Never show archived in status filters
-          return item.raw?.status?.toLowerCase() === statusFilter
-        })
-      } else {
-        // If status is 'all', exclude archived devices by default
-        filtered = filtered.filter(item => !item.archived)
+      // Apply the Selections accordion dimensions (multi-select, OR within a
+      // dimension and AND across dimensions)
+      if (selectedStatuses.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedStatuses, item.raw?.status))
       }
-
-      // Apply usage filter
-      if (usageFilter !== 'all') {
-        filtered = filtered.filter(item => item.usage?.toLowerCase() === usageFilter)
+      if (selectedUsages.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedUsages, item.usage))
       }
-
-      // Apply catalog filter
-      if (catalogFilter !== 'all') {
-        filtered = filtered.filter(item => item.catalog?.toLowerCase() === catalogFilter)
+      if (selectedCatalogs.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedCatalogs, item.catalog))
+      }
+      if (selectedAreas.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedAreas, item.area || item.department))
+      }
+      if (selectedLocations.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedLocations, item.location))
+      }
+      if (selectedFleets.length > 0) {
+        filtered = filtered.filter(item => includesCI(selectedFleets, item.fleet))
       }
 
       // Apply global platform filter
@@ -262,7 +302,8 @@ function DevicesPageContent() {
       return []
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inventory, statusFilter, usageFilter, catalogFilter, platformFilter, isPlatformVisible, searchQuery, sortColumn, sortDirection])
+  }, [inventory, selectedStatuses, selectedUsages, selectedCatalogs, selectedAreas, selectedLocations,
+      selectedFleets, platformFilter, isPlatformVisible, searchQuery, sortColumn, sortDirection])
 
   // Handle column header click for sorting
   const handleSort = (column: string) => {
@@ -279,59 +320,37 @@ function DevicesPageContent() {
   // Base count (without filters) for reference; inventory is already unique.
   const baseCounts = useMemo(() => ({ all: Array.isArray(inventory) ? inventory.length : 0 }), [inventory])
 
-  // Filter counts from search-filtered inventory (dynamic based on current search)
-  const filterCounts = useMemo(() => {
-    try {
-      if (!Array.isArray(inventory)) return {
-        all: 0, active: 0, stale: 0, missing: 0, assigned: 0, shared: 0, curriculum: 0, staff: 0, faculty: 0, kiosk: 0
-      }
-
-      // Apply search filter (inventory is already unique by serial number)
-      let searchFiltered = inventory
-      if (searchQuery.trim()) {
-        const query = searchQuery.toLowerCase()
-        searchFiltered = inventory.filter(item => matchesSearch(item, query))
-      }
-
-      // Calculate counts from search-filtered results
-      return {
-        all: searchFiltered.filter(item => !item.archived).length,
-        active: searchFiltered.filter(item => 
-          item.raw?.status?.toLowerCase() === 'active'
-        ).length,
-        stale: searchFiltered.filter(item => 
-          item.raw?.status?.toLowerCase() === 'stale'
-        ).length,
-        missing: searchFiltered.filter(item => 
-          item.raw?.status?.toLowerCase() === 'missing'
-        ).length,
-        assigned: searchFiltered.filter(item =>
-          item.usage?.toLowerCase() === 'assigned'
-        ).length,
-        shared: searchFiltered.filter(item => 
-          item.usage?.toLowerCase() === 'shared'
-        ).length,
-        curriculum: searchFiltered.filter(item => 
-          item.catalog?.toLowerCase() === 'curriculum'
-        ).length,
-        staff: searchFiltered.filter(item => 
-          item.catalog?.toLowerCase() === 'staff'
-        ).length,
-        faculty: searchFiltered.filter(item => 
-          item.catalog?.toLowerCase() === 'faculty'
-        ).length,
-        kiosk: searchFiltered.filter(item => 
-          item.catalog?.toLowerCase() === 'kiosk'
-        ).length,
-      }
-    } catch (e) {
-      console.error('Error calculating filter counts:', e)
-      return { all: 0, active: 0, stale: 0, missing: 0, assigned: 0, shared: 0, curriculum: 0, staff: 0, faculty: 0, kiosk: 0 }
+  // Options offered by the Selections accordion, drawn from the live inventory
+  // so a dimension with no collected data hides itself rather than showing
+  // dead pills.
+  const filterOptions: FilterOptions = useMemo(() => {
+    const active = Array.isArray(inventory) ? inventory.filter(i => !i.archived) : []
+    const distinct = (pick: (item: InventoryItem) => string | undefined | null) =>
+      Array.from(new Set(active.map(pick).filter(Boolean) as string[])).sort()
+    return {
+      statuses: distinct(i => i.raw?.status),
+      usages: distinct(i => i.usage),
+      catalogs: distinct(i => i.catalog),
+      areas: distinct(i => i.area || i.department),
+      locations: distinct(i => i.location),
+      fleets: distinct(i => i.fleet),
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inventory, searchQuery])
+  }, [inventory])
 
-  const isFiltered = searchQuery.trim() || statusFilter !== 'all' || usageFilter !== 'all' || catalogFilter !== 'all'
+  // Device count per location drives proportional pill sizing in the accordion
+  const locationCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    if (Array.isArray(inventory)) {
+      inventory.forEach(item => {
+        if (!item.archived && item.location) counts[item.location] = (counts[item.location] || 0) + 1
+      })
+    }
+    return counts
+  }, [inventory])
+
+  const totalSelections = selectedStatuses.length + selectedUsages.length + selectedCatalogs.length +
+    selectedAreas.length + selectedLocations.length + selectedFleets.length
+  const isFiltered = Boolean(searchQuery.trim()) || totalSelections > 0
 
   if (loading) {
     return (
@@ -349,13 +368,10 @@ function DevicesPageContent() {
                 <div className="h-10 bg-gray-300 dark:bg-gray-600 rounded w-64"></div>
               </div>
               
-              {/* Filter buttons skeleton */}
-              <div className="border-b border-gray-200 dark:border-gray-600 px-4 lg:px-6 py-3 bg-gray-50 dark:bg-gray-700">
-                <div className="flex flex-wrap gap-2">
-                  {[...Array(6)].map((_, i) => (
-                    <div key={i} className="h-8 bg-gray-300 dark:bg-gray-600 rounded-lg w-20"></div>
-                  ))}
-                </div>
+              {/* Selections accordion skeleton */}
+              <div className="border-b border-gray-200 dark:border-gray-700 px-6 py-3 flex items-center justify-between">
+                <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-20"></div>
+                <div className="h-4 w-4 bg-gray-300 dark:bg-gray-600 rounded"></div>
               </div>
 
               {/* Table skeleton */}
@@ -493,112 +509,30 @@ function DevicesPageContent() {
               </div>
             </div>
             
-            {/* Filter Row */}
-            <div className="border-b border-gray-200 dark:border-gray-600 px-4 lg:px-6 py-3 bg-gray-50 dark:bg-gray-700">
-              <nav className="flex flex-wrap gap-2 items-center">
-                {/* Status Filters */}
-                {[
-                  { key: 'active', label: 'Active', count: filterCounts.active, type: 'status', colors: 'bg-emerald-100 text-emerald-700 border-emerald-300 hover:bg-emerald-200 dark:bg-emerald-900 dark:text-emerald-300 dark:border-emerald-600 dark:hover:bg-emerald-800' },
-                  { key: 'stale', label: 'Stale', count: filterCounts.stale, type: 'status', colors: 'bg-amber-100 text-amber-700 border-amber-300 hover:bg-amber-200 dark:bg-amber-900 dark:text-amber-300 dark:border-amber-600 dark:hover:bg-amber-800' },
-                  { key: 'missing', label: 'Missing', count: filterCounts.missing, type: 'status', colors: 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 dark:hover:bg-gray-800' },
-                ].map((filter) => {
-                  const isActive = statusFilter === filter.key
-                  
-                  return (
-                    <button
-                      key={filter.key}
-                      onClick={() => setStatusFilter(statusFilter === filter.key ? 'all' : filter.key)}
-                      className={`${
-                        isActive
-                          ? filter.colors
-                          : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                      } px-3 py-1.5 border rounded-lg text-sm font-medium flex items-center gap-2 transition-colors`}
-                    >
-                      <span>{filter.label}</span>
-                      <span className={`${
-                        isActive 
-                          ? 'bg-white/20 text-current'
-                          : 'bg-gray-200 text-gray-700 dark:bg-gray-500 dark:text-gray-200'
-                      } inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ml-1`}>
-                        {filter.count}
-                      </span>
-                    </button>
-                  )
-                })}
-                
-                {/* Separator - Status/Usage */}
-                <div className="flex items-center px-2">
-                  <div className="h-6 w-px bg-gradient-to-b from-transparent via-gray-300 to-transparent dark:via-gray-500"></div>
-                </div>
-                
-                {/* Usage Filters */}
-                {[
-                  { key: 'assigned', label: 'Assigned', count: filterCounts.assigned, type: 'usage', colors: 'bg-yellow-100 text-yellow-700 border-yellow-300 hover:bg-yellow-200 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-600 dark:hover:bg-yellow-800' },
-                  { key: 'shared', label: 'Shared', count: filterCounts.shared, type: 'usage', colors: 'bg-blue-100 text-blue-700 border-blue-300 hover:bg-blue-200 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-600 dark:hover:bg-blue-800' },
-                ].map((filter) => {
-                  const isActive = usageFilter === filter.key
-                  
-                  return (
-                    <button
-                      key={filter.key}
-                      onClick={() => setUsageFilter(usageFilter === filter.key ? 'all' : filter.key)}
-                      className={`${
-                        isActive
-                          ? filter.colors
-                          : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                      } px-3 py-1.5 border rounded-lg text-sm font-medium flex items-center gap-2 transition-colors`}
-                    >
-                      <span>{filter.label}</span>
-                      <span className={`${
-                        isActive 
-                          ? 'bg-white/20 text-current'
-                          : 'bg-gray-200 text-gray-700 dark:bg-gray-500 dark:text-gray-200'
-                      } inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ml-1`}>
-                        {filter.count}
-                      </span>
-                    </button>
-                  )
-                })}
-                
-                {/* Separator - Usage/Catalog */}
-                <div className="flex items-center px-2">
-                  <div className="h-6 w-px bg-gradient-to-b from-transparent via-gray-300 to-transparent dark:via-gray-500"></div>
-                </div>
-                
-                {/* Catalog Filters */}
-                {[
-                  { key: 'curriculum', label: 'Curriculum', count: filterCounts.curriculum, type: 'catalog', colors: 'bg-teal-100 text-teal-700 border-teal-300 hover:bg-teal-200 dark:bg-teal-900 dark:text-teal-300 dark:border-teal-600 dark:hover:bg-teal-800' },
-                  { key: 'staff', label: 'Staff', count: filterCounts.staff, type: 'catalog', colors: 'bg-orange-100 text-orange-700 border-orange-300 hover:bg-orange-200 dark:bg-orange-900 dark:text-orange-300 dark:border-orange-600 dark:hover:bg-orange-800' },
-                  { key: 'faculty', label: 'Faculty', count: filterCounts.faculty, type: 'catalog', colors: 'bg-red-100 text-red-700 border-red-300 hover:bg-red-200 dark:bg-red-900 dark:text-red-300 dark:border-red-600 dark:hover:bg-red-800' },
-                  { key: 'kiosk', label: 'Kiosk', count: filterCounts.kiosk, type: 'catalog', colors: 'bg-cyan-100 text-cyan-700 border-cyan-300 hover:bg-cyan-200 dark:bg-cyan-900 dark:text-cyan-300 dark:border-cyan-600 dark:hover:bg-cyan-800' },
-                ].map((filter) => {
-                  const isActive = catalogFilter === filter.key
-                  
-                  return (
-                    <button
-                      key={filter.key}
-                      onClick={() => setCatalogFilter(catalogFilter === filter.key ? 'all' : filter.key)}
-                      className={`${
-                        isActive
-                          ? filter.colors
-                          : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                      } px-3 py-1.5 border rounded-lg text-sm font-medium flex items-center gap-2 transition-colors`}
-                    >
-                      <span>{filter.label}</span>
-                      <span className={`${
-                        isActive 
-                          ? 'bg-white/20 text-current'
-                          : 'bg-gray-200 text-gray-700 dark:bg-gray-500 dark:text-gray-200'
-                      } inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ml-1`}>
-                        {filter.count}
-                      </span>
-                    </button>
-                  )
-                })}
-              </nav>
-            </div>
+            {/* Selections accordion (shared component, same as every other report) */}
+            <DeviceFilters
+              filterOptions={filterOptions}
+              selectedStatuses={selectedStatuses}
+              selectedCatalogs={selectedCatalogs}
+              selectedAreas={selectedAreas}
+              selectedLocations={selectedLocations}
+              selectedFleets={selectedFleets}
+              selectedUsages={selectedUsages}
+              onStatusToggle={toggleStatus}
+              onCatalogToggle={toggleCatalog}
+              onAreaToggle={toggleArea}
+              onLocationToggle={toggleLocation}
+              onFleetToggle={toggleFleet}
+              onUsageToggle={toggleUsage}
+              onClearAll={clearAllSelections}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              expanded={effectiveFiltersExpanded}
+              onToggle={() => setFiltersExpanded(!filtersExpanded)}
+              locationCounts={locationCounts}
+            />
 
-            <div className="overflow-auto max-h-[calc(100vh-16rem)] table-scrollbar">
+            <div ref={tableContainerRef} className="overflow-auto max-h-[calc(100vh-16rem)] table-scrollbar">
               <table className="w-full relative">
                 <thead className="bg-gray-50 dark:bg-gray-700 sticky top-0 z-10 shadow-sm">
                   <tr>

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -234,9 +234,25 @@ function EventsPageContent() {
   const offsetRef = useRef(0)
   const fetchEventsRef = useRef<typeof fetchEvents | null>(null)
   
-  // Cache all fetched events for instant client-side filter switching
+  // Cache every event fetched for the current date window, keyed by id. Type
+  // toggles are answered from this cache so the table re-renders in the same
+  // frame; the server round-trip only tops the cache up in the background.
   const allEventsCache = useRef<Event[]>([])
-  
+  // Debounce handle for the background top-up fetch that follows a type toggle
+  const filterFetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Merge a freshly fetched page into the cache, de-duplicating by event id and
+  // keeping the newest-first order the table renders in.
+  const mergeIntoCache = useCallback((incoming: Event[]) => {
+    const byId = new Map<string, Event>()
+    for (const event of allEventsCache.current) byId.set(event.id, event)
+    for (const event of incoming) byId.set(event.id, event)
+    const merged = Array.from(byId.values())
+      .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+    allEventsCache.current = merged
+    return merged
+  }, [])
+
   // Date range state (default to last 48 hours)
   const [startDate, setStartDate] = useState(() => {
     const date = new Date()
@@ -292,10 +308,11 @@ function EventsPageContent() {
       if (isLoadMore) {
         setLoadingMore(true)
       } else if (!isFilterChange) {
-        // For filter changes keep old events visible; only show full skeleton on date/mount resets
+        // A type toggle never shows a skeleton — the cache already answered it.
+        // Only date/mount resets, which genuinely have nothing to show, do.
         setLoading(true)
       }
-      
+
       // Build query parameters
       const queryParams = new URLSearchParams()
       queryParams.append('limit', EVENTS_PER_PAGE.toString())
@@ -333,15 +350,11 @@ function EventsPageContent() {
           VALID_EVENT_KINDS.includes(event.kind?.toLowerCase())
         )
         
-        if (isLoadMore) {
-          // Append to existing events
-          setEvents(prev => [...prev, ...newEvents])
-        } else {
-          // Replace events (initial load or filter change)
-          setEvents(newEvents)
-          allEventsCache.current = newEvents
-        }
-        
+        // Always merge rather than replace: a type toggle re-queries the server
+        // with a different type set, and replacing would throw away events the
+        // user can toggle straight back on.
+        setEvents(mergeIntoCache(newEvents))
+
         // Check if there are more events to load
         setHasMore(newEvents.length >= EVENTS_PER_PAGE)
         
@@ -363,7 +376,7 @@ function EventsPageContent() {
       setLoading(false)
       setLoadingMore(false)
     }
-  }, [startDate, endDate, activeFilters, EVENTS_PER_PAGE])
+  }, [startDate, endDate, activeFilters, EVENTS_PER_PAGE, mergeIntoCache])
 
   // Initial fetch on mount or date range change (full skeleton)
   useEffect(() => {
@@ -375,15 +388,25 @@ function EventsPageContent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [startDate, endDate])
 
-  // Re-fetch when active filters change — keep old events visible until new results arrive
+  // A type toggle is answered client-side from the cache and repaints immediately.
+  // The server round-trip that follows only re-densifies the page — it is
+  // debounced so flipping several pills in a row costs one request, not one each.
   const prevActiveFilters = useRef(activeFilters)
   useEffect(() => {
-    if (prevActiveFilters.current !== activeFilters) {
-      prevActiveFilters.current = activeFilters
-      // Don't blank the table; swap events in once the first page of new results arrives
+    if (prevActiveFilters.current === activeFilters) return
+    prevActiveFilters.current = activeFilters
+
+    if (filterFetchTimer.current) clearTimeout(filterFetchTimer.current)
+    // Nothing selected renders an empty table, so there is nothing to top up
+    if (activeFilters.size === 0) return
+    filterFetchTimer.current = setTimeout(() => {
       setOffset(0)
       setHasMore(true)
       fetchEvents(0, false, activeFilters, true)
+    }, 300)
+
+    return () => {
+      if (filterFetchTimer.current) clearTimeout(filterFetchTimer.current)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeFilters])
@@ -422,8 +445,9 @@ function EventsPageContent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // stable — reads live values through refs
 
-  // Filter events based on platform, selected type and search query (client-side)
-  const filteredEvents = bundledEvents.filter(event => {
+  // Filter events by platform, selected type and search query — all client-side,
+  // so toggling a type pill repaints in the same frame instead of waiting on the API.
+  const filteredEvents = useMemo(() => bundledEvents.filter(event => {
     // Filter by platform first (global filter)
     if (platformFilter) {
       const eventPlatform = normalizePlatform((event as any).platform)
@@ -431,17 +455,23 @@ function EventsPageContent() {
         return false
       }
     }
-    
-    // Type filter is now handled server-side; always pass (for search + platform)
-    const typeMatch = true
-    
+
+    // A bundle matches when any of the kinds it rolled up is still selected
+    if (activeFilters.size > 0) {
+      const kinds = event.bundledKinds?.length ? event.bundledKinds : [event.kind]
+      if (!kinds.some(kind => activeFilters.has(kind?.toLowerCase()))) return false
+    } else {
+      // Every type deselected means nothing to show
+      return false
+    }
+
     // Then filter by search query if provided
     if (!searchQuery.trim()) {
-      return typeMatch
+      return true
     }
-    
+
     const query = searchQuery.toLowerCase()
-    const searchMatch = (
+    return (
       event.id.toLowerCase().includes(query) ||
       event.device.toLowerCase().includes(query) ||
       (event.bundledKinds || []).some(kind => kind.toLowerCase().includes(query)) ||
@@ -449,9 +479,8 @@ function EventsPageContent() {
       (event.deviceName && event.deviceName.toLowerCase().includes(query)) ||
       (event.assetTag && event.assetTag.toLowerCase().includes(query))
     )
-    
-    return typeMatch && searchMatch
-  })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [bundledEvents, platformFilter, isPlatformVisible, activeFilters, searchQuery])
 
   // currentEvents is just filteredEvents for infinite scroll (no client-side pagination)
   const currentEvents = filteredEvents

--- a/app/hardware/page.tsx
+++ b/app/hardware/page.tsx
@@ -12,6 +12,7 @@ import { CollapsibleSection } from "@/src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "@/src/hooks/useScrollCollapse"
 import { useDeviceData } from "@/src/hooks/useDeviceData"
 import DeviceFilters, { FilterOptions } from "@/src/components/shared/DeviceFilters"
+import { calculateDeviceStatus } from "@/src/lib/data-processing"
 import { 
   ArchitectureDonutChart, 
   MemoryBreakdownChart, 
@@ -101,7 +102,9 @@ function HardwarePageContent() {
 
   // Filter options computed from inventory data
   const filterOptions: FilterOptions = {
-    statuses: ['Active', 'Stale', 'Missing'],
+    statuses: Array.from(new Set(
+      hardware.map(h => calculateDeviceStatus((h as any).lastSeen || (h as any).collectedAt))
+    )).sort(),
     usages: Array.from(new Set(
       allDevices.map((d: any) => d.modules?.inventory?.usage).filter(Boolean)
     )).sort() as string[],
@@ -615,17 +618,10 @@ function HardwarePageContent() {
     return name
   }
 
-  // Helper to get device status based on lastSeen
-  const getDeviceStatus = (device: any): string => {
-    const lastSeen = device.lastSeen || device.collectedAt
-    if (!lastSeen) return 'Missing'
-    const lastSeenDate = new Date(lastSeen)
-    const now = new Date()
-    const diffDays = (now.getTime() - lastSeenDate.getTime()) / (1000 * 60 * 60 * 24)
-    if (diffDays <= 1) return 'Active'
-    if (diffDays <= 7) return 'Stale'
-    return 'Missing'
-  }
+  // Status comes from the shared helper so every report agrees on the same
+  // thresholds and the same lowercase values
+  const getDeviceStatus = (device: any): string =>
+    calculateDeviceStatus(device.lastSeen || device.collectedAt)
 
   // Helper to get inventory data
   const getInventory = (device: any) => {

--- a/app/identity/page.tsx
+++ b/app/identity/page.tsx
@@ -10,6 +10,7 @@ import { usePlatformFilterSafe, normalizePlatform } from "@/src/providers/Platfo
 import { CollapsibleSection } from "@/src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "@/src/hooks/useScrollCollapse"
 import DeviceFilters, { FilterOptions } from "@/src/components/shared/DeviceFilters"
+import { calculateDeviceStatus } from "@/src/lib/data-processing"
 
 interface IdentityDevice {
   id: string
@@ -153,19 +154,25 @@ function IdentityPageContent() {
   const [secureTokenFilter, setSecureTokenFilter] = useState<'with-token' | 'missing-token' | null>(null)
   const [bootstrapTokenFilter, setBootstrapTokenFilter] = useState<'escrowed' | 'not-escrowed' | null>(null)
   // Selections accordion state
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
   const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const toggleStatus = (s: string) => setSelectedStatuses(p => p.includes(s) ? p.filter(x => x !== s) : [...p, s])
   const toggleUsage = (u: string) => setSelectedUsages(p => p.includes(u) ? p.filter(x => x !== u) : [...p, u])
   const toggleCatalog = (c: string) => setSelectedCatalogs(p => p.includes(c) ? p.filter(x => x !== c) : [...p, c])
   const toggleLocation = (l: string) => setSelectedLocations(p => p.includes(l) ? p.filter(x => x !== l) : [...p, l])
   const toggleArea = (a: string) => setSelectedAreas(p => p.includes(a) ? p.filter(x => x !== a) : [...p, a])
   const toggleFleet = (f: string) => setSelectedFleets(p => p.includes(f) ? p.filter(x => x !== f) : [...p, f])
   const clearAllSelections = () => {
-    setSelectedUsages([]); setSelectedCatalogs([]); setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
+    setSelectedStatuses([]); setSelectedUsages([]); setSelectedCatalogs([])
+    setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
   }
+
+  // Status is derived from lastSeen, the same rule every other report uses
+  const statusOf = (d: { lastSeen?: string }) => calculateDeviceStatus(d.lastSeen)
   // Expandable legend categories
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
   const toggleCategory = (label: string) => {
@@ -290,6 +297,7 @@ function IdentityPageContent() {
       }
     }
     
+    if (selectedStatuses.length > 0 && !selectedStatuses.includes(statusOf(d))) return false
     if (selectedUsages.length > 0 && !selectedUsages.includes(d.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(d.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(d.location || '')) return false
@@ -580,7 +588,7 @@ function IdentityPageContent() {
           {/* Selections accordion (shared component) */}
           {(() => {
             const sharedFilterOptions: FilterOptions = {
-              statuses: [],
+              statuses: Array.from(new Set(platformFilteredDevices.map(statusOf))).sort(),
               usages: Array.from(new Set(platformFilteredDevices.map(d => d.usage).filter(Boolean) as string[])).sort(),
               catalogs: Array.from(new Set(platformFilteredDevices.map(d => d.catalog).filter(Boolean) as string[])).sort(),
               areas: Array.from(new Set(platformFilteredDevices.map(d => d.area || d.department).filter(Boolean) as string[])).sort(),
@@ -592,13 +600,13 @@ function IdentityPageContent() {
             return (
               <DeviceFilters
                 filterOptions={sharedFilterOptions}
-                selectedStatuses={[]}
+                selectedStatuses={selectedStatuses}
                 selectedCatalogs={selectedCatalogs}
                 selectedAreas={selectedAreas}
                 selectedLocations={selectedLocations}
                 selectedFleets={selectedFleets}
                 selectedUsages={selectedUsages}
-                onStatusToggle={() => { /* no statuses on /identity */ }}
+                onStatusToggle={toggleStatus}
                 onCatalogToggle={toggleCatalog}
                 onAreaToggle={toggleArea}
                 onLocationToggle={toggleLocation}

--- a/app/network/page.tsx
+++ b/app/network/page.tsx
@@ -12,6 +12,7 @@ import { Copy } from "lucide-react"
 import { CollapsibleSection } from "@/src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "@/src/hooks/useScrollCollapse"
 import DeviceFilters, { FilterOptions } from "@/src/components/shared/DeviceFilters"
+import { calculateDeviceStatus } from "@/src/lib/data-processing"
 
 interface NetworkDevice {
   id: string
@@ -50,6 +51,7 @@ function NetworkPageContent() {
     { filters: filtersExpanded, widgets: widgetsExpanded },
     { enabled: !loading }
   )
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
@@ -66,7 +68,16 @@ function NetworkPageContent() {
     }
   }
 
+  // Status is derived from lastSeen, the same rule every other report uses
+  const statusOf = (d: { lastSeen?: string }) => calculateDeviceStatus(d.lastSeen)
+
   // Toggle functions for filters
+  const toggleStatus = (status: string) => {
+    setSelectedStatuses(prev =>
+      prev.includes(status) ? prev.filter(s => s !== status) : [...prev, status]
+    )
+  }
+
   const toggleUsage = (usage: string) => {
     setSelectedUsages(prev => 
       prev.includes(usage) ? prev.filter(u => u !== usage) : [...prev, usage]
@@ -98,6 +109,7 @@ function NetworkPageContent() {
   }
 
   const _clearAllFilters = () => {
+    setSelectedStatuses([])
     setSelectedUsages([])
     setSelectedCatalogs([])
     setSelectedLocations([])
@@ -186,7 +198,7 @@ function NetworkPageContent() {
 
   // Extract unique filter options from devices (inventory data)
   const filterOptions: FilterOptions = {
-    statuses: [],
+    statuses: Array.from(new Set(networkDevices.map(statusOf))).sort(),
     usages: Array.from(new Set(
       devices.map(d => d.modules?.inventory?.usage).filter(Boolean)
     )).sort() as string[],
@@ -323,6 +335,7 @@ function NetworkPageContent() {
     }
 
     // Inventory-based filters
+    if (selectedStatuses.length > 0 && !selectedStatuses.includes(statusOf(n))) return false
     if (selectedUsages.length > 0 && !selectedUsages.includes(inventory?.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(inventory?.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(inventory?.location || '')) return false
@@ -681,13 +694,13 @@ function NetworkPageContent() {
           {/* Selections accordion (shared component) */}
           <DeviceFilters
             filterOptions={filterOptions}
-            selectedStatuses={[]}
+            selectedStatuses={selectedStatuses}
             selectedCatalogs={selectedCatalogs}
             selectedAreas={selectedAreas}
             selectedLocations={selectedLocations}
             selectedFleets={selectedFleets}
             selectedUsages={selectedUsages}
-            onStatusToggle={() => { /* no statuses on /network */ }}
+            onStatusToggle={toggleStatus}
             onCatalogToggle={toggleCatalog}
             onAreaToggle={toggleArea}
             onLocationToggle={toggleLocation}
@@ -1060,21 +1073,28 @@ function NetworkPageContent() {
                               
                               return (
                                 <>
-                                  <div className="flex items-center gap-1.5 flex-wrap">
+                                  <div className="flex items-center gap-1.5 min-w-0">
                                     {connectionDisplay && (
-                                      <span className="text-sm text-gray-900 dark:text-white">{connectionDisplay}</span>
+                                      <span className="text-sm text-gray-900 dark:text-white truncate">{connectionDisplay}</span>
                                     )}
                                     {networkDevice.networkInfo.vpnActive && (
-                                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-700">
+                                      // Adapter names like "Fortinet Virtual Ethernet Adapter" wrapped
+                                      // to two lines and pushed the row out of its own height. The
+                                      // badge stays a fixed-width "VPN"; the adapter name lives on the
+                                      // device's own network tab.
+                                      <span
+                                        className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-700 flex-shrink-0"
+                                        title={networkDevice.networkInfo.vpnName || 'VPN active'}
+                                      >
                                         <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                                         </svg>
-                                        {networkDevice.networkInfo.vpnName || 'VPN'}
+                                        VPN
                                       </span>
                                     )}
                                   </div>
                                   {protocolBand && protocolBand !== 'N/A' && (
-                                    <span className="text-xs text-gray-500 dark:text-gray-400">{protocolBand}</span>
+                                    <span className="text-xs text-gray-500 dark:text-gray-400 truncate">{protocolBand}</span>
                                   )}
                                 </>
                               );

--- a/app/peripherals/page.tsx
+++ b/app/peripherals/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, Suspense } from "react"
 import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { formatRelativeTime } from "@/src/lib/time"
+import { calculateDeviceStatus } from "@/src/lib/data-processing"
 import { usePlatformFilterSafe, normalizePlatform } from "@/src/providers/PlatformFilterProvider"
 import { CollapsibleSection } from "@/src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "@/src/hooks/useScrollCollapse"
@@ -37,6 +38,27 @@ interface Peripheral {
   fleet?: string | null
 }
 
+// The single Peripherals column renders one pill per type that a device
+// actually reports, so the table never needs a column per category (and so
+// never needs horizontal scrolling).
+const PERIPHERAL_TYPES = [
+  { key: 'usb', label: 'USB', field: 'usbDevices', pill: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200' },
+  { key: 'bluetooth', label: 'Bluetooth', field: 'bluetoothDevices', pill: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200' },
+  { key: 'printers', label: 'Printers', field: 'printers', pill: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200' },
+  { key: 'cameras', label: 'Cameras', field: 'cameras', pill: 'bg-pink-100 text-pink-800 dark:bg-pink-900/40 dark:text-pink-200' },
+  { key: 'audio', label: 'Audio', field: 'audioDevices', pill: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200' },
+  { key: 'displays', label: 'Displays', field: 'displayDevices', pill: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200' },
+  { key: 'input', label: 'Input', field: 'inputDevices', pill: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200' },
+  { key: 'storage', label: 'Storage', field: 'storageDevices', pill: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200' },
+] as const
+
+type PeripheralTypeKey = typeof PERIPHERAL_TYPES[number]['key']
+
+const countOf = (peripheral: Peripheral, field: string): number => {
+  const value = (peripheral as any)[field]
+  return Array.isArray(value) ? value.length : 0
+}
+
 function LoadingSkeleton() {
   return (
     <div className="animate-pulse">
@@ -61,8 +83,8 @@ function LoadingSkeleton() {
           <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded"></div>
         </div>
         <div className="px-6 py-4 border-t border-gray-100 dark:border-gray-700/50">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {[1, 2, 3].map(i => (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {[1, 2].map(i => (
               <div key={i} className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
                 <div className="h-4 w-24 bg-gray-200 dark:bg-gray-600 rounded mb-3"></div>
                 <div className="space-y-2">
@@ -85,19 +107,23 @@ function LoadingSkeleton() {
           <thead className="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th className="px-6 py-3"><div className="h-4 w-16 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
-              <th className="px-6 py-3"><div className="h-4 w-20 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
-              <th className="px-6 py-3"><div className="h-4 w-20 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
-              <th className="px-6 py-3"><div className="h-4 w-16 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
               <th className="px-6 py-3"><div className="h-4 w-24 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
+              <th className="px-6 py-3"><div className="h-4 w-12 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
+              <th className="px-6 py-3"><div className="h-4 w-20 bg-gray-300 dark:bg-gray-600 rounded"></div></th>
             </tr>
           </thead>
           <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {[...Array(8)].map((_, i) => (
               <tr key={i}>
                 <td className="px-6 py-4"><div className="h-4 w-32 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
-                <td className="px-6 py-4"><div className="h-4 w-12 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
-                <td className="px-6 py-4"><div className="h-4 w-12 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
-                <td className="px-6 py-4"><div className="h-4 w-12 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
+                <td className="px-6 py-4">
+                  <div className="flex gap-1.5">
+                    {[1, 2, 3, 4].map(j => (
+                      <div key={j} className="h-5 w-16 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-6 py-4"><div className="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
                 <td className="px-6 py-4"><div className="h-4 w-16 bg-gray-200 dark:bg-gray-700 rounded"></div></td>
               </tr>
             ))}
@@ -114,7 +140,8 @@ function PeripheralsPageContent() {
   const [error, setError] = useState<string | null>(null)
   const [peripherals, setPeripherals] = useState<Peripheral[]>([])
   const [searchQuery, setSearchQuery] = useState(searchParams.get('search') || '')
-  const [deviceTypeFilter, setDeviceTypeFilter] = useState('all')
+  // Multi-select peripheral-type pills, replacing the old dropdown
+  const [selectedTypes, setSelectedTypes] = useState<PeripheralTypeKey[]>([])
   const { platformFilter, isPlatformVisible } = usePlatformFilterSafe()
   
   // Sorting state
@@ -123,23 +150,28 @@ function PeripheralsPageContent() {
   const [widgetsExpanded, setWidgetsExpanded] = useState(true)
   const [filtersExpanded, setFiltersExpanded] = useState(false)
   // Widget-driven table filters (click a widget row to filter, click again to clear)
-  const [bluetoothFilter, setBluetoothFilter] = useState<'has' | 'none' | null>(null)
   const [printerFilter, setPrinterFilter] = useState<string | null>(null)
   const [usbTypeFilter, setUsbTypeFilter] = useState<string | null>(null)
   // Selections accordion state
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
   const [selectedAreas, setSelectedAreas] = useState<string[]>([])
   const [selectedFleets, setSelectedFleets] = useState<string[]>([])
+  const toggleStatus = (s: string) => setSelectedStatuses(p => p.includes(s) ? p.filter(x => x !== s) : [...p, s])
   const toggleUsage = (u: string) => setSelectedUsages(p => p.includes(u) ? p.filter(x => x !== u) : [...p, u])
   const toggleCatalog = (c: string) => setSelectedCatalogs(p => p.includes(c) ? p.filter(x => x !== c) : [...p, c])
   const toggleLocation = (l: string) => setSelectedLocations(p => p.includes(l) ? p.filter(x => x !== l) : [...p, l])
   const toggleArea = (a: string) => setSelectedAreas(p => p.includes(a) ? p.filter(x => x !== a) : [...p, a])
   const toggleFleet = (f: string) => setSelectedFleets(p => p.includes(f) ? p.filter(x => x !== f) : [...p, f])
   const clearAllSelections = () => {
-    setSelectedUsages([]); setSelectedCatalogs([]); setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
+    setSelectedStatuses([]); setSelectedUsages([]); setSelectedCatalogs([])
+    setSelectedLocations([]); setSelectedAreas([]); setSelectedFleets([])
   }
+
+  // Status is derived from lastSeen, the same rule every other report uses
+  const statusOf = (peripheral: Peripheral) => calculateDeviceStatus(peripheral.lastSeen)
 
   const { tableContainerRef, effectiveFiltersExpanded, effectiveWidgetsExpanded } = useScrollCollapse(
     { filters: filtersExpanded, widgets: widgetsExpanded },
@@ -184,23 +216,13 @@ function PeripheralsPageContent() {
     fetchPeripherals()
   }, [])
 
-  const getDeviceCount = (devices: any[]): number => {
-    return Array.isArray(devices) ? devices.length : 0
-  }
+  const getTotalDevices = (peripheral: Peripheral): number =>
+    PERIPHERAL_TYPES.reduce((sum, type) => sum + countOf(peripheral, type.field), 0)
 
-  const getTotalDevices = (peripheral: Peripheral): number => {
-    return getDeviceCount(peripheral.usbDevices) +
-           getDeviceCount(peripheral.bluetoothDevices) +
-           getDeviceCount(peripheral.printers) +
-           getDeviceCount(peripheral.cameras) +
-           getDeviceCount(peripheral.audioDevices) +
-           getDeviceCount(peripheral.displayDevices) +
-           getDeviceCount(peripheral.inputDevices) +
-           getDeviceCount(peripheral.storageDevices)
-  }
+  const query = searchQuery.trim().toLowerCase()
 
-  // Base filter (platform, search, device-type dropdown, inventory selections) —
-  // widget counts are computed from this so they stay stable as widget filters toggle.
+  // Base filter (platform, search, type pills, inventory selections) — widget
+  // counts are computed from this so they stay stable as widget filters toggle.
   const baseFiltered = peripherals.filter(peripheral => {
     // Global platform filter first
     if (platformFilter) {
@@ -210,48 +232,52 @@ function PeripheralsPageContent() {
       }
     }
 
-    const matchesSearch = peripheral.deviceName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      peripheral.serialNumber?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      JSON.stringify(peripheral.usbDevices).toLowerCase().includes(searchQuery.toLowerCase()) ||
-      JSON.stringify(peripheral.bluetoothDevices).toLowerCase().includes(searchQuery.toLowerCase()) ||
-      JSON.stringify(peripheral.printers).toLowerCase().includes(searchQuery.toLowerCase())
+    const matchesSearch = !query ||
+      peripheral.deviceName?.toLowerCase().includes(query) ||
+      peripheral.serialNumber?.toLowerCase().includes(query) ||
+      JSON.stringify(peripheral.usbDevices).toLowerCase().includes(query) ||
+      JSON.stringify(peripheral.bluetoothDevices).toLowerCase().includes(query) ||
+      JSON.stringify(peripheral.printers).toLowerCase().includes(query)
 
-    const matchesFilter = deviceTypeFilter === 'all' || (
-      (deviceTypeFilter === 'usb' && getDeviceCount(peripheral.usbDevices) > 0) ||
-      (deviceTypeFilter === 'bluetooth' && getDeviceCount(peripheral.bluetoothDevices) > 0) ||
-      (deviceTypeFilter === 'printers' && getDeviceCount(peripheral.printers) > 0) ||
-      (deviceTypeFilter === 'cameras' && getDeviceCount(peripheral.cameras) > 0) ||
-      (deviceTypeFilter === 'audio' && getDeviceCount(peripheral.audioDevices) > 0) ||
-      (deviceTypeFilter === 'displays' && getDeviceCount(peripheral.displayDevices) > 0) ||
-      (deviceTypeFilter === 'input' && getDeviceCount(peripheral.inputDevices) > 0) ||
-      (deviceTypeFilter === 'storage' && getDeviceCount(peripheral.storageDevices) > 0)
-    )
+    // A device matches when it reports at least one of the selected types
+    const matchesType = selectedTypes.length === 0 || selectedTypes.some(key => {
+      const type = PERIPHERAL_TYPES.find(t => t.key === key)
+      return type ? countOf(peripheral, type.field) > 0 : false
+    })
 
+    if (selectedStatuses.length > 0 && !selectedStatuses.includes(statusOf(peripheral))) return false
     if (selectedUsages.length > 0 && !selectedUsages.includes(peripheral.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(peripheral.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(peripheral.location || '')) return false
     if (selectedAreas.length > 0 && !selectedAreas.includes(peripheral.area || peripheral.department || '')) return false
     if (selectedFleets.length > 0 && !selectedFleets.includes(peripheral.fleet || '')) return false
 
-    return matchesSearch && matchesFilter
+    return matchesSearch && matchesType
   })
+
+  // Devices carrying each peripheral type, for the header type pills. Counted
+  // before the type pills themselves apply so the counts don't collapse to zero
+  // as soon as one is selected.
+  const typeDeviceCounts = PERIPHERAL_TYPES.reduce((acc, type) => {
+    acc[type.key] = peripherals.filter(p => {
+      if (platformFilter && !isPlatformVisible(normalizePlatform(p.platform))) return false
+      return countOf(p, type.field) > 0
+    }).length
+    return acc
+  }, {} as Record<string, number>)
+
+  // Widget rows are narrowed by the same search box as the table, so typing
+  // "laser" leaves only the matching printers standing.
+  const matchesWidgetQuery = (label: string) => !query || label.toLowerCase().includes(query)
 
   // Calculate peripheral statistics for widgets (from base, so counts stay stable)
   const peripheralStats = {
-    // Bluetooth power state
-    bluetoothOn: baseFiltered.filter(p =>
-      p.bluetoothDevices && p.bluetoothDevices.length > 0
-    ).length,
-    bluetoothOff: baseFiltered.filter(p =>
-      !p.bluetoothDevices || p.bluetoothDevices.length === 0
-    ).length,
-
     // Printer names and counts
     printerNames: baseFiltered.reduce((acc, p) => {
       if (p.printers && Array.isArray(p.printers)) {
         p.printers.forEach((printer: any) => {
           const name = printer.name || printer.printerName || 'Unknown Printer'
-          acc[name] = (acc[name] || 0) + 1
+          if (matchesWidgetQuery(name)) acc[name] = (acc[name] || 0) + 1
         })
       }
       return acc
@@ -262,22 +288,23 @@ function PeripheralsPageContent() {
       if (p.usbDevices && Array.isArray(p.usbDevices)) {
         p.usbDevices.forEach((device: any) => {
           const type = device.class || device.type || device.vendor || 'Unknown'
-          acc[type] = (acc[type] || 0) + 1
+          if (matchesWidgetQuery(type)) acc[type] = (acc[type] || 0) + 1
         })
       }
       return acc
     }, {} as Record<string, number>),
 
-    // Total counts
-    totalUSB: baseFiltered.reduce((sum, p) => sum + getDeviceCount(p.usbDevices), 0),
-    totalBluetooth: baseFiltered.reduce((sum, p) => sum + getDeviceCount(p.bluetoothDevices), 0),
-    totalPrinters: baseFiltered.reduce((sum, p) => sum + getDeviceCount(p.printers), 0)
   }
+
+  // Header counts sum the rows actually listed, so a search that narrows the
+  // widget can't leave a total that contradicts what is on screen.
+  const sumValues = (counts: Record<string, number>) =>
+    Object.values(counts).reduce((sum, n) => sum + n, 0)
+  const totalPrinters = sumValues(peripheralStats.printerNames)
+  const totalUSB = sumValues(peripheralStats.usbTypes)
 
   // Apply widget-driven filters on top of the base, then sort → table rows
   const filteredPeripherals = baseFiltered.filter(peripheral => {
-    if (bluetoothFilter === 'has' && getDeviceCount(peripheral.bluetoothDevices) === 0) return false
-    if (bluetoothFilter === 'none' && getDeviceCount(peripheral.bluetoothDevices) > 0) return false
     if (printerFilter && !(Array.isArray(peripheral.printers) ? peripheral.printers : []).some((p: any) => (p.name || p.printerName || 'Unknown Printer') === printerFilter)) return false
     if (usbTypeFilter && !(Array.isArray(peripheral.usbDevices) ? peripheral.usbDevices : []).some((d: any) => (d.class || d.type || d.vendor || 'Unknown') === usbTypeFilter)) return false
     return true
@@ -325,23 +352,6 @@ function PeripheralsPageContent() {
                 </p>
               </div>
               <div className="flex items-center gap-4">
-                {/* Device Type Filter */}
-                <select
-                  value={deviceTypeFilter}
-                  onChange={(e) => setDeviceTypeFilter(e.target.value)}
-                  className="text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5"
-                >
-                  <option value="all">All Device Types</option>
-                  <option value="usb">USB Devices</option>
-                  <option value="bluetooth">Bluetooth Devices</option>
-                  <option value="printers">Printers</option>
-                  <option value="cameras">Cameras</option>
-                  <option value="audio">Audio Devices</option>
-                  <option value="displays">Display Devices</option>
-                  <option value="input">Input Devices</option>
-                  <option value="storage">Storage Devices</option>
-                </select>
-
                 {/* Search */}
                 <div className="relative">
                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -359,12 +369,42 @@ function PeripheralsPageContent() {
                 </div>
               </div>
             </div>
+
+            {/* Peripheral type filters — multi-select, replacing the old dropdown */}
+            <nav className="flex flex-wrap gap-2 mt-4">
+              {PERIPHERAL_TYPES.map(type => {
+                const isActive = selectedTypes.includes(type.key)
+                const count = typeDeviceCounts[type.key] || 0
+                return (
+                  <button
+                    key={type.key}
+                    onClick={() => setSelectedTypes(prev =>
+                      prev.includes(type.key) ? prev.filter(k => k !== type.key) : [...prev, type.key]
+                    )}
+                    className={`px-3 py-1.5 border rounded-lg text-sm font-medium flex items-center gap-2 transition-colors ${
+                      isActive
+                        ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700'
+                        : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    <span>{type.label}</span>
+                    <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium ${
+                      isActive
+                        ? 'bg-blue-100 dark:bg-blue-800/50 text-blue-800 dark:text-blue-200'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                    }`}>
+                      {count}
+                    </span>
+                  </button>
+                )
+              })}
+            </nav>
           </div>
 
           {/* Selections accordion (shared component) */}
           {(() => {
             const sharedFilterOptions: FilterOptions = {
-              statuses: [],
+              statuses: Array.from(new Set(peripherals.map(statusOf))).sort(),
               usages: Array.from(new Set(peripherals.map(p => p.usage).filter(Boolean) as string[])).sort(),
               catalogs: Array.from(new Set(peripherals.map(p => p.catalog).filter(Boolean) as string[])).sort(),
               areas: Array.from(new Set(peripherals.map(p => p.area || p.department).filter(Boolean) as string[])).sort(),
@@ -376,13 +416,13 @@ function PeripheralsPageContent() {
             return (
               <DeviceFilters
                 filterOptions={sharedFilterOptions}
-                selectedStatuses={[]}
+                selectedStatuses={selectedStatuses}
                 selectedCatalogs={selectedCatalogs}
                 selectedAreas={selectedAreas}
                 selectedLocations={selectedLocations}
                 selectedFleets={selectedFleets}
                 selectedUsages={selectedUsages}
-                onStatusToggle={() => { /* no statuses on /peripherals */ }}
+                onStatusToggle={toggleStatus}
                 onCatalogToggle={toggleCatalog}
                 onAreaToggle={toggleArea}
                 onLocationToggle={toggleLocation}
@@ -417,76 +457,53 @@ function PeripheralsPageContent() {
             
             <CollapsibleSection expanded={effectiveWidgetsExpanded} maxHeight="60vh">
               <div className="px-6 py-4 bg-white dark:bg-gray-800 border-t border-gray-100 dark:border-gray-700/50">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {/* Bluetooth Power State Widget */}
-                  <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Bluetooth State</h4>
-                    <div className="space-y-1">
-                      <button
-                        onClick={() => setBluetoothFilter(bluetoothFilter === 'has' ? null : 'has')}
-                        className={`flex items-center justify-between w-full px-1.5 py-1 rounded transition-colors ${bluetoothFilter === 'has' ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
-                      >
-                        <div className="flex items-center gap-2">
-                          <div className="w-2.5 h-2.5 rounded-full bg-blue-500"></div>
-                          <span className="text-sm text-gray-600 dark:text-gray-400">Has Devices</span>
-                        </div>
-                        <span className="text-sm font-medium text-gray-900 dark:text-white">{peripheralStats.bluetoothOn}</span>
-                      </button>
-                      <button
-                        onClick={() => setBluetoothFilter(bluetoothFilter === 'none' ? null : 'none')}
-                        className={`flex items-center justify-between w-full px-1.5 py-1 rounded transition-colors ${bluetoothFilter === 'none' ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
-                      >
-                        <div className="flex items-center gap-2">
-                          <div className="w-2.5 h-2.5 rounded-full bg-gray-400"></div>
-                          <span className="text-sm text-gray-600 dark:text-gray-400">No Devices</span>
-                        </div>
-                        <span className="text-sm font-medium text-gray-900 dark:text-white">{peripheralStats.bluetoothOff}</span>
-                      </button>
-                    </div>
-                  </div>
-
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {/* Printers Widget */}
                   <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Printers ({peripheralStats.totalPrinters})</h4>
+                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Printers ({totalPrinters})</h4>
                     <div className="space-y-1 max-h-48 overflow-y-auto table-scrollbar pr-1">
                       {Object.entries(peripheralStats.printerNames).sort((a, b) => b[1] - a[1]).map(([name, count]) => (
                         <button
                           key={name}
                           onClick={() => setPrinterFilter(printerFilter === name ? null : name)}
-                          className={`flex items-center justify-between w-full px-1.5 py-1 rounded transition-colors ${printerFilter === name ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
+                          className={`flex items-center justify-between gap-3 w-full px-1.5 py-1 rounded transition-colors ${printerFilter === name ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
                         >
-                          <div className="flex items-center gap-2 min-w-0">
+                          <div className="flex items-center gap-2 min-w-0 flex-1">
                             <div className="w-2.5 h-2.5 rounded-full bg-purple-500 flex-shrink-0"></div>
-                            <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-[150px]" title={name}>{name}</span>
+                            <span className="text-sm text-gray-600 dark:text-gray-400 truncate text-left" title={name}>{name}</span>
                           </div>
                           <span className="text-sm font-medium text-gray-900 dark:text-white flex-shrink-0">{count}</span>
                         </button>
                       ))}
                       {Object.keys(peripheralStats.printerNames).length === 0 && (
-                        <span className="text-sm text-gray-500 dark:text-gray-400">No printers found</span>
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          {query ? `No printers match "${searchQuery}"` : 'No printers found'}
+                        </span>
                       )}
                     </div>
                   </div>
 
                   {/* USB Devices Widget */}
                   <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 border border-gray-200 dark:border-gray-600">
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">USB Devices ({peripheralStats.totalUSB})</h4>
+                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">USB Devices ({totalUSB})</h4>
                     <div className="space-y-1 max-h-48 overflow-y-auto table-scrollbar pr-1">
                       {Object.entries(peripheralStats.usbTypes).sort((a, b) => b[1] - a[1]).map(([type, count]) => (
                         <button
                           key={type}
                           onClick={() => setUsbTypeFilter(usbTypeFilter === type ? null : type)}
-                          className={`flex items-center justify-between w-full px-1.5 py-1 rounded transition-colors ${usbTypeFilter === type ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
+                          className={`flex items-center justify-between gap-3 w-full px-1.5 py-1 rounded transition-colors ${usbTypeFilter === type ? 'bg-blue-100 dark:bg-blue-900/30' : 'hover:bg-gray-100 dark:hover:bg-gray-600/50'}`}
                         >
-                          <div className="flex items-center gap-2 min-w-0">
+                          <div className="flex items-center gap-2 min-w-0 flex-1">
                             <div className="w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0"></div>
-                            <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-[150px]" title={type}>{type}</span>
+                            <span className="text-sm text-gray-600 dark:text-gray-400 truncate text-left" title={type}>{type}</span>
                           </div>
                           <span className="text-sm font-medium text-gray-900 dark:text-white flex-shrink-0">{count}</span>
                         </button>
                       ))}
                       {Object.keys(peripheralStats.usbTypes).length === 0 && (
-                        <span className="text-sm text-gray-500 dark:text-gray-400">No USB devices found</span>
+                        <span className="text-sm text-gray-500 dark:text-gray-400">
+                          {query ? `No USB devices match "${searchQuery}"` : 'No USB devices found'}
+                        </span>
                       )}
                     </div>
                   </div>
@@ -495,13 +512,13 @@ function PeripheralsPageContent() {
             </CollapsibleSection>
           </div>
 
-          <div ref={tableContainerRef} className="flex-1 overflow-auto min-h-0 table-scrollbar">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <div ref={tableContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden min-h-0 table-scrollbar">
+            <table className="w-full table-fixed divide-y divide-gray-200 dark:divide-gray-700">
               <thead className="bg-gray-50 dark:bg-gray-700 sticky top-0 z-10">
                 <tr>
-                  <th 
+                  <th
                     onClick={() => handleSort('device')}
-                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
+                    className="w-64 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
                   >
                     <div className="flex items-center gap-1">
                       Device
@@ -512,13 +529,10 @@ function PeripheralsPageContent() {
                       )}
                     </div>
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700">USB Devices</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700">Bluetooth</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700">Printers</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700">Other Devices</th>
-                  <th 
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700">Peripherals</th>
+                  <th
                     onClick={() => handleSort('total')}
-                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
+                    className="w-24 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
                   >
                     <div className="flex items-center gap-1">
                       Total
@@ -529,9 +543,8 @@ function PeripheralsPageContent() {
                       )}
                     </div>
                   </th>
-                  <th 
+                  <th className="w-36 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
                     onClick={() => handleSort('lastSeen')}
-                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider bg-gray-50 dark:bg-gray-700 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 select-none"
                   >
                     <div className="flex items-center gap-1">
                       Last Seen
@@ -547,7 +560,7 @@ function PeripheralsPageContent() {
               <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                 {error ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-12 text-center">
+                    <td colSpan={4} className="px-6 py-12 text-center">
                       <div className="flex flex-col items-center">
                         <div className="w-12 h-12 mb-4 bg-red-50 dark:bg-red-900/20 rounded-full flex items-center justify-center">
                           <svg className="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -567,7 +580,7 @@ function PeripheralsPageContent() {
                   </tr>
                 ) : filteredPeripherals.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-12 text-center">
+                    <td colSpan={4} className="px-6 py-12 text-center">
                       <div className="flex flex-col items-center">
                         <svg className="w-12 h-12 text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.8 3.2h6.4a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H8.8a1 1 0 0 1-1-1V4.2a1 1 0 0 1 1-1zM8.8 7.2h6.4a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H8.8a2 2 0 0 1-2-2V9.2a2 2 0 0 1 2-2zM10.4 17.2h3.2a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-3.2a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1z" />
@@ -580,7 +593,7 @@ function PeripheralsPageContent() {
                 ) : (
                   filteredPeripherals.map((peripheral) => (
                     <tr key={peripheral.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                      <td className="px-6 py-4 max-w-56">
+                      <td className="px-6 py-4">
                         <Link
                           href={`/device/${peripheral.serialNumber}#peripherals`}
                           className="group block min-w-0"
@@ -596,92 +609,26 @@ function PeripheralsPageContent() {
                         </Link>
                       </td>
                       <td className="px-6 py-4">
-                        <div className="text-sm">
-                          <div className="text-gray-900 dark:text-white font-medium">
-                            {getDeviceCount(peripheral.usbDevices)} devices
-                          </div>
-                          {peripheral.usbDevices && peripheral.usbDevices.length > 0 && (
-                            <div className="text-gray-500 dark:text-gray-400 text-xs max-w-xs">
-                              {peripheral.usbDevices.slice(0, 2).map((device: any, idx: number) => (
-                                <div key={idx} className="truncate">
-                                  {device.product_name || device.name || 'Unknown USB Device'}
-                                </div>
-                              ))}
-                              {peripheral.usbDevices.length > 2 && (
-                                <div>+{peripheral.usbDevices.length - 2} more...</div>
-                              )}
-                            </div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {PERIPHERAL_TYPES.map(type => {
+                            const count = countOf(peripheral, type.field)
+                            if (count === 0) return null
+                            return (
+                              <span
+                                key={type.key}
+                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${type.pill}`}
+                              >
+                                <span className="tabular-nums">{count}</span>
+                                {type.label}
+                              </span>
+                            )
+                          })}
+                          {getTotalDevices(peripheral) === 0 && (
+                            <span className="text-sm text-gray-400 dark:text-gray-500">No peripherals reported</span>
                           )}
                         </div>
                       </td>
-                      <td className="px-6 py-4">
-                        <div className="text-sm">
-                          <div className="text-gray-900 dark:text-white font-medium">
-                            {getDeviceCount(peripheral.bluetoothDevices)} devices
-                          </div>
-                          {peripheral.bluetoothDevices && peripheral.bluetoothDevices.length > 0 && (
-                            <div className="text-gray-500 dark:text-gray-400 text-xs max-w-xs">
-                              {peripheral.bluetoothDevices.slice(0, 2).map((device: any, idx: number) => (
-                                <div key={idx} className="truncate">
-                                  {device.name || device.address || 'Unknown Bluetooth'}
-                                </div>
-                              ))}
-                              {peripheral.bluetoothDevices.length > 2 && (
-                                <div>+{peripheral.bluetoothDevices.length - 2} more...</div>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4">
-                        <div className="text-sm">
-                          <div className="text-gray-900 dark:text-white font-medium">
-                            {getDeviceCount(peripheral.printers)} printers
-                          </div>
-                          {peripheral.printers && peripheral.printers.length > 0 && (
-                            <div className="text-gray-500 dark:text-gray-400 text-xs max-w-xs">
-                              {peripheral.printers.slice(0, 2).map((printer: any, idx: number) => (
-                                <div key={idx} className="truncate">
-                                  {printer.name || printer.display_name || 'Unknown Printer'}
-                                </div>
-                              ))}
-                              {peripheral.printers.length > 2 && (
-                                <div>+{peripheral.printers.length - 2} more...</div>
-                              )}
-                            </div>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4">
-                        <div className="flex flex-wrap gap-1">
-                          {getDeviceCount(peripheral.cameras) > 0 && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-                              {getDeviceCount(peripheral.cameras)} cameras
-                            </span>
-                          )}
-                          {getDeviceCount(peripheral.audioDevices) > 0 && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                              {getDeviceCount(peripheral.audioDevices)} audio
-                            </span>
-                          )}
-                          {getDeviceCount(peripheral.displayDevices) > 0 && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                              {getDeviceCount(peripheral.displayDevices)} displays
-                            </span>
-                          )}
-                          {getDeviceCount(peripheral.inputDevices) > 0 && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-                              {getDeviceCount(peripheral.inputDevices)} input
-                            </span>
-                          )}
-                          {getDeviceCount(peripheral.storageDevices) > 0 && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
-                              {getDeviceCount(peripheral.storageDevices)} storage
-                            </span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-900 dark:text-white font-medium">
+                      <td className="px-6 py-4 text-sm text-gray-900 dark:text-white font-medium tabular-nums">
                         {getTotalDevices(peripheral)}
                       </td>
                       <td className="px-6 py-4 text-sm text-gray-900 dark:text-white">

--- a/app/system/page.tsx
+++ b/app/system/page.tsx
@@ -17,6 +17,7 @@ import { usePlatformFilterSafe, normalizePlatform } from "@/src/providers/Platfo
 import { CollapsibleSection } from "@/src/components/ui/CollapsibleSection"
 import { useScrollCollapse } from "@/src/hooks/useScrollCollapse"
 import DeviceFilters, { FilterOptions } from "@/src/components/shared/DeviceFilters"
+import { calculateDeviceStatus } from "@/src/lib/data-processing"
 
 interface SystemDevice {
   id: string
@@ -249,6 +250,7 @@ function SystemPageContent() {
   // Filters accordion state
   const [filtersExpanded, setFiltersExpanded] = useState(false)
 
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([])
   const [selectedUsages, setSelectedUsages] = useState<string[]>([])
   const [selectedCatalogs, setSelectedCatalogs] = useState<string[]>([])
   const [selectedLocations, setSelectedLocations] = useState<string[]>([])
@@ -301,6 +303,15 @@ function SystemPageContent() {
   const toggleLocation = (location: string) => {
     setSelectedLocations(prev =>
       prev.includes(location) ? prev.filter(l => l !== location) : [...prev, location]
+    )
+  }
+
+  // Status is derived from lastSeen, the same rule every other report uses
+  const statusOf = (d: { lastSeen?: string }) => calculateDeviceStatus(d.lastSeen)
+
+  const toggleStatus = (status: string) => {
+    setSelectedStatuses(prev =>
+      prev.includes(status) ? prev.filter(s => s !== status) : [...prev, status]
     )
   }
 
@@ -373,6 +384,7 @@ function SystemPageContent() {
   }
   
   const clearAllFilters = () => {
+    setSelectedStatuses([])
     setSelectedUsages([])
     setSelectedCatalogs([])
     setSelectedLocations([])
@@ -393,8 +405,8 @@ function SystemPageContent() {
     if (osVersionFilter) router.push('/system')
   }
   
-  const totalActiveFilters = selectedUsages.length + selectedCatalogs.length + selectedLocations.length +
-    selectedAreas.length + selectedFleets.length +
+  const totalActiveFilters = selectedStatuses.length + selectedUsages.length + selectedCatalogs.length +
+    selectedLocations.length + selectedAreas.length + selectedFleets.length +
     selectedEditions.length + selectedActivationStatus.length + selectedLicenseType.length +
     selectedArchitectures.length + selectedTimeZones.length + selectedUptimeBuckets.length + selectedLicenseSources.length +
     selectedPendingBuckets.length +
@@ -503,7 +515,7 @@ function SystemPageContent() {
 
   // FilterOptions slice fed to the shared DeviceFilters component (inventory dimensions only)
   const selectionFilterOptions: FilterOptions = {
-    statuses: [],
+    statuses: Array.from(new Set(systems.map(statusOf))).sort(),
     usages: filterOptions.usages,
     catalogs: filterOptions.catalogs,
     areas: filterOptions.areas,
@@ -635,6 +647,7 @@ function SystemPageContent() {
     }
 
     // Inventory-based filters
+    if (selectedStatuses.length > 0 && !selectedStatuses.includes(statusOf(s))) return false
     if (selectedUsages.length > 0 && !selectedUsages.includes(inventory?.usage || '')) return false
     if (selectedCatalogs.length > 0 && !selectedCatalogs.includes(inventory?.catalog || '')) return false
     if (selectedLocations.length > 0 && !selectedLocations.includes(inventory?.location || '')) return false
@@ -888,13 +901,13 @@ function SystemPageContent() {
           {/* Selections accordion (shared component) */}
           <DeviceFilters
             filterOptions={selectionFilterOptions}
-            selectedStatuses={[]}
+            selectedStatuses={selectedStatuses}
             selectedCatalogs={selectedCatalogs}
             selectedAreas={selectedAreas}
             selectedLocations={selectedLocations}
             selectedFleets={selectedFleets}
             selectedUsages={selectedUsages}
-            onStatusToggle={() => { /* no statuses on /system */ }}
+            onStatusToggle={toggleStatus}
             onCatalogToggle={toggleCatalog}
             onAreaToggle={toggleArea}
             onLocationToggle={toggleLocation}

--- a/src/hooks/useDeviceData.ts
+++ b/src/hooks/useDeviceData.ts
@@ -110,7 +110,7 @@ export function useDeviceData(options: UseDeviceDataOptions = {}): UseDeviceData
         const startTime = Date.now()
         console.log(`[useDeviceData] Fetching ${moduleType} module data... (attempt ${attempt}/${maxRetries})`)
         
-        const response = await fetch(`/api/v1/`, {
+        const response = await fetch(`/api/v1/${moduleType}`, {
           cache: 'no-store',
           headers: {
             'Cache-Control': 'no-cache',


### PR DESCRIPTION
Closes #44

## Selections accordion

`/devices` was the last page still running its own filter model — three single-select groups of Status, Usage and Catalog, each pill clearing the others in its group, and no Area, Location or Fleet at all. It now renders the shared `DeviceFilters` accordion over all six dimensions, multi-select, with options derived from the live inventory rather than hardcoded, so a dimension with no collected data hides itself. Matching is case-insensitive because inventory values differ in casing between platforms. URL parameters accept comma-separated lists so a deep link can preselect more than one pill per dimension. The per-pill counts go with the old row; no other report shows them.

Status was the remaining inconsistency across the pages that already used the accordion. `/system`, `/network`, `/identity` and `/peripherals` passed an empty list and a no-op toggle, so the dimension never rendered; `/hardware` hardcoded `Active/Stale/Missing` from its own copy of the threshold arithmetic and produced capitalised values no other page emitted. All of them now derive Status from `lastSeen` through `calculateDeviceStatus`, the helper `/security` and `/devices` already used.

`/installs` and `/applications` are deliberately untouched. They are report builders whose filter options come from a server endpoint and whose selections are applied server-side when the report is generated; adding a client-side Status there would silently disagree with the generated report. That needs an API change, not a UI one.

Fleet still renders nowhere, and that is correct — see the note at the end.

## Event type filters

Toggling Success/Warnings/Errors on `/events` sent the active type set to the API and replaced the whole list with the response, so the pill flipped instantly and the table sat unchanged for a round-trip. Type filtering is now client-side: every event fetched for the current date window accumulates in a cache keyed by id, and the table renders from that cache filtered by the active types, so a toggle repaints in the same frame and toggling a type back on restores its rows from cache.

The server still receives the type set, because that is what keeps each 100-row page dense enough for infinite scroll, but the request is now a background top-up — it merges into the cache instead of replacing it, and is debounced by 300ms so flipping several pills costs one request rather than one each. Deselecting every type renders an empty table and skips the fetch.

## Peripherals

Eight columns (count-plus-sample-names for USB, Bluetooth and Printers, then an "Other Devices" pill column) guaranteed horizontal scrolling and made row height depend on how many peripherals a device reported. All eight types now share one central Peripherals column of count pills, in the style the "Other Devices" column already used, and the table is fixed-layout with `overflow-x` hidden.

The device-type dropdown is removed. It did filter, but nearly every device reports audio and USB, so most selections changed nothing visible. In its place is a row of multi-select type pills carrying the count of devices reporting each type, matching the Wired/Wireless/VPN pills on `/network`.

Widgets: Bluetooth State is gone, leaving Printers and USB Devices at half the row each with labels taking the full width instead of truncating at 150px. Both filter live against the search box, and their header counts sum the rows actually listed so a search cannot leave a total that contradicts what is on screen.

## Network VPN rows

The connection cell was clamped to `h-12` but rendered the full adapter name inside the badge. Names like "Fortinet Virtual Ethernet Adapter" wrapped to two lines, and the badge plus the network name above it and the protocol line below it spilled past the row and printed over neighbouring rows. The badge is now a fixed-width `VPN` with the adapter name on hover, and the surrounding text truncates. The adapter name is already shown in full on the device network tab.

## Unrelated bug found on the way

`useDeviceData` fetched `` `/api/v1/` `` with the `moduleType` interpolation missing from the template literal, so `/system` — the only caller that requests module data — got a 404 HTML body on all three retries and rendered "0 devices" with every widget empty. Restored in its own commit; `/system` now loads.

## Verification

Ran against live data in a dev server and stepped through `/devices`, `/events`, `/peripherals`, `/network`, `/system`, `/identity` and `/hardware`: accordion layout is identical on all seven, selections filter correctly, event toggles repaint without a visible delay, the peripherals table has no horizontal scroll and its widgets filter as you type, and VPN rows sit inside their own height. Typecheck error count is unchanged from `main` (133 pre-existing, none added).

## Note on Fleet

Fleet renders on no page because no device carries the value. All 878 devices in the current payload have `modules.inventory.fleet` null, and `area` is null too, which is why the AREA pills are actually department values via the existing fallback. The accordion already hides an empty dimension, so this is the frontend behaving correctly over absent data — the gap is at collection, not here.