### PR TITLE
Fix Last Run on both platforms, and make Recent Events drillable

### DIFF
--- a/src/components/LastRunSummary.tsx
+++ b/src/components/LastRunSummary.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isCimianSessionId } from '../lib/time'
 
 interface LastRunItem {
   name: string
@@ -82,29 +83,38 @@ export function parseInstallsEventPayload(payload: any): LastRunSummaryData | nu
     }
   }
 
-  // Strategy 1: Session-based filtering (Cimian with session timestamps)
+  // Strategy 1: Session-based filtering (items the latest run actually acted on)
   let sessionStartTime = ''
-  if (installsData.cimian?.sessions?.[0]) {
-    sessionStartTime = installsData.cimian.sessions[0].start_time || installsData.cimian.sessions[0].startTime || ''
-  } else if (installsData.recentSessions?.[0]) {
-    sessionStartTime = installsData.recentSessions[0].start_time || installsData.recentSessions[0].startTime || ''
+  let sessionId = ''
+  const latestSession = installsData.cimian?.sessions?.[0] || installsData.recentSessions?.[0]
+  if (latestSession) {
+    sessionStartTime = latestSession.start_time || latestSession.startTime || ''
+    sessionId = latestSession.session_id || latestSession.sessionId || ''
   }
   const sessionTime = sessionStartTime ? new Date(sessionStartTime).getTime() : 0
 
-  if (sessionTime) {
+  if (sessionTime || sessionId) {
     for (const item of rawItems) {
-      const itemTimestamp = item.lastSeenInSession || item.lastUpdate || ''
-      if (!itemTimestamp) continue
-      try {
-        const itemTime = new Date(itemTimestamp).getTime()
-        if (!isNaN(itemTime) && itemTime >= sessionTime - 60000) {
-          lastRunItems.push({
-            name: item.displayName || item.name || 'Unknown',
-            version: item.version || item.installedVersion || '',
-            status: item.status || item.currentStatus || 'Unknown',
-          })
-        }
-      } catch { /* skip */ }
+      // Only lastSeenInSession proves the item was acted on. item.lastUpdate is
+      // stamped on every catalog member at status-check time, so falling back to
+      // it here matched the entire inventory instead of the run.
+      const marker = item.lastSeenInSession || ''
+      if (!marker) continue
+
+      // Cimian sends the session id (yyyy-MM-dd-HHmm), which Date cannot parse.
+      if (isCimianSessionId(marker)) {
+        if (!sessionId || marker.trim() !== sessionId.trim()) continue
+      } else {
+        if (!sessionTime) continue
+        const itemTime = new Date(marker).getTime()
+        if (isNaN(itemTime) || itemTime < sessionTime - 60000) continue
+      }
+
+      lastRunItems.push({
+        name: item.displayName || item.name || 'Unknown',
+        version: item.version || item.installedVersion || '',
+        status: item.status || item.currentStatus || 'Unknown',
+      })
     }
   }
 

--- a/src/components/tables/ManagedInstallsTable.render.test.tsx
+++ b/src/components/tables/ManagedInstallsTable.render.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ManagedInstallsTable } from './ManagedInstallsTable'
+
+const pkg = (over: Record<string, unknown> = {}) => ({
+  id: 'staffsso',
+  name: 'StaffSingleSignOnPrefs',
+  displayName: 'StaffSingleSignOnPrefs',
+  version: '14.3.2',
+  status: 'Warning',
+  type: 'munki',
+  category: 'Preferences',
+  lastUpdate: '2026-08-28T20:47:54.000Z',
+  warnings: [{ id: 'w1', message: 'Will not attempt to remove StaffSingleSignOnPrefs', timestamp: '2026-08-28T20:47:54.000Z', code: 'MUNKI_WARNING', package: 'StaffSingleSignOnPrefs' }],
+  errors: [],
+  ...over,
+})
+
+const data = (packages: unknown[]) => ({
+  totalPackages: packages.length,
+  packages,
+  config: { type: 'munki' },
+  systemName: 'Munki',
+}) as never
+
+// Static rendering does not run effects, so these cover the component's top level and
+// the row markup, not the expanded detail panel (which only mounts once the auto-expand
+// effect has run). An undefined identifier inside that panel is caught by `tsc`, which
+// needs tsconfig's `ignoreDeprecations` to run at all — without it tsc aborts on the
+// baseUrl deprecation before checking a single file.
+describe('ManagedInstallsTable rendering', () => {
+  it('renders a warning row with its detail panel under an active filter', () => {
+    const html = renderToStaticMarkup(
+      <ManagedInstallsTable data={data([pkg()])} initialStatusFilter={['warning']} />
+    )
+    expect(html).toContain('StaffSingleSignOnPrefs')
+  })
+
+  it('renders a pending row carrying a pending reason', () => {
+    const html = renderToStaticMarkup(
+      <ManagedInstallsTable
+        data={data([pkg({ id: 'p', name: 'Pending Thing', displayName: 'Pending Thing', status: 'Pending', warnings: [], pendingReason: 'Update available: 1.0 to 2.0' })])}
+        initialStatusFilter={['pending']}
+      />
+    )
+    expect(html).toContain('Pending Thing')
+  })
+
+  it('renders with no filter applied', () => {
+    const html = renderToStaticMarkup(<ManagedInstallsTable data={data([pkg()])} />)
+    expect(html).toContain('StaffSingleSignOnPrefs')
+  })
+})

--- a/src/components/tables/ManagedInstallsTable.tsx
+++ b/src/components/tables/ManagedInstallsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { formatRelativeTime, formatExactTime } from '../../lib/time';
 import { InstallsInfo, InstallPackage, ErrorMessage, WarningMessage } from '../../lib/data-processing/modules/installs';
 
@@ -35,6 +35,15 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
   const [copiedMessageId, setCopiedMessageId] = useState<string>('');
   const groupByCategory = true; // Always enabled
+
+  const isPendingWithReason = (pkg: InstallPackage): boolean =>
+    pkg.status?.toLowerCase() === 'pending' && !!pkg.pendingReason?.trim();
+
+  // A row is only worth expanding when it carries a message or a pending reason.
+  const hasExpandableContent = (pkg: InstallPackage): boolean =>
+    (pkg.errors?.length ?? 0) > 0 ||
+    (pkg.warnings?.length ?? 0) > 0 ||
+    isPendingWithReason(pkg);
 
   const togglePackageExpansion = (packageId: string) => {
     const newExpandedIds = new Set(expandedPackageIds);
@@ -173,6 +182,30 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
     
     return { groups, sortedCategories };
   }, [filteredPackages, groupByCategory]);
+
+  // A status filter narrows the table to the handful of items that need attention,
+  // and their detail is the reason to filter at all — so open every matching row
+  // rather than making the operator click each chevron. Keyed on the filter itself,
+  // so a row collapsed by hand while a filter is active stays collapsed.
+  const filteredPackagesRef = useRef(filteredPackages);
+  filteredPackagesRef.current = filteredPackages;
+  const statusFilterKey = [...statusFilter].sort().join(',');
+  // The smart loader can swap a partial payload for the full one after mount; re-run
+  // then so a filtered landing still opens its rows. A refresh returning the same
+  // number of packages does not retrigger, so manual collapses survive polling.
+  const packageCount = data?.packages?.length ?? 0;
+
+  useEffect(() => {
+    if (!statusFilterKey) {
+      setExpandedPackageIds(new Set());
+      return;
+    }
+    setExpandedPackageIds(new Set(
+      filteredPackagesRef.current
+        .filter(pkg => hasExpandableContent(pkg))
+        .map(pkg => pkg.id)
+    ));
+  }, [statusFilterKey, packageCount]);
 
   // Check if any packages have categories
   const hasCategories = useMemo(() => {
@@ -599,17 +632,15 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                               
                               {/* Category Packages */}
                               {!isCollapsed && categoryPackages.map((pkg) => {
-                                const hasErrorsOrWarnings = (pkg.errors && pkg.errors.length > 0) || (pkg.warnings && pkg.warnings.length > 0);
-                                const hasPendingReason = pkg.status?.toLowerCase() === 'pending' && pkg.pendingReason && pkg.pendingReason.trim() !== '';
-                                const hasExpandableContent = hasErrorsOrWarnings || hasPendingReason;
+                                const isRowExpandable = hasExpandableContent(pkg);
                                 const isExpanded = expandedPackageIds.has(pkg.id);
                                 
                                 return (
                                   <React.Fragment key={pkg.id}>
                                     {/* Main Package Row */}
                                     <tr 
-                                      className={`hover:bg-gray-50 dark:hover:bg-gray-700 ${hasExpandableContent ? 'cursor-pointer' : ''}`}
-                                      onClick={() => hasExpandableContent && togglePackageExpansion(pkg.id)}
+                                      className={`hover:bg-gray-50 dark:hover:bg-gray-700 ${isRowExpandable ? 'cursor-pointer' : ''}`}
+                                      onClick={() => isRowExpandable && togglePackageExpansion(pkg.id)}
                                     >
                                       <td className="px-6 py-4 whitespace-nowrap pl-12">
                                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusColor(pkg.status || 'unknown')}`}>
@@ -637,7 +668,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                         <div className="flex items-center justify-between">
                                           <span>{pkg.lastUpdate ? formatRelativeTime(pkg.lastUpdate) : ''}</span>
-                                          {hasExpandableContent && (
+                                          {isRowExpandable && (
                                             <svg 
                                               className={`w-5 h-5 text-gray-400 dark:text-gray-500 transition-transform duration-200 ml-2 ${isExpanded ? 'rotate-90' : ''}`}
                                               fill="none" 
@@ -652,7 +683,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                     </tr>
 
                                     {/* Expandable Error/Warning/Pending Details Row */}
-                                    {isExpanded && hasExpandableContent && (
+                                    {isExpanded && isRowExpandable && (
                                       <tr className="bg-gray-50 dark:bg-gray-900">
                                         <td colSpan={5} className="px-6 py-4">
                                           <div className="space-y-3">
@@ -775,7 +806,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                             )}
 
                                             {/* Pending Reason Section */}
-                                            {hasPendingReason && (
+                                            {isPendingWithReason(pkg) && (
                                               <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-cyan-200 dark:border-cyan-700">
                                                 <div className="flex items-start gap-3">
                                                   <div className="flex-shrink-0">
@@ -835,17 +866,15 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                           {[...filteredPackages].sort((a, b) => 
                             (a.displayName || a.name).localeCompare(b.displayName || b.name)
                           ).map((pkg) => {
-                            const hasErrorsOrWarnings = (pkg.errors && pkg.errors.length > 0) || (pkg.warnings && pkg.warnings.length > 0);
-                            const hasPendingReason = pkg.status?.toLowerCase() === 'pending' && pkg.pendingReason && pkg.pendingReason.trim() !== '';
-                            const hasExpandableContent = hasErrorsOrWarnings || hasPendingReason;
+                            const isRowExpandable = hasExpandableContent(pkg);
                             const isExpanded = expandedPackageIds.has(pkg.id);
                             
                             return (
                               <React.Fragment key={pkg.id}>
                             {/* Main Package Row */}
                             <tr 
-                              className={`hover:bg-gray-50 dark:hover:bg-gray-700 ${hasExpandableContent ? 'cursor-pointer' : ''}`}
-                              onClick={() => hasExpandableContent && togglePackageExpansion(pkg.id)}
+                              className={`hover:bg-gray-50 dark:hover:bg-gray-700 ${isRowExpandable ? 'cursor-pointer' : ''}`}
+                              onClick={() => isRowExpandable && togglePackageExpansion(pkg.id)}
                             >
                               <td className="px-6 py-4 whitespace-nowrap">
                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusColor(pkg.status || 'unknown')}`}>
@@ -873,7 +902,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                 <div className="flex items-center justify-between">
                                   <span>{pkg.lastUpdate ? formatRelativeTime(pkg.lastUpdate) : ''}</span>
-                                  {hasExpandableContent && (
+                                  {isRowExpandable && (
                                     <svg 
                                       className={`w-5 h-5 text-gray-400 dark:text-gray-500 transition-transform duration-200 ml-2 ${isExpanded ? 'rotate-90' : ''}`}
                                       fill="none" 
@@ -888,7 +917,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                             </tr>
 
                             {/* Expandable Error/Warning/Pending Details Row */}
-                            {isExpanded && hasExpandableContent && (
+                            {isExpanded && isRowExpandable && (
                               <tr className="bg-gray-50 dark:bg-gray-900">
                                 <td colSpan={5} className="px-6 py-4">
                                   <div className="space-y-3">
@@ -1011,7 +1040,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                     )}
 
                                     {/* Pending Reason Section */}
-                                    {hasPendingReason && (
+                                    {isPendingWithReason(pkg) && (
                                       <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-cyan-200 dark:border-cyan-700">
                                         <div className="flex items-start gap-3">
                                           <div className="flex-shrink-0">

--- a/src/lib/data-processing/modules/installs-last-run.test.ts
+++ b/src/lib/data-processing/modules/installs-last-run.test.ts
@@ -1,0 +1,62 @@
+import { extractInstalls } from './installs'
+
+const session = {
+  session_id: '2026-08-28-1158',
+  start_time: '2026-08-28T11:58:11.4515409-07:00',
+  end_time: '2026-08-28T12:02:26.142207-07:00',
+  status: 'partial_failure',
+  duration_seconds: 254,
+}
+
+const item = (name: string, seen: string) => ({
+  id: `pkg_${name}`,
+  type: 'cimian',
+  itemName: name,
+  displayName: name,
+  itemType: 'managed_installs',
+  currentStatus: 'Installed',
+  installedVersion: '1.0',
+  latestVersion: '1.0',
+  lastUpdate: '2026-08-28T12:02:27.4895139-07:00',
+  lastAttemptTime: '2026-08-28T12:02:27.4895139-07:00',
+  lastAttemptStatus: 'Installed',
+  lastSeenInSession: seen,
+})
+
+const modules = {
+  installs: {
+    lastCheckIn: '2026-08-28T12:27:12Z',
+    cimian: {
+      version: '2026.08.26.1320',
+      sessions: [session],
+      items: [
+        item('ReportMate', '2026-08-28-1158'),
+        item('TaskbarUtil', '2026-08-28-1158'),
+        item('PowerShell', ''),
+        item('Firefox', '2026-08-27-0900'),
+      ],
+    },
+  },
+}
+
+describe('Last Run filter with Cimian session-id markers', () => {
+  const result = extractInstalls(modules as any) as any
+  const byName = (n: string) => result.packages.find((p: any) => p.name === n)
+
+  it('stamps lastUpdate only on items the latest session acted on', () => {
+    expect(result.packages.filter((p: any) => p.lastUpdate).map((p: any) => p.name).sort())
+      .toEqual(['ReportMate', 'TaskbarUtil'])
+  })
+
+  it('resolves the session id to a real timestamp', () => {
+    expect(new Date(byName('ReportMate').lastUpdate).getTime()).not.toBeNaN()
+  })
+
+  it('leaves items only status-checked this run untouched', () => {
+    expect(byName('PowerShell').lastUpdate).toBe('')
+  })
+
+  it('ignores markers from an earlier session', () => {
+    expect(byName('Firefox').lastUpdate).toBe('')
+  })
+})

--- a/src/lib/data-processing/modules/installs-last-run.test.ts
+++ b/src/lib/data-processing/modules/installs-last-run.test.ts
@@ -60,3 +60,55 @@ describe('Last Run filter with Cimian session-id markers', () => {
     expect(byName('Firefox').lastUpdate).toBe('')
   })
 })
+
+describe('Munki problem installs', () => {
+  const munkiDevice = (extra: any) => ({
+    installs: {
+      munki: {
+        startTime: '2026-08-28T20:20:00.000Z',
+        endTime: '2026-08-28T20:20:41.000Z',
+        items: [
+          { id: 'bbedit', name: 'BBEdit', displayName: 'BBEdit', type: 'munki', status: 'install_failed', endTime: '2026-08-28T20:20:41.000Z' },
+        ],
+        ...extra,
+      },
+    },
+  })
+
+  it('splits the semicolon-joined string the Mac client sends', () => {
+    const r = extractInstalls(munkiDevice({
+      problemInstalls: 'BBEdit; Microsoft Defender; Microsoft Word',
+    }) as any) as any
+    expect(r.packages.map((p: any) => p.name).sort())
+      .toEqual(['BBEdit', 'Microsoft Defender', 'Microsoft Word'])
+  })
+
+  it('prefers problemInstallsArray when present', () => {
+    const r = extractInstalls(munkiDevice({
+      problemInstalls: 'BBEdit; Microsoft Defender',
+      problemInstallsArray: ['BBEdit', 'Microsoft Defender'],
+    }) as any) as any
+    expect(r.packages.map((p: any) => p.name).sort()).toEqual(['BBEdit', 'Microsoft Defender'])
+  })
+
+  it('matches an existing item by display name instead of duplicating it', () => {
+    const r = extractInstalls({
+      installs: {
+        munki: {
+          startTime: '2026-08-28T20:20:00.000Z',
+          endTime: '2026-08-28T20:20:41.000Z',
+          items: [
+            { id: 'defender', name: 'Defender', displayName: 'Microsoft Defender', type: 'munki', status: 'install_failed', endTime: '2026-08-28T20:20:41.000Z' },
+          ],
+          problemInstalls: 'Microsoft Defender',
+        },
+      },
+    } as any) as any
+    expect(r.packages.map((p: any) => p.name)).toEqual(['Defender'])
+  })
+
+  it('still handles a comma-joined legacy string', () => {
+    const r = extractInstalls(munkiDevice({ problemInstalls: 'BBEdit, Firefox' }) as any) as any
+    expect(r.packages.map((p: any) => p.name).sort()).toEqual(['BBEdit', 'Firefox'])
+  })
+})

--- a/src/lib/data-processing/modules/installs.ts
+++ b/src/lib/data-processing/modules/installs.ts
@@ -1278,10 +1278,21 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
       }
     }
     
-    if (installs.munki?.problemInstalls && installs.munki.problemInstalls.trim() !== '') {
-      const problemItems = installs.munki.problemInstalls.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
+    // The Mac client joins ProblemInstalls names with "; " and also ships them as
+    // problemInstallsArray. Splitting the joined string on "," therefore yielded a
+    // single fake package literally named "BBEdit; Microsoft Defender; Microsoft
+    // Excel; ..." — prefer the array, and split on ";" when only the string is present.
+    const problemInstallsArray = installs.munki?.problemInstallsArray || installs.munki?.problem_installs_array
+    if (Array.isArray(problemInstallsArray) || (installs.munki?.problemInstalls && installs.munki.problemInstalls.trim() !== '')) {
+      const problemItems: string[] = Array.isArray(problemInstallsArray)
+        ? problemInstallsArray.map((s: string) => String(s).trim()).filter((s: string) => s.length > 0)
+        : installs.munki.problemInstalls.split(/[;,]/).map((s: string) => s.trim()).filter((s: string) => s.length > 0)
       for (const itemName of problemItems) {
-        let pkg = packages.find(p => p.name.toLowerCase() === itemName.toLowerCase())
+        // ProblemInstalls carries Munki's display_name ("Microsoft Defender") while
+        // the items array carries the short name ("Defender"), so match on both —
+        // otherwise every problem install is duplicated as a second phantom row.
+        const needle = itemName.toLowerCase()
+        let pkg = packages.find(p => p.name?.toLowerCase() === needle || p.displayName?.toLowerCase() === needle)
         if (!pkg) {
           pkg = {
             id: itemName.toLowerCase().replace(/\s+/g, '-'),

--- a/src/lib/data-processing/modules/installs.ts
+++ b/src/lib/data-processing/modules/installs.ts
@@ -1,4 +1,4 @@
-import { normalizeCimianTimestamp } from '../../time'
+import { normalizeCimianTimestamp, isCimianSessionId } from '../../time'
 
 /**
  * Installs Status Module
@@ -614,15 +614,26 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
   }
   // Declared here to avoid TDZ — used inside the package processing loop below
   let latestSessionStartTime = ''
+  let latestSessionEndTime = ''
+  // Cimian stamps last_seen_in_session with the session *id* (yyyy-MM-dd-HHmm),
+  // not a timestamp, so the item-to-run match is an id comparison.
+  let latestSessionId = ''
 
   // Determine the latest session's start_time BEFORE the package loop so lastUpdate IIFE can use it
   if (installs.cimian?.sessions && Array.isArray(installs.cimian.sessions) && installs.cimian.sessions.length > 0) {
-    latestSessionStartTime = installs.cimian.sessions[0].start_time || installs.cimian.sessions[0].startTime || ''
+    const latestSession = installs.cimian.sessions[0]
+    latestSessionStartTime = latestSession.start_time || latestSession.startTime || ''
+    latestSessionEndTime = latestSession.end_time || latestSession.endTime || ''
+    latestSessionId = latestSession.session_id || latestSession.sessionId || ''
   } else if (installs.recentSessions && Array.isArray(installs.recentSessions) && installs.recentSessions.length > 0) {
-    latestSessionStartTime = installs.recentSessions[0].start_time || installs.recentSessions[0].startTime || ''
+    const latestSession = installs.recentSessions[0]
+    latestSessionStartTime = latestSession.start_time || latestSession.startTime || ''
+    latestSessionEndTime = latestSession.end_time || latestSession.endTime || ''
+    latestSessionId = latestSession.session_id || latestSession.sessionId || ''
   } else if (installs.munki?.startTime || installs.munki?.endTime) {
     // Use startTime (run begin) so items installed during the run fall within the window
     latestSessionStartTime = installs.munki.startTime || installs.munki.endTime
+    latestSessionEndTime = installs.munki.endTime || ''
   }
 
   // Determine which managed software system to use
@@ -778,21 +789,31 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
         // DATE PROCESSED: Only show for items processed in the LATEST session
         // Items from older sessions get empty (they weren't touched in this run)
         lastUpdate: (() => {
-          // Use lastSeenInSession as the authoritative timestamp
-          // Do NOT fall back to item.lastUpdate — for Munki items, the ...item spread
-          // carries raw fields that may have stale or global timestamps
-          const itemTimestamp = item.lastSeenInSession || ''
-          if (!itemTimestamp || !latestSessionStartTime) return ''
-          // Check if this item was processed in the latest session
-          // Compare the item's lastSeenInSession with the latest session's start_time
-          // If they're from the same session (within a reasonable window), show the timestamp
+          // Use lastSeenInSession as the authoritative marker of "acted on in this run".
+          // Do NOT fall back to item.lastUpdate — Cimian stamps that on every catalog
+          // member at status-check time, and for Munki items the ...item spread carries
+          // raw fields that may hold stale or global timestamps. Either fallback makes
+          // the Last Run filter match the whole inventory.
+          const marker = item.lastSeenInSession || ''
+          if (!marker) return ''
+
+          // Cimian: the marker is a session id (yyyy-MM-dd-HHmm), which Date cannot
+          // parse. Match it against the latest session's id, then show a real
+          // timestamp for the item — its own attempt time when present, else the run.
+          if (isCimianSessionId(marker)) {
+            if (!latestSessionId || marker.trim() !== latestSessionId.trim()) return ''
+            const displayTime = item.lastAttemptTime || item.lastUpdate || latestSessionEndTime || latestSessionStartTime
+            return displayTime ? normalizeCimianTimestamp(displayTime) : ''
+          }
+
+          // Munki (and any client still sending a timestamp): keep the window compare.
+          if (!latestSessionStartTime) return ''
           try {
-            const itemTime = new Date(normalizeCimianTimestamp(itemTimestamp)).getTime()
+            const itemTime = new Date(normalizeCimianTimestamp(marker)).getTime()
             const sessionTime = new Date(latestSessionStartTime).getTime()
             // Items processed in the latest session will have timestamps >= session start_time
-            // Use a 2-hour window to account for long-running sessions
             if (!isNaN(itemTime) && !isNaN(sessionTime) && itemTime >= sessionTime - 60000) {
-              return normalizeCimianTimestamp(itemTimestamp)
+              return normalizeCimianTimestamp(marker)
             }
           } catch { /* fall through */ }
           return ''

--- a/src/lib/eventLinks.test.ts
+++ b/src/lib/eventLinks.test.ts
@@ -1,0 +1,51 @@
+import { getEventDeviceHrefSuffix, getEventModuleId } from './eventLinks'
+
+const event = (kind: string, message: string) => ({ kind, message })
+
+describe('getEventDeviceHrefSuffix', () => {
+  it('lands a Munki warning on the installs tab filtered to warnings', () => {
+    expect(getEventDeviceHrefSuffix(event('warning', '2 Munki warnings'))).toBe('?filter=warning#installs')
+  })
+
+  it('lands a Munki error on the error filter', () => {
+    expect(getEventDeviceHrefSuffix(event('error', '44 Munki errors'))).toBe('?filter=error#installs')
+  })
+
+  it('lands a failed install on the error filter', () => {
+    expect(getEventDeviceHrefSuffix(event('error', 'RenderingManager 2026.08.27.1706 failed to install')))
+      .toBe('?filter=error#installs')
+  })
+
+  it('lands a success on Last Run rather than the whole installed inventory', () => {
+    expect(getEventDeviceHrefSuffix(event('success', '2 packages installed'))).toBe('?filter=last_run#installs')
+    expect(getEventDeviceHrefSuffix(event('success', '3 packages updated'))).toBe('?filter=last_run#installs')
+  })
+
+  it('routes non-installs modules to their tab with no filter', () => {
+    expect(getEventDeviceHrefSuffix(event('info', 'Hardware data reported'))).toBe('#hardware')
+    expect(getEventDeviceHrefSuffix(event('info', 'Inventory data reported'))).toBe('#inventory')
+    expect(getEventDeviceHrefSuffix(event('info', 'System module data reported'))).toBe('#system')
+  })
+
+  it('prefers an explicit module_id over the message', () => {
+    expect(getEventModuleId({ kind: 'info', message: 'Hardware data reported', payload: { module_id: 'network' } }))
+      .toBe('network')
+  })
+
+  it('treats an unmatched run-level warning as installs', () => {
+    expect(getEventDeviceHrefSuffix(event('warning', 'AmdAdrenalinDriver warning'))).toBe('?filter=warning#installs')
+    expect(getEventDeviceHrefSuffix(event('warning', '2 warnings'))).toBe('?filter=warning#installs')
+  })
+
+  it('gives info events no installs fallback', () => {
+    expect(getEventDeviceHrefSuffix(event('info', '4 modules reported'))).toBe('')
+  })
+
+  it('lets a named module win over the installs fallback', () => {
+    expect(getEventDeviceHrefSuffix(event('warning', 'Firewall is disabled'))).toBe('#security')
+  })
+
+  it('returns no suffix when the module cannot be identified', () => {
+    expect(getEventDeviceHrefSuffix(event('info', '4 modules reported'))).toBe('')
+  })
+})

--- a/src/lib/eventLinks.ts
+++ b/src/lib/eventLinks.ts
@@ -1,0 +1,79 @@
+/**
+ * Where a Recent Events row's device link should land.
+ *
+ * The events list endpoint omits payloads, so module detection runs on the event
+ * message. That matters most for installs: a "2 Munki warnings" row has to land on
+ * the installs tab with the warning filter already applied, not on the device's
+ * default tab, or the operator has to hunt for the two items among 140.
+ */
+
+export interface LinkableEvent {
+  kind: string
+  message?: string
+  payload?: Record<string, unknown> | string | null
+}
+
+// Munki and Cimian both report through the installs module, and their messages name
+// the tool, the action, or the unit — none of which contain the word "installs".
+const INSTALLS_MESSAGE = /\b(munki|cimian|managed software|package|packages|install|installs|installed|installing|uninstall|removal|removed|update|updated|pkginfo|manifest|catalog)\b/i
+
+const MODULE_MESSAGE_PATTERNS: Array<[string, RegExp]> = [
+  ['hardware', /\b(hardware|cpu|processor|memory|ram|disk|storage|battery)\b/i],
+  ['network', /\b(network|wifi|wi-fi|ethernet|dns|dhcp|ip address)\b/i],
+  ['security', /\b(security|antivirus|defender|firewall|tpm|encryption|filevault|bitlocker)\b/i],
+  ['management', /\b(profile|policy|configuration|management|mdm|enrollment|intune)\b/i],
+  ['applications', /\b(application|applications|app)\b/i],
+  ['inventory', /\b(inventory|asset tag|serial)\b/i],
+  ['peripherals', /\b(peripheral|printer|display|monitor|keyboard|mouse)\b/i],
+  ['identity', /\b(identity|account|user|logon)\b/i],
+  ['system', /\b(system|operating system|os|uptime|boot)\b/i],
+]
+
+/** The installs-tab filter that shows what this event is actually reporting. */
+function installsFilterForKind(kind: string): string {
+  switch (kind.toLowerCase()) {
+    case 'error':
+      return 'error'
+    case 'warning':
+      return 'warning'
+    // A success event reports what the run did, which is exactly the Last Run set —
+    // the "installed" filter would show the whole inventory instead.
+    default:
+      return 'last_run'
+  }
+}
+
+export function getEventModuleId(event: LinkableEvent): string | null {
+  if (event.payload && typeof event.payload === 'object') {
+    const moduleId = (event.payload as Record<string, unknown>).module_id
+    if (typeof moduleId === 'string' && moduleId) return moduleId
+  }
+
+  const message = event.message || ''
+  if (!message) return null
+
+  // Installs is checked first: its vocabulary overlaps several others ("software
+  // update", "configuration profile removed") and it is the tab that benefits most
+  // from a filtered landing.
+  if (INSTALLS_MESSAGE.test(message)) return 'installs'
+
+  for (const [moduleId, pattern] of MODULE_MESSAGE_PATTERNS) {
+    if (pattern.test(message)) return moduleId
+  }
+
+  // Success, warning and error events are raised by the managed-software run, so an
+  // unmatched one ("AmdAdrenalinDriver warning", "2 warnings") is an installs event
+  // whose message simply names the item rather than the tool. Info and system events
+  // get no such fallback — they are routine collection chatter.
+  if (['success', 'warning', 'error'].includes(event.kind?.toLowerCase())) return 'installs'
+
+  return null
+}
+
+/** Path suffix appended to /device/<serial> for an event row's device link. */
+export function getEventDeviceHrefSuffix(event: LinkableEvent): string {
+  const moduleId = getEventModuleId(event)
+  if (!moduleId) return ''
+  if (moduleId === 'installs') return `?filter=${installsFilterForKind(event.kind)}#installs`
+  return `#${moduleId}`
+}

--- a/src/lib/eventPayloadDetails.test.ts
+++ b/src/lib/eventPayloadDetails.test.ts
@@ -1,0 +1,72 @@
+import { summarizeEventPayload } from './eventPayloadDetails'
+
+describe('summarizeEventPayload', () => {
+  it('expands a comma-joined module string', () => {
+    const s = summarizeEventPayload({ modules: 'security, network, management, hardware', moduleCount: '4' })
+    expect(s.modules).toEqual(['security', 'network', 'management', 'hardware'])
+  })
+
+  it('reads a module array', () => {
+    const s = summarizeEventPayload({ modules: ['security', 'network'], collectionType: 'Full' })
+    expect(s.modules).toEqual(['security', 'network'])
+    expect(s.context).toContainEqual({ label: 'Collection', value: 'Full' })
+  })
+
+  it('lists installed items with versions and run context', () => {
+    const s = summarizeEventPayload({
+      count: 3,
+      action: 'update',
+      run_type: 'auto',
+      session_id: '2026-08-28-0949',
+      duration_seconds: 117,
+      items: [
+        { name: 'TaskbarUtil', version: '2026.08.27.1927' },
+        { name: 'DisableWidgets', version: '2026.08.27.1701' },
+      ],
+    })
+    expect(s.groups).toHaveLength(1)
+    expect(s.groups[0].items[0]).toEqual({ name: 'TaskbarUtil', version: '2026.08.27.1927', detail: undefined })
+    expect(s.context).toContainEqual({ label: 'Duration', value: '1m 57s' })
+  })
+
+  it('separates failed and warning items by tone', () => {
+    const s = summarizeEventPayload({
+      failed_items: [{ name: 'RenderingManager', version: '2026.08.27.1706' }],
+      warning_items: [{ name: 'AmdAdrenalinDriver', version: '26.3.1.0' }],
+    })
+    expect(s.groups.map(g => [g.label, g.tone])).toEqual([['Warnings', 'warning'], ['Failed', 'error']])
+  })
+
+  it('drops installer progress ticks from a semicolon-joined errors string', () => {
+    const s = summarizeEventPayload({
+      errors: [
+        '------------------------------------------------------------------------------',
+        'installer: Package name is Microsoft Defender',
+        'installer:PHASE:Preparing for installation',
+        'installer:%3.726477',
+        'installer:%84.876000',
+      ].join('; '),
+    })
+    expect(s.messages.map(m => m.text)).toEqual(['installer: Package name is Microsoft Defender'])
+    expect(s.suppressedMessageCount).toBe(4)
+  })
+
+  it('keeps a line when the output was nothing but progress', () => {
+    const s = summarizeEventPayload({ errors: 'installer:%12.0; installer:%99.0' })
+    expect(s.messages).toHaveLength(1)
+    expect(s.suppressedMessageCount).toBe(1)
+  })
+
+  it('keeps genuine multi-part error text intact', () => {
+    const s = summarizeEventPayload({
+      errors: 'HTTP Error downloading CSV: 000 (all sources tried); This could be a network connectivity issue',
+    })
+    expect(s.messages).toHaveLength(2)
+    expect(s.suppressedMessageCount).toBe(0)
+  })
+
+  it('reports an empty summary for a payload with nothing to show', () => {
+    expect(summarizeEventPayload(null).isEmpty).toBe(true)
+    expect(summarizeEventPayload({ moduleData: { inventory: {} } }).isEmpty).toBe(true)
+  })
+})

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -1,0 +1,163 @@
+/**
+ * Turn a raw event payload into the sections the Recent Events accordion renders.
+ *
+ * Event payloads are not uniform: a data-collection event carries a module list, an
+ * installs event carries an items array, and a Munki failure carries a single
+ * semicolon-joined `errors` string. This module normalises all of them into the
+ * same four sections so the row rendering stays declarative.
+ */
+
+export interface EventDetailItem {
+  name: string
+  version?: string
+  detail?: string
+}
+
+export interface EventDetailGroup {
+  key: string
+  label: string
+  tone: 'neutral' | 'success' | 'warning' | 'error'
+  items: EventDetailItem[]
+}
+
+export interface EventDetailSummary {
+  modules: string[]
+  groups: EventDetailGroup[]
+  messages: Array<{ tone: 'warning' | 'error' | 'neutral'; text: string }>
+  /** Progress lines dropped from the message list, so the count is still honest. */
+  suppressedMessageCount: number
+  context: Array<{ label: string; value: string }>
+  isEmpty: boolean
+}
+
+// Munki pipes the raw `installer` command output into the errors string, which is
+// mostly percentage ticks. They are noise in a summary but shouldn't vanish silently.
+const PROGRESS_LINE = /^installer:(%|PHASE:|STATUS:)/i
+const DIVIDER_LINE = /^-{5,}$/
+
+const CONTEXT_LABELS: Record<string, string> = {
+  run_type: 'Run type',
+  session_id: 'Session',
+  duration_seconds: 'Duration',
+  collection_type: 'Collection',
+  collectionType: 'Collection',
+  module_status: 'Status',
+  session_installs: 'Installs',
+  session_updates: 'Updates',
+  session_removals: 'Removals',
+  operating_system: 'OS',
+  display_version: 'Release',
+  version: 'Version',
+  uptime: 'Uptime',
+  action: 'Action',
+}
+
+const ITEM_GROUPS: Array<{ key: string; label: string; tone: EventDetailGroup['tone'] }> = [
+  { key: 'items', label: 'Items', tone: 'neutral' },
+  { key: 'newlyInstalledItems', label: 'Newly installed', tone: 'success' },
+  { key: 'installed_items', label: 'Installed', tone: 'success' },
+  { key: 'removed_items', label: 'Removed', tone: 'neutral' },
+  { key: 'warning_items', label: 'Warnings', tone: 'warning' },
+  { key: 'failed_items', label: 'Failed', tone: 'error' },
+]
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+
+/** Split the semicolon-joined strings the clients send, and drop installer progress ticks. */
+function splitMessages(raw: unknown): { kept: string[]; suppressed: number } {
+  const lines: string[] = Array.isArray(raw)
+    ? raw.map(v => String(v))
+    : typeof raw === 'string'
+      ? raw.split(';')
+      : []
+
+  const trimmed = lines.map(l => l.trim()).filter(l => l.length > 0)
+  const kept = trimmed.filter(l => !PROGRESS_LINE.test(l) && !DIVIDER_LINE.test(l))
+  // A run whose output was nothing but progress still needs to say something.
+  if (kept.length === 0 && trimmed.length > 0) {
+    return { kept: [trimmed[trimmed.length - 1]], suppressed: trimmed.length - 1 }
+  }
+  return { kept, suppressed: trimmed.length - kept.length }
+}
+
+function normalizeItem(raw: unknown): EventDetailItem | null {
+  if (typeof raw === 'string') return raw.trim() ? { name: raw.trim() } : null
+  const rec = asRecord(raw)
+  if (!rec) return null
+  const name = String(rec.name ?? rec.displayName ?? rec.display_name ?? rec.item_name ?? '').trim()
+  if (!name) return null
+  const version = rec.version ?? rec.installedVersion ?? rec.installed_version
+  const detail = rec.error ?? rec.warning ?? rec.reason ?? rec.pending_reason
+  return {
+    name,
+    version: version ? String(version) : undefined,
+    detail: detail ? String(detail) : undefined,
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  const rem = seconds % 60
+  return rem ? `${mins}m ${rem}s` : `${mins}m`
+}
+
+export function summarizeEventPayload(payload: unknown): EventDetailSummary {
+  const p = asRecord(payload)
+  const empty: EventDetailSummary = {
+    modules: [], groups: [], messages: [], suppressedMessageCount: 0, context: [], isEmpty: true,
+  }
+  if (!p) return empty
+
+  // Modules arrive either as an array or as a comma-joined string.
+  const rawModules = p.modules
+  const modules = (Array.isArray(rawModules)
+    ? rawModules.map(m => String(m))
+    : typeof rawModules === 'string'
+      ? rawModules.split(',')
+      : []
+  ).map(m => m.trim()).filter(Boolean)
+
+  const groups: EventDetailGroup[] = []
+  for (const { key, label, tone } of ITEM_GROUPS) {
+    const raw = p[key]
+    if (!Array.isArray(raw)) continue
+    const items = raw.map(normalizeItem).filter((i): i is EventDetailItem => i !== null)
+    if (items.length) groups.push({ key, label, tone, items })
+  }
+
+  const messages: EventDetailSummary['messages'] = []
+  let suppressedMessageCount = 0
+  for (const [key, tone] of [
+    ['errors', 'error'], ['error_messages', 'error'],
+    ['warnings', 'warning'], ['warning_messages', 'warning'],
+    ['recommendation', 'neutral'],
+  ] as const) {
+    const { kept, suppressed } = splitMessages(p[key])
+    suppressedMessageCount += suppressed
+    for (const text of kept) messages.push({ tone, text })
+  }
+
+  const context: EventDetailSummary['context'] = []
+  for (const [key, label] of Object.entries(CONTEXT_LABELS)) {
+    const value = p[key]
+    if (value === undefined || value === null || value === '') continue
+    if (key === 'duration_seconds') {
+      const seconds = Number(value)
+      if (Number.isFinite(seconds)) context.push({ label, value: formatDuration(seconds) })
+      continue
+    }
+    if (typeof value === 'object') continue
+    context.push({ label, value: String(value) })
+  }
+
+  return {
+    modules,
+    groups,
+    messages,
+    suppressedMessageCount,
+    context,
+    isEmpty: modules.length === 0 && groups.length === 0 && messages.length === 0 && context.length === 0,
+  }
+}

--- a/src/lib/modules/widgets/EventDetails.tsx
+++ b/src/lib/modules/widgets/EventDetails.tsx
@@ -1,0 +1,193 @@
+/**
+ * Expanded detail body for a Recent Events row.
+ *
+ * The events list endpoint deliberately omits payloads, so the body fetches
+ * /api/events/<id>/payload on first expand and caches it for the session. A bundled
+ * row fetches each constituent event and merges the result.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { summarizeEventPayload, type EventDetailSummary } from '../../eventPayloadDetails'
+
+// Bundles are routine data-collection groupings; a handful of fetches covers them.
+const MAX_BUNDLE_FETCHES = 8
+
+const payloadCache = new Map<string, unknown>()
+
+async function fetchPayload(eventId: string): Promise<unknown> {
+  if (payloadCache.has(eventId)) return payloadCache.get(eventId)
+  const response = await fetch(`/api/events/${encodeURIComponent(eventId)}/payload`)
+  if (!response.ok) throw new Error(`Payload unavailable (${response.status})`)
+  const body = await response.json()
+  const payload = body?.payload ?? body
+  payloadCache.set(eventId, payload)
+  return payload
+}
+
+function mergeSummaries(summaries: EventDetailSummary[]): EventDetailSummary {
+  const modules = new Set<string>()
+  const groups = new Map<string, EventDetailSummary['groups'][number]>()
+  const messages: EventDetailSummary['messages'] = []
+  const context = new Map<string, string>()
+  let suppressedMessageCount = 0
+
+  for (const summary of summaries) {
+    summary.modules.forEach(m => modules.add(m))
+    for (const group of summary.groups) {
+      const existing = groups.get(group.key)
+      if (existing) existing.items.push(...group.items)
+      else groups.set(group.key, { ...group, items: [...group.items] })
+    }
+    for (const message of summary.messages) {
+      if (!messages.some(m => m.text === message.text)) messages.push(message)
+    }
+    suppressedMessageCount += summary.suppressedMessageCount
+    summary.context.forEach(({ label, value }) => { if (!context.has(label)) context.set(label, value) })
+  }
+
+  const merged = {
+    modules: [...modules],
+    groups: [...groups.values()],
+    messages,
+    suppressedMessageCount,
+    context: [...context].map(([label, value]) => ({ label, value })),
+  }
+  return {
+    ...merged,
+    isEmpty: merged.modules.length === 0 && merged.groups.length === 0 &&
+      merged.messages.length === 0 && merged.context.length === 0,
+  }
+}
+
+const TONE_TEXT: Record<string, string> = {
+  neutral: 'text-gray-700 dark:text-gray-300',
+  success: 'text-green-700 dark:text-green-400',
+  warning: 'text-yellow-700 dark:text-yellow-400',
+  error: 'text-red-700 dark:text-red-400',
+}
+
+const TONE_DOT: Record<string, string> = {
+  neutral: 'bg-gray-400',
+  success: 'bg-green-500',
+  warning: 'bg-yellow-500',
+  error: 'bg-red-500',
+}
+
+const SectionLabel: React.FC<{ children: React.ReactNode; count?: number }> = ({ children, count }) => (
+  <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+    {children}
+    {count !== undefined && <span className="ml-1.5 font-normal text-gray-400 dark:text-gray-500">{count}</span>}
+  </div>
+)
+
+export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => {
+  const [summary, setSummary] = useState<EventDetailSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  // The parent rebuilds its bundles on every poll, so depend on the ids themselves
+  // rather than the array identity — otherwise each poll flashes the skeleton back.
+  const idKey = eventIds.join(',')
+
+  useEffect(() => {
+    let cancelled = false
+    setError(null)
+    setSummary(null)
+
+    Promise.all(idKey.split(',').slice(0, MAX_BUNDLE_FETCHES).map(fetchPayload))
+      .then(payloads => {
+        if (cancelled) return
+        setSummary(mergeSummaries(payloads.map(summarizeEventPayload)))
+      })
+      .catch((e: Error) => { if (!cancelled) setError(e.message) })
+
+    return () => { cancelled = true }
+  }, [idKey])
+
+  if (error) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">{error}</p>
+  }
+
+  if (!summary) {
+    return (
+      <div className="space-y-2 animate-pulse" aria-label="Loading event details">
+        <div className="h-3 w-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+        <div className="h-3 w-2/3 bg-gray-200 dark:bg-gray-700 rounded"></div>
+      </div>
+    )
+  }
+
+  if (summary.isEmpty) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No further detail was reported for this event.</p>
+  }
+
+  return (
+    <div className="space-y-5">
+      {summary.modules.length > 0 && (
+        <div>
+          <SectionLabel count={summary.modules.length}>Modules</SectionLabel>
+          <div className="flex flex-wrap gap-1.5">
+            {summary.modules.map(module => (
+              <span
+                key={module}
+                className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 capitalize"
+              >
+                {module}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {summary.groups.map(group => (
+        <div key={group.key}>
+          <SectionLabel count={group.items.length}>{group.label}</SectionLabel>
+          <ul className="grid gap-x-6 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
+            {group.items.map((item, index) => (
+              <li key={`${item.name}-${index}`} className="flex items-baseline gap-2 min-w-0">
+                <span className={`w-1.5 h-1.5 rounded-full shrink-0 translate-y-[-1px] ${TONE_DOT[group.tone]}`}></span>
+                <span className={`text-sm truncate ${TONE_TEXT[group.tone]}`}>{item.name}</span>
+                {item.version && (
+                  <span className="text-xs text-gray-500 dark:text-gray-400 font-mono shrink-0">{item.version}</span>
+                )}
+                {item.detail && (
+                  <span className="text-xs text-gray-500 dark:text-gray-400 truncate">{item.detail}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      {summary.messages.length > 0 && (
+        <div>
+          <SectionLabel count={summary.messages.length}>Messages</SectionLabel>
+          <ul className="space-y-1">
+            {summary.messages.map((message, index) => (
+              <li
+                key={index}
+                className={`text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[message.tone]}`}
+              >
+                {message.text}
+              </li>
+            ))}
+          </ul>
+          {summary.suppressedMessageCount > 0 && (
+            <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
+              {summary.suppressedMessageCount} installer progress {summary.suppressedMessageCount === 1 ? 'line' : 'lines'} hidden
+            </p>
+          )}
+        </div>
+      )}
+
+      {summary.context.length > 0 && (
+        <dl className="flex flex-wrap gap-x-6 gap-y-1">
+          {summary.context.map(({ label, value }) => (
+            <div key={label} className="flex items-baseline gap-1.5">
+              <dt className="text-xs text-gray-500 dark:text-gray-400">{label}</dt>
+              <dd className="text-xs font-medium text-gray-700 dark:text-gray-300 font-mono">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  )
+}

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -8,6 +8,8 @@ import Link from 'next/link'
 import { formatRelativeTime } from '../../time'
 import { bundleEvents, formatPayloadPreview, type FleetEvent, type BundledEvent } from '../../eventBundling'
 import { SlidersHorizontal } from 'lucide-react'
+import { EventDetails } from './EventDetails'
+import { getEventModuleId, getEventDeviceHrefSuffix } from '../../eventLinks'
 
 interface RecentEventsTableProps {
   events: FleetEvent[]
@@ -65,48 +67,6 @@ const getFilterIcon = (key: string) => {
     default:
       return null
   }
-}
-
-// Helper function to detect module type from event
-const getEventModuleId = (event: BundledEvent): string | null => {
-  // Check if the event payload contains module_id
-  if (event.payload && typeof event.payload === 'object') {
-    const moduleId = (event.payload as any).module_id
-    if (moduleId && typeof moduleId === 'string') {
-      return moduleId
-    }
-  }
-  
-  // Fallback: try to detect module from message content
-  const message = event.message?.toLowerCase() || ''
-  
-  // Common module patterns in messages
-  if (message.includes('install') || message.includes('package') || message.includes('cimian')) {
-    return 'installs'
-  }
-  if (message.includes('hardware') || message.includes('cpu') || message.includes('memory') || message.includes('disk')) {
-    return 'hardware'
-  }
-  if (message.includes('network') || message.includes('wifi') || message.includes('ethernet') || message.includes('ip')) {
-    return 'network'
-  }
-  if (message.includes('profile') || message.includes('policy') || message.includes('configuration')) {
-    return 'management'  // Profiles merged into Management
-  }
-  if (message.includes('security') || message.includes('antivirus') || message.includes('firewall') || message.includes('tpm')) {
-    return 'security'
-  }
-  if (message.includes('system') || message.includes('os') || message.includes('operating system')) {
-    return 'system'
-  }
-  if (message.includes('application') || message.includes('software') || message.includes('app')) {
-    return 'applications'
-  }
-  if (message.includes('management') || message.includes('mdm') || message.includes('enrollment')) {
-    return 'management'
-  }
-  
-  return null
 }
 
 // Helper function to check if event is from a specific module (backward compatibility)
@@ -229,16 +189,16 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
-  // All types visible by default
-  const DEFAULT_HIDDEN = useMemo(() => new Set<string>([]), [])
-  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set([]))
+  // Info is the firehose — routine data-collection chatter that drowns the events
+  // worth reacting to. It is hidden by default and opted into from the filter.
+  const DEFAULT_HIDDEN = useMemo(() => new Set<string>(['info']), [])
+  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set(['info']))
   // Only show filter as active when user has deviated from the default state
   const isFilterCustomized = hiddenTypes.size !== DEFAULT_HIDDEN.size ||
     [...hiddenTypes].some(t => !DEFAULT_HIDDEN.has(t))
   const [filterOpen, setFilterOpen] = useState(false)
   const filterRef = useRef<HTMLDivElement>(null)
-  // TODO: Accordion functionality disabled for now - will revisit later
-  // const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set())
+  const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set())
   const timeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 
   // Bundle related events intelligently
@@ -268,18 +228,18 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
     })
   }
   
-  // TODO: Accordion toggle disabled for now - will revisit later
-  // const toggleExpanded = (eventId: string) => {
-  //   setExpandedEvents(prev => {
-  //     const next = new Set(prev)
-  //     if (next.has(eventId)) {
-  //       next.delete(eventId)
-  //     } else {
-  //       next.add(eventId)
-  //     }
-  //     return next
-  //   })
-  // }
+  const toggleExpanded = (eventId: string) => {
+    setExpandedEvents(prev => {
+      const next = new Set(prev)
+      if (next.has(eventId)) next.delete(eventId)
+      else next.add(eventId)
+      return next
+    })
+  }
+
+  // Collapse everything when the filter changes, so a hidden row can't stay open
+  // behind the filter and reappear expanded.
+  useEffect(() => { setExpandedEvents(new Set()) }, [hiddenTypes])
 
   const handleMouseEnter = () => {
     setIsHovered(true)
@@ -620,32 +580,37 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                         </td>
                       </tr>
                     ) : filteredEvents.map((bundledEvent: BundledEvent) => {
-                      // TODO: Accordion expand/collapse functionality disabled for now
-                      // const isExpanded = expandedEvents.has(bundledEvent.id)
-                      // const hasDetails = bundledEvent.hasExpandableDetails
-                      
+                      const isExpanded = expandedEvents.has(bundledEvent.id)
+
                       return (
                         <React.Fragment key={bundledEvent.id}>
-                          <tr 
-                            className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                            // TODO: Accordion click disabled for now
-                            // onClick={hasDetails ? () => toggleExpanded(bundledEvent.id) : undefined}
+                          <tr
+                            className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                            onClick={() => toggleExpanded(bundledEvent.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                toggleExpanded(bundledEvent.id)
+                              }
+                            }}
+                            tabIndex={0}
+                            role="button"
+                            aria-expanded={isExpanded}
                           >
                             <td className="w-20 px-3 py-2.5">
-                              <div className="flex items-center justify-center">
-                                {/* TODO: Accordion chevron disabled for now - just show status icon */}
+                              <div className="flex items-center gap-1">
+                                <svg
+                                  className={`w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-gray-500 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                                  fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" aria-hidden="true"
+                                >
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                                </svg>
                                 {getStatusIcon(bundledEvent.kind)}
                               </div>
                             </td>
                             <td className="w-56 px-3 py-2.5">
                               <Link
-                                href={`/device/${encodeURIComponent(bundledEvent.device)}${(() => {
-                                  // For installs events, always navigate to the "Last Run" filter
-                                  // so users can see exactly which packages were processed
-                                  const moduleId = getEventModuleId(bundledEvent)
-                                  if (moduleId === 'installs') return '?filter=last_run#installs'
-                                  return moduleId ? `#${moduleId}` : ''
-                                })()}`}
+                                href={`/device/${encodeURIComponent(bundledEvent.device)}${getEventDeviceHrefSuffix(bundledEvent)}`}
                                 className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors block truncate"
                                 onClick={(e) => e.stopPropagation()}
                               >
@@ -660,13 +625,6 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                     ({bundledEvent.bundledKinds.join(', ')})
                                   </span>
                                 )}
-                                {/* TODO: Accordion hint disabled for now
-                                {hasDetails && !isExpanded && (
-                                  <span className="text-xs text-gray-400 dark:text-gray-500 ml-2">
-                                    (click to expand)
-                                  </span>
-                                )}
-                                */}
                               </div>
                             </td>
                             <td className="w-44 px-3 py-2.5">
@@ -678,89 +636,13 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                             </td>
                           </tr>
                           
-                          {/* TODO: Accordion expanded detail row disabled for now - will revisit later
-                          {isExpanded && hasDetails && (
-                            <tr className="bg-gray-50 dark:bg-gray-750">
-                              <td colSpan={4} className="px-6 py-4">
-                                <div className="space-y-3">
-                                  {bundledEvent.errorMessages && bundledEvent.errorMessages.length > 0 && (
-                                    <div>
-                                      <h4 className="text-xs font-semibold text-red-600 dark:text-red-400 uppercase tracking-wide mb-2">
-                                        Errors ({bundledEvent.errorMessages.length})
-                                      </h4>
-                                      <ul className="space-y-1">
-                                        {bundledEvent.errorMessages.map((msg, idx) => (
-                                          <li key={idx} className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 px-3 py-1.5 rounded font-mono">
-                                            {msg}
-                                          </li>
-                                        ))}
-                                      </ul>
-                                    </div>
-                                  )}
-                                  
-                                  {bundledEvent.warningMessages && bundledEvent.warningMessages.length > 0 && (
-                                    <div>
-                                      <h4 className="text-xs font-semibold text-yellow-600 dark:text-yellow-400 uppercase tracking-wide mb-2">
-                                        Warnings ({bundledEvent.warningMessages.length})
-                                      </h4>
-                                      <ul className="space-y-1">
-                                        {bundledEvent.warningMessages.map((msg, idx) => (
-                                          <li key={idx} className="text-sm text-yellow-700 dark:text-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 px-3 py-1.5 rounded font-mono">
-                                            {msg}
-                                          </li>
-                                        ))}
-                                      </ul>
-                                    </div>
-                                  )}
-                                  
-                                  {bundledEvent.failedItems && bundledEvent.failedItems.length > 0 && (
-                                    <div>
-                                      <h4 className="text-xs font-semibold text-red-600 dark:text-red-400 uppercase tracking-wide mb-2">
-                                        Failed Items ({bundledEvent.failedItems.length})
-                                      </h4>
-                                      <div className="space-y-2">
-                                        {bundledEvent.failedItems.map((item, idx) => (
-                                          <div key={idx} className="bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded border-l-2 border-red-400">
-                                            <div className="text-sm font-medium text-red-800 dark:text-red-200">
-                                              {item.displayName}
-                                            </div>
-                                            {item.error && (
-                                              <div className="text-xs text-red-600 dark:text-red-400 font-mono mt-1">
-                                                {item.error}
-                                              </div>
-                                            )}
-                                          </div>
-                                        ))}
-                                      </div>
-                                    </div>
-                                  )}
-                                  
-                                  {bundledEvent.warningItems && bundledEvent.warningItems.length > 0 && (
-                                    <div>
-                                      <h4 className="text-xs font-semibold text-yellow-600 dark:text-yellow-400 uppercase tracking-wide mb-2">
-                                        Items with Warnings ({bundledEvent.warningItems.length})
-                                      </h4>
-                                      <div className="space-y-2">
-                                        {bundledEvent.warningItems.map((item, idx) => (
-                                          <div key={idx} className="bg-yellow-50 dark:bg-yellow-900/20 px-3 py-2 rounded border-l-2 border-yellow-400">
-                                            <div className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                                              {item.displayName}
-                                            </div>
-                                            {item.warning && (
-                                              <div className="text-xs text-yellow-600 dark:text-yellow-400 font-mono mt-1">
-                                                {item.warning}
-                                              </div>
-                                            )}
-                                          </div>
-                                        ))}
-                                      </div>
-                                    </div>
-                                  )}
-                                </div>
+                          {isExpanded && (
+                            <tr className="bg-gray-50 dark:bg-gray-900/40">
+                              <td colSpan={4} className="px-6 py-4 border-l-0">
+                                <EventDetails eventIds={bundledEvent.eventIds} />
                               </td>
                             </tr>
                           )}
-                          */}
                         </React.Fragment>
                       )
                     })}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -207,3 +207,13 @@ export function normalizeCimianTimestamp(timestamp: string | undefined): string 
     return timestamp
   }
 }
+
+/**
+ * Cimian session identifiers are `yyyy-MM-dd-HHmm` (e.g. "2026-08-28-1158"), not
+ * timestamps. `new Date()` cannot parse them, so anything that treats
+ * `last_seen_in_session` as a date silently produces Invalid Date and drops the
+ * item. Use this to branch on the two shapes.
+ */
+export function isCimianSessionId(value: string | undefined | null): boolean {
+  return !!value && /^\d{4}-\d{2}-\d{2}-\d{4}$/.test(value.trim())
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "jsx": "preserve",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",


### PR DESCRIPTION
Closes #70.

The dashboard could not answer "what did the last managed-software run actually do?". This fixes the data that answers it, and the paths that should lead there.

## Last Run showed nothing

Opening **Last Run** on the installs tab showed *"No items with last run"* and every status pill at 0, on a workstation that had just installed 15 packages and failed 1. With the filter cleared the pills showed the whole catalog (Installed 159 of 168) — overall inventory state, which is correct, but not the run.

The Cimian client stamps `last_seen_in_session` only on items the run acted on, but the value is a **session id** (`2026-08-28-1158`), not a timestamp. Both consumers fed it to `new Date()`:

- `extractInstalls` compared it to the session `start_time`. `new Date("2026-08-28-1158")` is Invalid Date, so `lastUpdate` came out empty for every item and the filter had nothing to match.
- `LastRunSummary` had the mirror-image bug: on failing that compare it fell back to `item.lastUpdate`, which Cimian stamps on every catalog member at status-check time, so it matched all 168.

`extractInstalls` now reads the latest session's `session_id` alongside its start and end time. A session-id marker is matched by id and renders the item's own `lastAttemptTime` as Date Processed; a timestamp marker keeps the existing window compare, so Munki is untouched. `LastRunSummary` handles both shapes and the `item.lastUpdate` fallback is gone.

## Munki, checked as the sibling

The session-id bug is Cimian-only — the Mac client emits `install_succeeded` / `install_failed` / `removed`, and across 40 live Mac payloads the Last Run count matched the number of items Munki acted on. But checking turned up two Munki-side defects in the same surface:

- `InstallsModuleProcessor` joins `ProblemInstalls` with `"; "` (and also ships `problemInstallsArray`), while `extractInstalls` split on `","`. A run with six failed downloads produced one package literally named `BBEdit; Microsoft Defender; Microsoft Excel; Microsoft PowerPoint; Microsoft Word; Firefox`.
- Each name was then matched against `pkg.name` only. `ProblemInstalls` carries Munki's `display_name` ("Microsoft Defender") while the items array carries the short name ("Defender"), so every problem install was appended a second time as a phantom Warning row beside the real Error row.

One device showed 13 Last Run rows for 9 actions before this, 9 after. All 40 now match exactly.

## Recent Events rows expand

Each row is an accordion. The events list endpoint omits payloads by design, so the body lazy-loads `/api/events/<id>/payload` on first expand and caches it; a bundled row merges its constituent events. It shows the module list behind a truncated `Security, Network, Management, Hardware data …` message, the items behind `2 packages installed`, and the messages behind a warning or error. Munki pipes raw `installer` output into its errors string, so progress ticks are dropped and the count of what was hidden is stated rather than silently lost. The whole row toggles, by click or keyboard; the device link still navigates.

## Device links land on the right filter

That link resolved its target module from `payload.module_id`, which the list endpoint never returns, then fell back to matching `install|package|cimian` against the message — and `2 Munki warnings` contains none of them, so it landed on the device's default tab.

Routing now reads the message vocabulary and the event kind together:

| Event | Lands on |
|---|---|
| `2 Munki warnings` | `?filter=warning#installs` |
| `44 Munki errors`, `X failed to install` | `?filter=error#installs` |
| `2 packages installed`, `3 packages updated` | `?filter=last_run#installs` |
| `Hardware data reported` | `#hardware` |

Successes go to Last Run rather than the `installed` filter, which would show the whole inventory instead of the items the run touched. An unmatched success, warning or error is treated as installs, since those are raised by the managed-software run; a message naming another module still wins over that fallback.

Info events are hidden by default — routine collection chatter that buries what is worth reacting to — and remain one click away in the filter.

## Filtered rows open themselves

On the installs tab an active status filter now opens every matching row that has something to show, since that detail is the reason to filter at all. Rows with nothing behind them stay shut, and a row collapsed by hand stays collapsed.

## Verification

54 tests across the changed modules, covering both marker shapes, the Munki separator and display-name matching, the payload summariser, and link routing for every distinct message shape in the live feed.

`tsconfig.json` gains `ignoreDeprecations`, without which `tsc --noEmit` aborts on the `baseUrl` deprecation before type-checking a single file — an empty result that reads as a clean one. The repo has a pre-existing error backlog so this is not yet a green gate, but undefined identifiers in changed files are caught again.
