### PR TITLE
Show a tablet's ids and serial on its card

### DIFF
--- a/src/components/tabs/PeripheralsTab.tsx
+++ b/src/components/tabs/PeripheralsTab.tsx
@@ -52,11 +52,28 @@ interface InputDevice {
   name: string
   vendor?: string
   vendorId?: string
+  productId?: string
+  // The Windows client names the USB product id `modelId`; read either.
+  modelId?: string
+  serialNumber?: string
   isBuiltIn?: boolean
   connectionType?: string
   deviceType?: string
   supportsForcTouch?: boolean
   tabletType?: string
+}
+
+/**
+ * A tablet's type badge comes from the client. Payloads collected before the
+ * client carried `tabletType` through the flat input list have none, so derive
+ * one from the name rather than dropping the badge on existing data.
+ */
+const deriveTabletType = (name?: string): string | undefined => {
+  const n = (name || '').toLowerCase()
+  if (!n) return undefined
+  if (n.includes('cintiq') || n.includes('display')) return 'Pen Display'
+  if (n.includes('intuos') || n.includes('bamboo')) return 'Pen Tablet'
+  return undefined
 }
 
 interface InputDevices {
@@ -692,9 +709,12 @@ const InputDevicesContent = ({
           </h4>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {tablets.map((tablet, idx) => (
-              <DeviceCard key={idx} title={tablet.name || 'Graphics Tablet'} icon={Tablet} badge={tablet.tabletType}>
+              <DeviceCard key={idx} title={tablet.name || 'Graphics Tablet'} icon={Tablet} badge={tablet.tabletType || deriveTabletType(tablet.name)}>
                 <div className="space-y-2 text-sm">
                   {tablet.vendor && <InfoRow label="Vendor" value={tablet.vendor} />}
+                  {tablet.vendorId && <InfoRow label="Vendor ID" value={tablet.vendorId} />}
+                  {(tablet.productId || tablet.modelId) && <InfoRow label="Product ID" value={tablet.productId || tablet.modelId || ''} />}
+                  {tablet.serialNumber && <InfoRow label="Serial" value={tablet.serialNumber} />}
                   {tablet.connectionType && <InfoRow label="Connection" value={tablet.connectionType} />}
                 </div>
               </DeviceCard>


### PR DESCRIPTION
The Graphics Tablets card showed only **Vendor** and **Connection**, while the USB card for the same physical device showed vendor id, product id and serial. A pen display is a tracked asset and the serial is what distinguishes one from another — the card that names it as a tablet should carry at least as much as the one that names it as a bus device.

Adds Vendor ID, Product ID and Serial, reading `productId || modelId` exactly as the USB card already does for the Windows client's naming of that value.

Also derives the type badge from the name when the payload carries no `tabletType`. The Windows client only started passing that field through its flat input list in reportmate/reportmate-client-win#66, so data already collected would otherwise render with no badge at all.

Pairs with reportmate/reportmate-client-win#66 (emits the fields) and reportmate/reportmate-client-mac#51 (same on macOS).

### Verification

`tsc --noEmit`: 175 errors before, 175 after — no new type errors. The one pre-existing error in this file (`moduleVersion` missing from `PeripheralsData`) is on `main` and untouched.