### PR TITLE
Pin pnpm to 10.34.5 and let the declared builds actually run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install pnpm. PINNED: `npm install -g pnpm` follows the latest major, and
-# pnpm 12 (2026-08-26) turned "Ignored build scripts" from a warning into
-# ERR_PNPM_IGNORED_BUILDS, which broke this image mid-deploy with no change to
-# the app. onlyBuiltDependencies is declared in pnpm-workspace.yaml, but that
-# file is not copied into the build context below, so pnpm never sees it --
-# fixing that changes which install scripts run, so it is left alone here.
-RUN npm install -g pnpm@11.24.0
+# Install pnpm. PINNED: `npm install -g pnpm` resolves the latest release the
+# base image can run, so the toolchain moved on its own and broke this build.
+# 10.34.5 is the newest pnpm that supports the Node 20 base above -- 11.x
+# requires Node >=22.13 and dies on `node:sqlite`, and 12.x is a standalone
+# binary that ignores the Node constraint entirely, which is how it got pulled
+# in on 2026-08-26 and turned ignored build scripts into a hard error.
+RUN npm install -g pnpm@10.34.5
 
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
@@ -27,7 +27,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 # Install pnpm (pinned to match the deps stage above)
-RUN npm install -g pnpm@11.24.0
+RUN npm install -g pnpm@10.34.5
 
 # Set environment variable for Docker build
 ENV DOCKER_BUILD=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm. PINNED: `npm install -g pnpm` follows the latest major, and
+# pnpm 12 (2026-08-26) turned "Ignored build scripts" from a warning into
+# ERR_PNPM_IGNORED_BUILDS, which broke this image mid-deploy with no change to
+# the app. onlyBuiltDependencies is declared in pnpm-workspace.yaml, but that
+# file is not copied into the build context below, so pnpm never sees it --
+# fixing that changes which install scripts run, so it is left alone here.
+RUN npm install -g pnpm@11.24.0
 
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml* ./
@@ -21,8 +26,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm (pinned to match the deps stage above)
+RUN npm install -g pnpm@11.24.0
 
 # Set environment variable for Docker build
 ENV DOCKER_BUILD=true

--- a/package.json
+++ b/package.json
@@ -66,5 +66,15 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "@tailwindcss/oxide",
+      "prisma",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
The web image build started failing today with `ERR_PNPM_IGNORED_BUILDS`, with no app change involved.

## What happened

`RUN npm install -g pnpm` resolves the newest release the base image can run, so the toolchain moved on its own:

- Before **15:12 UTC today**, the newest pnpm was 11.24.0, which declares `engines.node >= 22.13`. This image is `node:20-alpine`, so npm fell back to 10.x and everything worked.
- **pnpm 12.0.0 published at 15:12 UTC** is a standalone binary with no Node constraint, so npm installed it — and it turns ignored build scripts into a hard error rather than a warning.

The deploy that succeeded at 04:21 UTC logs the identical warning, boxed and non-fatal.

## Pinned to 10.34.5, not forward

10.34.5 is the newest pnpm the Node 20 base can run. I checked 11.24.0 first and it dies immediately on `node:sqlite`:

```
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

Pinning forward would have swapped one broken build for another. Moving the base image to Node 22 is the other way out, but that is a runtime change and does not belong in an unblock.

## The declared builds now actually run

`onlyBuiltDependencies` was declared in `pnpm-workspace.yaml` and lists exactly the packages pnpm complains about — but the deps stage copies only `package.json` and `pnpm-lock.yaml*`, so the setting has never reached the image. pnpm has been silently skipping those scripts in every image this repo has shipped.

Moved into `package.json`, which *is* copied, so the declaration finally applies. Copying `pnpm-workspace.yaml` in instead does **not** work — I tested it, along with rooting it at `.` and dropping its `packages` key; all three still fail, because that file also lists packages (`apps/www`, `database`) that do not exist in this repo. It is a stray copy of the parent monorepo's root config. Left alone rather than deleted with a deploy in flight.

## Verification

The GitHub `build` check does not build this Dockerfile, so it cannot catch any of this. Built the real image locally instead:

- image builds clean on `node:20-alpine`
- `next build` generates all 9 static pages
- no `Ignored build scripts` warning — `sharp`, `prisma`, `@prisma/engines` and `@tailwindcss/oxide` compile during install
- container starts and serves (`307` to the SSO redirect, as expected)
- also verified with `pnpm-workspace.yaml` present alongside, which is the local-dev layout — no conflict

The **runtime image is unchanged**: these are devDependencies, so they never reached the standalone runner either way. The behaviour change is confined to build time.

Blocks pipeline 86 build 16822.