### PR TITLE
Remove fleet identifiers from the public repo

### DIFF
--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -852,72 +852,15 @@ function ApplicationsPageContent() {
         let estimatedTotal = 100  // placeholder for progress bar
         let progress = 0
         
-        // Sample device serial numbers with realistic app counts for progress messages
-        const sampleDevices = [
-          { serial: '74J10W2', apps: 143 },
-          { serial: '77BQKQ3', apps: 372 },
-          { serial: '8073GT3', apps: 361 },
-          { serial: '87BQKQ3', apps: 370 },
-          { serial: '8LCX9Z2', apps: 105 },
-          { serial: '8LD0BZ2', apps: 36 },
-          { serial: '8LDW9Z2', apps: 36 },
-          { serial: '97BQKQ3', apps: 370 },
-          { serial: 'B7BQKQ3', apps: 367 },
-          { serial: 'B9DVN23', apps: 96 },
-          { serial: 'C5BQKQ3', apps: 318 },
-          { serial: 'C7BQKQ3', apps: 345 },
-          { serial: 'CT8M0Q2', apps: 327 },
-          { serial: 'CT8Q0Q2', apps: 271 },
-          { serial: 'CT9Q0Q2', apps: 341 },
-          { serial: 'CTBP0Q2', apps: 345 },
-          { serial: 'CTDN0Q2', apps: 460 },
-          { serial: 'CTDP0Q2', apps: 351 },
-          { serial: 'CTDQ0Q2', apps: 342 },
-          { serial: 'CTDR0Q2', apps: 342 },
-          { serial: 'D1FZFK3', apps: 164 },
-          { serial: 'D5BQKQ3', apps: 364 },
-          { serial: 'D7C10R3', apps: 190 },
-          { serial: 'F5BQKQ3', apps: 151 },
-          { serial: 'F7C10R3', apps: 191 },
-          { serial: 'G5BQKQ3', apps: 348 },
-          { serial: 'H5BQKQ3', apps: 357 },
-          { serial: 'J3RDDV2', apps: 220 },
-          { serial: 'J5BQKQ3', apps: 362 },
-          { serial: 'JRCWCV2', apps: 113 },
-          { serial: 'JRD3DV2', apps: 119 },
-          { serial: 'JRF7DV2', apps: 78 },
-          { serial: 'GD7DPY2', apps: 256 },
-          { serial: 'GM0MB0JQ', apps: 40 },
-          { serial: 'GM0MB0JS', apps: 74 },
-          { serial: 'HVQ0Z93', apps: 21 },
-          { serial: 'MJ071W8M', apps: 148 }
-        ]
-        let deviceIndex = 0
         
         progressInterval = setInterval(() => {
           // Progress quickly to 85%, then slow down dramatically, but keep moving
           if (progress < Math.floor(estimatedTotal * 0.85)) {
             progress += 5 // Fast progress to 85% (0-6 seconds)
-            // Show device-specific messages with app counts during processing
-            if (deviceIndex < sampleDevices.length) {
-              const device = sampleDevices[deviceIndex]
-              setLoadingMessage(`Processing ${device.apps} apps from device ${device.serial}`)
-              deviceIndex++
-            }
           } else if (progress < Math.floor(estimatedTotal * 0.95)) {
             progress += 1 // Medium slow progress from 85% to 95%
-            if (deviceIndex < sampleDevices.length) {
-              const device = sampleDevices[deviceIndex]
-              setLoadingMessage(`Processing ${device.apps} apps from device ${device.serial}`)
-              deviceIndex++
-            }
           } else if (progress < Math.floor(estimatedTotal * 0.995)) {
             progress += 0.5 // Very slow progress from 95% to 99.5%, keeps moving but never reaches 100%
-            if (deviceIndex < sampleDevices.length) {
-              const device = sampleDevices[deviceIndex]
-              setLoadingMessage(`Processing ${device.apps} apps from device ${device.serial}`)
-              deviceIndex++
-            }
           }
           setLoadingProgress({ current: Math.floor(progress), total: estimatedTotal })
         }, 200)

--- a/middleware.ts
+++ b/middleware.ts
@@ -45,7 +45,7 @@ function identifyDeviceIdentifierType(identifier: string): 'uuid' | 'assetTag' |
     return 'deviceName'
   }
   
-  // Asset tag pattern: Letter followed by digits (e.g., L003994, A004733)
+  // Asset tag pattern: a letter followed by digits (e.g. L000001, A000042)
   const assetTagPattern = /^[A-Z]\d+$/i
   if (assetTagPattern.test(identifier)) {
     return 'assetTag'

--- a/src/lib/data-processing/cimian-version.ts
+++ b/src/lib/data-processing/cimian-version.ts
@@ -1,5 +1,5 @@
 /**
- * Cimian client version normalization (AB#3754).
+ * Cimian client version normalization.
  *
  * The Cimian client stamps its build as a calendar version. The canonical,
  * preferred form is `YYYY.MM.DD.HHMM` — zero-padded, four components — emitted

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -151,7 +151,7 @@ const getDeviceName = (event: FleetEvent, deviceNameMap: Record<string, string>)
   
   // If deviceId looks like an asset tag (short, alphanumeric), show it nicely
   if (deviceId && deviceId.length <= 10 && /^[A-Z0-9]+$/i.test(deviceId)) {
-    return deviceId // Return the serial number directly (e.g., "N2YLJFHWRT")
+    return deviceId // Return the serial number directly
   }
   
   // Final fallback - return the deviceId (serial number) directly


### PR DESCRIPTION
This repository is public. It carried inventory-sourced identifiers that mean nothing to an outside reader and disclose the estate to anyone who looks.

- `app/applications/page.tsx` hardcoded **37 real device serials** paired with app counts, used only to animate the loading bar with lines like `Processing 372 apps from device <serial>`. That is a disclosure *and* invented data presented to users as real, which this codebase forbids. The list and the fabricated per-device messaging are removed; the progress bar behaviour is otherwise unchanged.
- `middleware.ts` illustrated the asset-tag pattern with two real asset tags — now neutral placeholders.
- `RecentEventsWidget.tsx` illustrated a serial with a real one — dropped.
- `cimian-version.ts` carried a private work-item id in its docstring — dropped.

Found by a repo-wide sweep for identifiers that must not cross to a public remote. Remaining matches in this repo are SVG path data, lockfile hashes and binary content, not identifiers.
