### PR TITLE
Keep the device header pinned, size Windows tables to fit, and filter services by state and source

### DIFF
--- a/app/device/[deviceId]/ClientDeviceDetailPage.tsx
+++ b/app/device/[deviceId]/ClientDeviceDetailPage.tsx
@@ -762,8 +762,10 @@ export default function ClientDeviceDetailPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-black">
-      {/* Sticky Header with Device Info and Tabs */}
-      <div className="sticky top-0 z-30 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+      {/* Sticky Header with Device Info and Tabs. The app toolbar is sticky at
+          top-0 and 4rem tall, so this must offset by that height or the toolbar
+          covers the device row on scroll and only the tab strip stays visible. */}
+      <div className="sticky top-16 z-30 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
         {/* Header Bar */}
         <div className="border-b border-gray-200 dark:border-gray-700">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/app/devices/ClientDevicesPage.tsx
+++ b/app/devices/ClientDevicesPage.tsx
@@ -693,9 +693,7 @@ function DevicesPageContent() {
                             className="font-medium text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 min-w-0 flex-1"
                             title={item.deviceName || 'Unknown Device'}
                           >
-                            <span className="block truncate">
-                              {item.deviceName || 'Unknown Device'}
-                            </span>
+                            <TailTruncate text={item.deviceName || 'Unknown Device'} />
                           </Link>
                           <PlatformBadge platform={item.platform || ''} size="sm" />
                         </div>
@@ -796,6 +794,18 @@ function DevicesPageContent() {
         )}
       </div>
     </div>
+  )
+}
+
+// Truncate in the middle so a numbered name keeps its number: the head
+// ellipsises, the last three characters always stay put.
+function TailTruncate({ text, keep = 3 }: { text: string; keep?: number }) {
+  if (text.length <= keep + 1) return <span className="block truncate">{text}</span>
+  return (
+    <span className="flex min-w-0">
+      <span className="truncate">{text.slice(0, -keep)}</span>
+      <span className="shrink-0">{text.slice(-keep)}</span>
+    </span>
   )
 }
 

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -1055,10 +1055,10 @@ function EventsPageContent() {
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Type
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-1/2">
                         Message
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
                         Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -1426,10 +1426,10 @@ function EventsPageContent() {
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Type
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-1/2">
                         Message
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
                         Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -12,6 +12,7 @@ import { bundleEvents, formatPayloadPreview, type FleetEvent, type BundledEvent 
 import { CopyButton } from "../../src/components/ui/CopyButton"
 import { LastRunSummary } from "../../src/components/LastRunSummary"
 import { EventDetails } from "../../src/lib/modules/widgets/EventDetails"
+import { extractInlineDetails, inlineLineClass, type InlineLine } from "../../src/lib/eventInlineDetails"
 import { usePlatformFilterSafe, normalizePlatform } from "../../src/providers/PlatformFilterProvider"
 import { Search, X } from 'lucide-react'
 
@@ -137,97 +138,6 @@ const getEventMessage = (event: BundledEvent): string => {
   return formatPayloadPreview(originalEvent.payload);
 }
 
-// Payload keys that carry structure/metadata rather than an installed package.
-// Everything else with a string value in a success payload is a "name → version" pair.
-const RESERVED_PAYLOAD_KEYS = new Set([
-  'count', 'errors', 'warnings', 'error_items', 'warning_items', 'failed_items',
-  'error_messages', 'warning_messages', 'module_status', 'warning_count', 'error_count',
-  'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
-  'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
-  'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
-])
-
-// Extract human-readable detail lines from a loaded event payload so they can be
-// shown inline in the Message column without expanding the raw payload.
-// Handles the shapes ReportMate actually emits:
-//   Munki:   { errors: "a; b", warnings: "c; d" }         (semicolon-joined string)
-//   Cimian:  { warning_items: ["Name"], error_items: [] }  (array of names)
-//   Installs:{ failed_items: [{ displayName, error }] }    (array of objects)
-//   Generic: { error_messages: [...], warning_messages: [...] }
-//   Success: { "Managed Safari": "15.6.1", "ZoomPrefs": "14.1" }  (name → version)
-//   Cimian:  { items: [{ name: "Chrome", version: "151.0.7922.170" }] }  (array of objects)
-// A line is either a run message (sentence from the client) or an item
-// ("Name version"); the flag decides how the row renders it.
-type InlineLine = { text: string; isMessage: boolean }
-const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[] } => {
-  const errors: InlineLine[] = []
-  const warnings: InlineLine[] = []
-  const successes: string[] = []
-  if (!payload || typeof payload !== 'object') return { errors, warnings, successes }
-  const p = payload as Record<string, any>
-
-  const pushString = (target: InlineLine[], val: unknown) => {
-    if (typeof val === 'string' && val.trim()) {
-      val.split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push({ text: s, isMessage: true }))
-    }
-  }
-  const pushItems = (target: InlineLine[], val: unknown) => {
-    if (!Array.isArray(val)) return
-    for (const item of val) {
-      if (typeof item === 'string') {
-        if (item.trim()) target.push({ text: item.trim(), isMessage: false })
-      } else if (item && typeof item === 'object') {
-        const name = item.displayName || item.name || ''
-        const version = item.version ? ` ${item.version}` : ''
-        const detail = item.error || item.warning || ''
-        const line = detail ? (name ? `${name}${version}: ${detail}` : detail) : `${name}${version}`
-        if (line) target.push({ text: line, isMessage: Boolean(detail) })
-      }
-    }
-  }
-
-  // The Windows installs collector sends its success items as an array of
-  // { name, version } objects rather than a flat map, and always includes them
-  // even when the summary message is a count. Read them so a multi-package run
-  // can still list what it installed.
-  if (Array.isArray(p.items)) {
-    for (const item of p.items) {
-      if (typeof item === 'string') {
-        if (item.trim()) successes.push(item.trim())
-      } else if (item && typeof item === 'object') {
-        const name = String(item.displayName || item.name || '').trim()
-        const version = String(item.version || '').trim()
-        if (name) successes.push(version ? `${name} ${version}` : name)
-      }
-    }
-  }
-
-  pushString(errors, p.errors)
-  pushString(warnings, p.warnings)
-  pushItems(errors, p.error_messages)
-  pushItems(warnings, p.warning_messages)
-  pushItems(errors, p.error_items)
-  pushItems(warnings, p.warning_items)
-  pushItems(errors, p.failed_items)
-
-  // Success payloads are a flat "package name → version" map — one line each.
-  for (const [key, value] of Object.entries(p)) {
-    if (RESERVED_PAYLOAD_KEYS.has(key)) continue
-    if (typeof value === 'string' && value.trim()) {
-      successes.push(`${key} ${value.trim()}`)
-    }
-  }
-
-  const dedupe = (lines: InlineLine[]) => {
-    const seen = new Set<string>()
-    return lines.filter(l => (seen.has(l.text) ? false : (seen.add(l.text), true)))
-  }
-  return {
-    errors: dedupe(errors),
-    warnings: dedupe(warnings),
-    successes: Array.from(new Set(successes)),
-  }
-}
 
 function EventsPageContent() {
   const [events, setEvents] = useState<Event[]>([])
@@ -823,11 +733,6 @@ function EventsPageContent() {
 
   // A run message (a sentence from the client) gets the same mono chip the
   // expanded view uses; a bare "Name version" item line stays plain text.
-  const inlineLineClass = (line: InlineLine, tone: string) =>
-    line.isMessage
-      ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${tone}`
-      : `text-sm break-words ${tone}`
-
   // Render the extracted error/warning/success detail lines beneath the summary
   // message. One line per item. Returns null when there is nothing to add.
   // The row shows the items themselves, not a count of them: "4 warnings" or

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -826,43 +826,23 @@ function EventsPageContent() {
   const inlineLineClass = (line: InlineLine, tone: string) =>
     line.isMessage
       ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${tone}`
-      : `text-xs break-words ${tone}`
+      : `text-sm break-words ${tone}`
 
   // Render the extracted error/warning/success detail lines beneath the summary
   // message. One line per item. Returns null when there is nothing to add.
-  // "FortiClient warning" becomes "FortiClient 7.4.3.4799 warning" when the
-  // payload carries exactly one item and the summary names it. The item line
-  // under the summary is then a repeat, so renderInlineDetails drops it.
-  const singleNamedItem = (event: BundledEvent): InlineLine | null => {
-    if (event.isBundle) return null
-    const { errors, warnings } = extractInlineDetails(fullPayloads[event.id])
-    const lines = [...errors, ...warnings]
-    if (lines.length !== 1 || lines[0].isMessage) return null
-    const first = lines[0].text.split(' ')[0]
-    return (event.message || '').toLowerCase().startsWith(first.toLowerCase()) ? lines[0] : null
+  // The row shows the items themselves, not a count of them: "4 warnings" or
+  // "2 packages installed" is replaced by the list once the payload is in.
+  // The summary stays only while loading, or when the payload has no items.
+  const inlineLines = (event: BundledEvent) => {
+    const { errors, warnings, successes } = extractInlineDetails(fullPayloads[event.id])
+    return { errors, warnings, successes, hasDetails: errors.length > 0 || warnings.length > 0 || successes.length > 0 }
   }
-  const getDisplayMessage = (event: BundledEvent): string => {
-    const message = getEventMessage(event)
-    const item = singleNamedItem(event)
-    if (!item) return message
-    const [name, ...rest] = item.text.split(' ')
-    const version = rest.join(' ')
-    if (!version || message.includes(version)) return message
-    return message.replace(new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i'), `${name} ${version}`)
-  }
+  const getDisplayMessage = (event: BundledEvent): string | null =>
+    inlineLines(event).hasDetails ? null : getEventMessage(event)
 
   const renderInlineDetails = (event: BundledEvent): React.ReactNode => {
-    const extracted = extractInlineDetails(fullPayloads[event.id])
-    // A summary like "FortiClient warning" already names its one item, so a lone
-    // item line under it is a repeat; keep item lines only for 2+ or for messages
-    const promoted = singleNamedItem(event)
-    const trimItems = (lines: InlineLine[]) => (promoted && lines.length === 1 && lines[0].text === promoted.text ? [] : lines)
-    const errors = trimItems(extracted.errors)
-    const warnings = trimItems(extracted.warnings)
-    const successes = extracted.successes
-    // Success summaries already spell out a single package, so only expand 2+
-    const successLines = successes.length > 1 ? successes : []
-    const hasDetails = errors.length > 0 || warnings.length > 0 || successLines.length > 0
+    const { errors, warnings, successes, hasDetails } = inlineLines(event)
+    const successLines = successes
     if (!hasDetails) {
       if (shouldAutoFetch(event) && loadingPayloads.has(event.id)) {
         return <div className="text-xs text-gray-400 dark:text-gray-500 mt-1 italic">Loading details…</div>
@@ -870,7 +850,7 @@ function EventsPageContent() {
       return null
     }
     return (
-      <div className="mt-1 space-y-1">
+      <div className="space-y-1">
         {errors.map((m, i) => (
           <div key={`e-${i}`} className={inlineLineClass(m, 'text-red-700 dark:text-red-300')}>{m.text}</div>
         ))}
@@ -878,7 +858,7 @@ function EventsPageContent() {
           <div key={`w-${i}`} className={inlineLineClass(m, 'text-yellow-700 dark:text-yellow-300')}>{m.text}</div>
         ))}
         {successLines.map((m, i) => (
-          <div key={`s-${i}`} className="text-xs text-green-700 dark:text-green-300 break-words">{m}</div>
+          <div key={`s-${i}`} className="text-sm text-green-700 dark:text-green-300 break-words">{m}</div>
         ))}
       </div>
     )

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -1052,19 +1052,19 @@ function EventsPageContent() {
                     </tr>
                     {/* Header Row - desktop */}
                     <tr>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-16">
                         Type
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-1/2">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
                         Device
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-40">
                         Time
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-24">
                         Payloads
                       </th>
                     </tr>
@@ -1423,19 +1423,19 @@ function EventsPageContent() {
                     </tr>
                     {/* Header Row */}
                     <tr>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-16">
                         Type
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-1/2">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
                         Device
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-40">
                         Time
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-24">
                         Payloads
                       </th>
                     </tr>

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -150,6 +150,19 @@ function EventsPageContent() {
     () => new Set(['success', 'warning', 'error'])
   )
   const [searchQuery, setSearchQuery] = useState('')
+  // Success, Warnings and Errors combine. System and Info are solo views: the
+  // first click shows only that kind, the second returns to the default set.
+  const DEFAULT_KINDS = ['success', 'warning', 'error']
+  const SOLO_KINDS = new Set(['system', 'info'])
+  const toggleKindFilter = (key: string) => setActiveFilters(prev => {
+    if (SOLO_KINDS.has(key)) {
+      return prev.has(key) && prev.size === 1 ? new Set(DEFAULT_KINDS) : new Set([key])
+    }
+    const next = new Set([...prev].filter(k => !SOLO_KINDS.has(k)))
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
   // Several rows can be open at once; a Set of ids rather than a single id
   const [expandedEvents, setExpandedEvents] = useState<Set<string>>(() => new Set())
   const collapseEvent = (id: string) => setExpandedEvents(prev => { const next = new Set(prev); next.delete(id); return next })
@@ -1008,12 +1021,7 @@ function EventsPageContent() {
                             return (
                               <button
                                 key={filter.key}
-                                onClick={() => setActiveFilters(prev => {
-                                  const next = new Set(prev)
-                                  if (next.has(filter.key)) next.delete(filter.key)
-                                  else next.add(filter.key)
-                                  return next
-                                })}
+                                onClick={() => toggleKindFilter(filter.key)}
                                 className={`flex items-center justify-center gap-2 px-3 py-1.5 border rounded-lg text-sm font-medium transition-colors ${getFilterStyles(filter.key, isActive)}`}
                               >
                                 {getStatusIcon(filter.key)}
@@ -1035,12 +1043,7 @@ function EventsPageContent() {
                             return (
                               <button
                                 key={filter.key}
-                                onClick={() => setActiveFilters(prev => {
-                                  const next = new Set(prev)
-                                  if (next.has(filter.key)) next.delete(filter.key)
-                                  else next.add(filter.key)
-                                  return next
-                                })}
+                                onClick={() => toggleKindFilter(filter.key)}
                                 className={`flex items-center gap-1 px-2 py-1 border rounded text-xs font-medium transition-colors ${getFilterStyles(filter.key, isActive)}`}
                               >
                                 {getStatusIcon(filter.key)}
@@ -1367,12 +1370,7 @@ function EventsPageContent() {
                             return (
                               <button
                                 key={filter.key}
-                                onClick={() => setActiveFilters(prev => {
-                                  const next = new Set(prev)
-                                  if (next.has(filter.key)) next.delete(filter.key)
-                                  else next.add(filter.key)
-                                  return next
-                                })}
+                                onClick={() => toggleKindFilter(filter.key)}
                                 className={`${
                                   isActive
                                     ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-600'
@@ -1403,12 +1401,7 @@ function EventsPageContent() {
                             return (
                               <button
                                 key={filter.key}
-                                onClick={() => setActiveFilters(prev => {
-                                  const next = new Set(prev)
-                                  if (next.has(filter.key)) next.delete(filter.key)
-                                  else next.add(filter.key)
-                                  return next
-                                })}
+                                onClick={() => toggleKindFilter(filter.key)}
                                 className={`flex items-center gap-1 px-2 py-1 border rounded text-xs font-medium transition-colors ${
                                   isActive
                                     ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-600'

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -11,6 +11,7 @@ import { EventsPageSkeleton } from "../../src/components/skeleton/EventsPageSkel
 import { bundleEvents, formatPayloadPreview, type FleetEvent, type BundledEvent } from "../../src/lib/eventBundling"
 import { CopyButton } from "../../src/components/ui/CopyButton"
 import { LastRunSummary } from "../../src/components/LastRunSummary"
+import { EventDetails } from "../../src/lib/modules/widgets/EventDetails"
 import { usePlatformFilterSafe, normalizePlatform } from "../../src/providers/PlatformFilterProvider"
 import { Search, X } from 'lucide-react'
 
@@ -92,23 +93,23 @@ const isBundleId = (id: string | number): boolean => {
 function getFilterStyles(key: string, isActive: boolean) {
   const baseColors: Record<string, { active: string; inactive: string }> = {
     success: {
-      active: 'bg-green-700 text-white border-green-800 shadow-md dark:bg-green-600 dark:border-green-700',
+      active: 'bg-green-200 text-green-900 border-green-400 ring-1 ring-green-400 dark:bg-green-900/70 dark:text-green-100 dark:border-green-600 dark:ring-green-600',
       inactive: 'bg-green-100 text-green-700 border-green-200 hover:bg-green-200 hover:border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-800 dark:hover:bg-green-900/60'
     },
     warning: {
-      active: 'bg-yellow-600 text-white border-yellow-700 shadow-md dark:bg-yellow-500 dark:border-yellow-600',
+      active: 'bg-yellow-200 text-yellow-900 border-yellow-400 ring-1 ring-yellow-400 dark:bg-yellow-900/70 dark:text-yellow-100 dark:border-yellow-600 dark:ring-yellow-600',
       inactive: 'bg-yellow-100 text-yellow-700 border-yellow-200 hover:bg-yellow-200 hover:border-yellow-300 dark:bg-yellow-900/40 dark:text-yellow-400 dark:border-yellow-800 dark:hover:bg-yellow-900/60'
     },
     error: {
-      active: 'bg-red-700 text-white border-red-800 shadow-md dark:bg-red-600 dark:border-red-700',
+      active: 'bg-red-200 text-red-900 border-red-400 ring-1 ring-red-400 dark:bg-red-900/70 dark:text-red-100 dark:border-red-600 dark:ring-red-600',
       inactive: 'bg-red-100 text-red-700 border-red-200 hover:bg-red-200 hover:border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-900/60'
     },
     info: {
-      active: 'bg-blue-700 text-white border-blue-800 shadow-md dark:bg-blue-600 dark:border-blue-700',
+      active: 'bg-blue-200 text-blue-900 border-blue-400 ring-1 ring-blue-400 dark:bg-blue-900/70 dark:text-blue-100 dark:border-blue-600 dark:ring-blue-600',
       inactive: 'bg-blue-100 text-blue-700 border-blue-200 hover:bg-blue-200 hover:border-blue-300 dark:bg-blue-900/40 dark:text-blue-400 dark:border-blue-800 dark:hover:bg-blue-900/60'
     },
     system: {
-      active: 'bg-purple-700 text-white border-purple-800 shadow-md dark:bg-purple-600 dark:border-purple-700',
+      active: 'bg-purple-200 text-purple-900 border-purple-400 ring-1 ring-purple-400 dark:bg-purple-900/70 dark:text-purple-100 dark:border-purple-600 dark:ring-purple-600',
       inactive: 'bg-purple-100 text-purple-700 border-purple-200 hover:bg-purple-200 hover:border-purple-300 dark:bg-purple-900/40 dark:text-purple-400 dark:border-purple-800 dark:hover:bg-purple-900/60'
     },
   }
@@ -155,28 +156,32 @@ const RESERVED_PAYLOAD_KEYS = new Set([
 //   Generic: { error_messages: [...], warning_messages: [...] }
 //   Success: { "Managed Safari": "15.6.1", "ZoomPrefs": "14.1" }  (name → version)
 //   Cimian:  { items: [{ name: "Chrome", version: "151.0.7922.170" }] }  (array of objects)
-const extractInlineDetails = (payload: unknown): { errors: string[]; warnings: string[]; successes: string[] } => {
-  const errors: string[] = []
-  const warnings: string[] = []
+// A line is either a run message (sentence from the client) or an item
+// ("Name version"); the flag decides how the row renders it.
+type InlineLine = { text: string; isMessage: boolean }
+const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[] } => {
+  const errors: InlineLine[] = []
+  const warnings: InlineLine[] = []
   const successes: string[] = []
   if (!payload || typeof payload !== 'object') return { errors, warnings, successes }
   const p = payload as Record<string, any>
 
-  const pushString = (target: string[], val: unknown) => {
+  const pushString = (target: InlineLine[], val: unknown) => {
     if (typeof val === 'string' && val.trim()) {
-      val.split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push(s))
+      val.split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push({ text: s, isMessage: true }))
     }
   }
-  const pushItems = (target: string[], val: unknown) => {
+  const pushItems = (target: InlineLine[], val: unknown) => {
     if (!Array.isArray(val)) return
     for (const item of val) {
       if (typeof item === 'string') {
-        if (item.trim()) target.push(item.trim())
+        if (item.trim()) target.push({ text: item.trim(), isMessage: false })
       } else if (item && typeof item === 'object') {
         const name = item.displayName || item.name || ''
+        const version = item.version ? ` ${item.version}` : ''
         const detail = item.error || item.warning || ''
-        const line = detail ? (name ? `${name}: ${detail}` : detail) : name
-        if (line) target.push(line)
+        const line = detail ? (name ? `${name}${version}: ${detail}` : detail) : `${name}${version}`
+        if (line) target.push({ text: line, isMessage: Boolean(detail) })
       }
     }
   }
@@ -213,9 +218,13 @@ const extractInlineDetails = (payload: unknown): { errors: string[]; warnings: s
     }
   }
 
+  const dedupe = (lines: InlineLine[]) => {
+    const seen = new Set<string>()
+    return lines.filter(l => (seen.has(l.text) ? false : (seen.add(l.text), true)))
+  }
   return {
-    errors: Array.from(new Set(errors)),
-    warnings: Array.from(new Set(warnings)),
+    errors: dedupe(errors),
+    warnings: dedupe(warnings),
     successes: Array.from(new Set(successes)),
   }
 }
@@ -230,7 +239,10 @@ function EventsPageContent() {
     () => new Set(['success', 'warning', 'error', 'system'])
   )
   const [searchQuery, setSearchQuery] = useState('')
-  const [expandedEvent, setExpandedEvent] = useState<string | null>(null)
+  // Several rows can be open at once; a Set of ids rather than a single id
+  const [expandedEvents, setExpandedEvents] = useState<Set<string>>(() => new Set())
+  const collapseEvent = (id: string) => setExpandedEvents(prev => { const next = new Set(prev); next.delete(id); return next })
+  const expandEvent = (id: string) => setExpandedEvents(prev => new Set(prev).add(id))
   // Device name map removed - events API now includes deviceName and assetTag directly
   const [fullPayloads, setFullPayloads] = useState<Record<string, unknown>>({})
   const [loadingPayloads, setLoadingPayloads] = useState<Set<string>>(new Set())
@@ -241,7 +253,7 @@ function EventsPageContent() {
   const { platformFilter, isPlatformVisible } = usePlatformFilterSafe()
   
   // Ref for infinite scroll sentinel
-  const loadMoreRef = useRef<HTMLDivElement>(null)
+  const _loadMoreRef = useRef<HTMLDivElement>(null)
   // Refs for scroll containers (used by scroll-based infinite scroll)
   const desktopScrollRef = useRef<HTMLDivElement>(null)
   const tabletScrollRef = useRef<HTMLDivElement>(null)
@@ -809,10 +821,45 @@ function EventsPageContent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFetchKey])
 
+  // A run message (a sentence from the client) gets the same mono chip the
+  // expanded view uses; a bare "Name version" item line stays plain text.
+  const inlineLineClass = (line: InlineLine, tone: string) =>
+    line.isMessage
+      ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${tone}`
+      : `text-xs break-words ${tone}`
+
   // Render the extracted error/warning/success detail lines beneath the summary
   // message. One line per item. Returns null when there is nothing to add.
+  // "FortiClient warning" becomes "FortiClient 7.4.3.4799 warning" when the
+  // payload carries exactly one item and the summary names it. The item line
+  // under the summary is then a repeat, so renderInlineDetails drops it.
+  const singleNamedItem = (event: BundledEvent): InlineLine | null => {
+    if (event.isBundle) return null
+    const { errors, warnings } = extractInlineDetails(fullPayloads[event.id])
+    const lines = [...errors, ...warnings]
+    if (lines.length !== 1 || lines[0].isMessage) return null
+    const first = lines[0].text.split(' ')[0]
+    return (event.message || '').toLowerCase().startsWith(first.toLowerCase()) ? lines[0] : null
+  }
+  const getDisplayMessage = (event: BundledEvent): string => {
+    const message = getEventMessage(event)
+    const item = singleNamedItem(event)
+    if (!item) return message
+    const [name, ...rest] = item.text.split(' ')
+    const version = rest.join(' ')
+    if (!version || message.includes(version)) return message
+    return message.replace(new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i'), `${name} ${version}`)
+  }
+
   const renderInlineDetails = (event: BundledEvent): React.ReactNode => {
-    const { errors, warnings, successes } = extractInlineDetails(fullPayloads[event.id])
+    const extracted = extractInlineDetails(fullPayloads[event.id])
+    // A summary like "FortiClient warning" already names its one item, so a lone
+    // item line under it is a repeat; keep item lines only for 2+ or for messages
+    const promoted = singleNamedItem(event)
+    const trimItems = (lines: InlineLine[]) => (promoted && lines.length === 1 && lines[0].text === promoted.text ? [] : lines)
+    const errors = trimItems(extracted.errors)
+    const warnings = trimItems(extracted.warnings)
+    const successes = extracted.successes
     // Success summaries already spell out a single package, so only expand 2+
     const successLines = successes.length > 1 ? successes : []
     const hasDetails = errors.length > 0 || warnings.length > 0 || successLines.length > 0
@@ -823,12 +870,12 @@ function EventsPageContent() {
       return null
     }
     return (
-      <div className="mt-1 space-y-0.5">
+      <div className="mt-1 space-y-1">
         {errors.map((m, i) => (
-          <div key={`e-${i}`} className="text-xs text-red-700 dark:text-red-300 break-words">{m}</div>
+          <div key={`e-${i}`} className={inlineLineClass(m, 'text-red-700 dark:text-red-300')}>{m.text}</div>
         ))}
         {warnings.map((m, i) => (
-          <div key={`w-${i}`} className="text-xs text-yellow-700 dark:text-yellow-300 break-words">{m}</div>
+          <div key={`w-${i}`} className={inlineLineClass(m, 'text-yellow-700 dark:text-yellow-300')}>{m.text}</div>
         ))}
         {successLines.map((m, i) => (
           <div key={`s-${i}`} className="text-xs text-green-700 dark:text-green-300 break-words">{m}</div>
@@ -1145,7 +1192,7 @@ function EventsPageContent() {
                       </tr>
                     ) : (
                       currentEvents.map((event) => {
-                      const isExpanded = expandedEvent === event.id
+                      const isExpanded = expandedEvents.has(event.id)
                       
                       return (
                         <React.Fragment key={event.id}>
@@ -1153,9 +1200,9 @@ function EventsPageContent() {
                             className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer"
                             onClick={async () => {
                               if (isExpanded) {
-                                setExpandedEvent(null)
+                                collapseEvent(event.id)
                               } else {
-                                setExpandedEvent(event.id)
+                                expandEvent(event.id)
                                 await fetchFullPayload(event.id)
                               }
                             }}
@@ -1187,7 +1234,7 @@ function EventsPageContent() {
                             </td>
                             <td className="px-4 lg:px-6 py-4 align-top">
                               <div className="text-sm text-gray-900 dark:text-white break-words">
-                                {getEventMessage(event)}
+                                {getDisplayMessage(event)}
                               </div>
                               {renderInlineDetails(event)}
                             </td>
@@ -1203,9 +1250,9 @@ function EventsPageContent() {
                                 onClick={async (e) => {
                                   e.preventDefault()
                                   if (isExpanded) {
-                                    setExpandedEvent(null)
+                                    collapseEvent(event.id)
                                   } else {
-                                    setExpandedEvent(event.id)
+                                    expandEvent(event.id)
                                     // Fetch full payload when expanding
                                     await fetchFullPayload(event.id)
                                   }
@@ -1246,10 +1293,11 @@ function EventsPageContent() {
                                     {!!fullPayloads[event.id] && !loadingPayloads.has(event.id) && (
                                       <LastRunSummary payload={fullPayloads[event.id]} />
                                     )}
+                                    <EventDetails eventIds={event.isBundle && event.eventIds ? event.eventIds : [String(event.id)]} />
                                     <div className="flex items-center justify-between">
                                       <div className="flex items-center gap-2">
                                         <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-                                          {fullPayloads[event.id] ? 'Full Raw Payload' : 'Raw Payload (from events list)'}
+                                          {fullPayloads[event.id] ? 'Raw Payload' : 'Raw Payload (from events list)'}
                                         </h4>
                                       </div>
                                       <div className="flex items-center gap-2">
@@ -1535,7 +1583,7 @@ function EventsPageContent() {
                       </tr>
                     ) : (
                       currentEvents.map((event) => {
-                      const isExpanded = expandedEvent === event.id
+                      const isExpanded = expandedEvents.has(event.id)
                       
                       return (
                         <React.Fragment key={event.id}>
@@ -1543,9 +1591,9 @@ function EventsPageContent() {
                             className="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer"
                             onClick={async () => {
                               if (isExpanded) {
-                                setExpandedEvent(null)
+                                collapseEvent(event.id)
                               } else {
-                                setExpandedEvent(event.id)
+                                expandEvent(event.id)
                                 await fetchFullPayload(event.id)
                               }
                             }}
@@ -1577,7 +1625,7 @@ function EventsPageContent() {
                             </td>
                             <td className="px-4 py-3 max-w-xs align-top">
                               <div className="text-sm text-gray-900 dark:text-white break-words">
-                                {getEventMessage(event)}
+                                {getDisplayMessage(event)}
                               </div>
                               {renderInlineDetails(event)}
                             </td>
@@ -1593,9 +1641,9 @@ function EventsPageContent() {
                                 onClick={async (e) => {
                                   e.preventDefault()
                                   if (isExpanded) {
-                                    setExpandedEvent(null)
+                                    collapseEvent(event.id)
                                   } else {
-                                    setExpandedEvent(event.id)
+                                    expandEvent(event.id)
                                     await fetchFullPayload(event.id)
                                   }
                                 }}
@@ -1623,6 +1671,7 @@ function EventsPageContent() {
                                     {!!fullPayloads[event.id] && !loadingPayloads.has(event.id) && (
                                       <LastRunSummary payload={fullPayloads[event.id]} />
                                     )}
+                                    <EventDetails eventIds={event.isBundle && event.eventIds ? event.eventIds : [String(event.id)]} />
                                     <div className="flex items-center justify-between">
                                       <div className="flex items-center gap-2">
                                         <h4 className="text-sm font-medium text-gray-900 dark:text-white">
@@ -1777,7 +1826,7 @@ function EventsPageContent() {
                 </div>
               ) : (
                 currentEvents.map((event) => {
-                const isExpanded = expandedEvent === event.id
+                const isExpanded = expandedEvents.has(event.id)
                 
                 return (
                   <div 
@@ -1785,9 +1834,9 @@ function EventsPageContent() {
                     className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 cursor-pointer"
                     onClick={async () => {
                       if (isExpanded) {
-                        setExpandedEvent(null)
+                        collapseEvent(event.id)
                       } else {
-                        setExpandedEvent(event.id)
+                        expandEvent(event.id)
                         await fetchFullPayload(event.id)
                       }
                     }}
@@ -1831,7 +1880,7 @@ function EventsPageContent() {
                     <div className="mb-3">
                       <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Message</div>
                       <div className="text-sm text-gray-900 dark:text-white break-words">
-                        {getEventMessage(event)}
+                        {getDisplayMessage(event)}
                       </div>
                       {renderInlineDetails(event)}
                     </div>
@@ -1847,9 +1896,9 @@ function EventsPageContent() {
                         onClick={async (e) => {
                           e.preventDefault()
                           if (isExpanded) {
-                            setExpandedEvent(null)
+                            collapseEvent(event.id)
                           } else {
-                            setExpandedEvent(event.id)
+                            expandEvent(event.id)
                             await fetchFullPayload(event.id)
                           }
                         }}
@@ -1890,6 +1939,7 @@ function EventsPageContent() {
                         {!!fullPayloads[event.id] && !loadingPayloads.has(event.id) && (
                           <LastRunSummary payload={fullPayloads[event.id]} />
                         )}
+                        <EventDetails eventIds={event.isBundle && event.eventIds ? event.eventIds : [String(event.id)]} />
                         <div className="flex items-center justify-between mb-2">
                           <div className="flex items-center gap-2">
                             <h4 className="text-sm font-medium text-gray-900 dark:text-white">

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -998,10 +998,10 @@ function EventsPageContent() {
                 <table className="w-full table-fixed relative border-collapse">
                   <colgroup>
                     <col style={{width: '5%'}} />
-                    <col style={{width: '52%'}} />
-                    <col style={{width: '21%'}} />
-                    <col style={{width: '13%'}} />
-                    <col style={{width: '9%'}} />
+                    <col style={{width: '22%'}} />
+                    <col style={{width: '49%'}} />
+                    <col style={{width: '14%'}} />
+                    <col style={{width: '10%'}} />
                   </colgroup>
                   <thead className="bg-gray-50 dark:bg-gray-700 sticky top-0 z-10 shadow-sm">
                     {/* Filter Row */}
@@ -1060,10 +1060,10 @@ function EventsPageContent() {
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Message
+                        Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Device
+                        Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
@@ -1108,12 +1108,6 @@ function EventsPageContent() {
                                 {getStatusIcon(event.kind)}
                               </div>
                             </td>
-                            <td className="px-4 lg:px-6 py-4 align-top">
-                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
-                                {getDisplayMessage(event)}
-                              </div>
-                              {renderInlineDetails(event)}
-                            </td>
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
                               <div>
                                 <Link
@@ -1133,6 +1127,12 @@ function EventsPageContent() {
                                   )}
                                 </div>
                               </div>
+                            </td>
+                            <td className="px-4 lg:px-6 py-4 align-top">
+                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                                {getDisplayMessage(event)}
+                              </div>
+                              {renderInlineDetails(event)}
                             </td>
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
                               <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -1346,10 +1346,10 @@ function EventsPageContent() {
                 <table className="w-full table-fixed border-collapse">
                   <colgroup>
                     <col style={{width: '5%'}} />
-                    <col style={{width: '52%'}} />
-                    <col style={{width: '21%'}} />
-                    <col style={{width: '13%'}} />
-                    <col style={{width: '9%'}} />
+                    <col style={{width: '22%'}} />
+                    <col style={{width: '49%'}} />
+                    <col style={{width: '14%'}} />
+                    <col style={{width: '10%'}} />
                   </colgroup>
                   <thead className="bg-gray-50 dark:bg-gray-700">
                     {/* Filter Row */}
@@ -1421,10 +1421,10 @@ function EventsPageContent() {
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Message
+                        Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Device
+                        Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
@@ -1489,12 +1489,6 @@ function EventsPageContent() {
                                 {getStatusIcon(event.kind)}
                               </div>
                             </td>
-                            <td className="px-4 py-3 max-w-xs align-top">
-                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
-                                {getDisplayMessage(event)}
-                              </div>
-                              {renderInlineDetails(event)}
-                            </td>
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
                               <div>
                                 <Link
@@ -1514,6 +1508,12 @@ function EventsPageContent() {
                                   )}
                                 </div>
                               </div>
+                            </td>
+                            <td className="px-4 py-3 max-w-xs align-top">
+                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                                {getDisplayMessage(event)}
+                              </div>
+                              {renderInlineDetails(event)}
                             </td>
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
                               <div className="text-sm text-gray-600 dark:text-gray-400">

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -144,9 +144,10 @@ function EventsPageContent() {
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  // Multi-select filters: success, warning, error, system active by default; info off
+  // Multi-select filters: success, warning, error on by default; system (the
+  // reboot log) and info (collection chatter) are opted into
   const [activeFilters, setActiveFilters] = useState<Set<string>>(
-    () => new Set(['success', 'warning', 'error', 'system'])
+    () => new Set(['success', 'warning', 'error'])
   )
   const [searchQuery, setSearchQuery] = useState('')
   // Several rows can be open at once; a Set of ids rather than a single id
@@ -984,10 +985,10 @@ function EventsPageContent() {
                 <table className="w-full table-fixed relative border-collapse">
                   <colgroup>
                     <col style={{width: '5%'}} />
-                    <col style={{width: '22%'}} />
-                    <col style={{width: '49%'}} />
-                    <col style={{width: '14%'}} />
-                    <col style={{width: '10%'}} />
+                    <col style={{width: '52%'}} />
+                    <col style={{width: '21%'}} />
+                    <col style={{width: '13%'}} />
+                    <col style={{width: '9%'}} />
                   </colgroup>
                   <thead className="bg-gray-50 dark:bg-gray-700 sticky top-0 z-10 shadow-sm">
                     {/* Filter Row */}
@@ -1052,19 +1053,19 @@ function EventsPageContent() {
                     </tr>
                     {/* Header Row - desktop */}
                     <tr>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-16">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Message
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Device
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-40">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-24">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Payloads
                       </th>
                     </tr>
@@ -1342,10 +1343,10 @@ function EventsPageContent() {
                 <table className="w-full table-fixed border-collapse">
                   <colgroup>
                     <col style={{width: '5%'}} />
-                    <col style={{width: '22%'}} />
-                    <col style={{width: '49%'}} />
-                    <col style={{width: '14%'}} />
-                    <col style={{width: '10%'}} />
+                    <col style={{width: '52%'}} />
+                    <col style={{width: '21%'}} />
+                    <col style={{width: '13%'}} />
+                    <col style={{width: '9%'}} />
                   </colgroup>
                   <thead className="bg-gray-50 dark:bg-gray-700">
                     {/* Filter Row */}
@@ -1423,19 +1424,19 @@ function EventsPageContent() {
                     </tr>
                     {/* Header Row */}
                     <tr>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-16">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Message
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-64">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Device
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-40">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
                       </th>
-                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-24">
+                      <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Payloads
                       </th>
                     </tr>

--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -12,7 +12,7 @@ import { bundleEvents, formatPayloadPreview, type FleetEvent, type BundledEvent 
 import { CopyButton } from "../../src/components/ui/CopyButton"
 import { LastRunSummary } from "../../src/components/LastRunSummary"
 import { EventDetails } from "../../src/lib/modules/widgets/EventDetails"
-import { extractInlineDetails, inlineLineClass, type InlineLine } from "../../src/lib/eventInlineDetails"
+import { extractInlineDetails, inlineLineClass } from "../../src/lib/eventInlineDetails"
 import { usePlatformFilterSafe, normalizePlatform } from "../../src/providers/PlatformFilterProvider"
 import { Search, X } from 'lucide-react'
 
@@ -742,6 +742,13 @@ function EventsPageContent() {
     const { errors, warnings, successes } = extractInlineDetails(fullPayloads[event.id])
     return { errors, warnings, successes, hasDetails: errors.length > 0 || warnings.length > 0 || successes.length > 0 }
   }
+  // A count summary takes its kind's colour, like the item lines it stands in for
+  const summaryToneClass = (kind: string) => ({
+    success: 'text-green-700 dark:text-green-300',
+    warning: 'text-yellow-700 dark:text-yellow-300',
+    error: 'text-red-700 dark:text-red-300',
+  } as Record<string, string>)[(kind || '').toLowerCase()] || 'text-gray-900 dark:text-white'
+
   const getDisplayMessage = (event: BundledEvent): string | null =>
     inlineLines(event).hasDetails ? null : getEventMessage(event)
 
@@ -1049,10 +1056,10 @@ function EventsPageContent() {
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Device
+                        Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Message
+                        Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
@@ -1097,11 +1104,17 @@ function EventsPageContent() {
                                 {getStatusIcon(event.kind)}
                               </div>
                             </td>
+                            <td className="px-4 lg:px-6 py-4 align-top">
+                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                                {getDisplayMessage(event)}
+                              </div>
+                              {renderInlineDetails(event)}
+                            </td>
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
                               <div>
                                 <Link
                                   href={getDeviceHref(event)}
-                                  className="font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors block truncate"
+                                  className="font-medium text-gray-900 dark:text-white hover:underline block truncate"
                                   title={event.deviceName || event.device}
                                   onClick={(e) => e.stopPropagation()}
                                 >
@@ -1116,12 +1129,6 @@ function EventsPageContent() {
                                   )}
                                 </div>
                               </div>
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 align-top">
-                              <div className="text-sm text-gray-900 dark:text-white break-words">
-                                {getDisplayMessage(event)}
-                              </div>
-                              {renderInlineDetails(event)}
                             </td>
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
                               <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -1420,10 +1427,10 @@ function EventsPageContent() {
                         Type
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Device
+                        Message
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                        Message
+                        Device
                       </th>
                       <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Time
@@ -1488,11 +1495,17 @@ function EventsPageContent() {
                                 {getStatusIcon(event.kind)}
                               </div>
                             </td>
+                            <td className="px-4 py-3 max-w-xs align-top">
+                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                                {getDisplayMessage(event)}
+                              </div>
+                              {renderInlineDetails(event)}
+                            </td>
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
                               <div>
                                 <Link
                                   href={getDeviceHref(event)}
-                                  className="font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors block truncate"
+                                  className="font-medium text-gray-900 dark:text-white hover:underline block truncate"
                                   title={event.deviceName || event.device}
                                   onClick={(e) => e.stopPropagation()}
                                 >
@@ -1507,12 +1520,6 @@ function EventsPageContent() {
                                   )}
                                 </div>
                               </div>
-                            </td>
-                            <td className="px-4 py-3 max-w-xs align-top">
-                              <div className="text-sm text-gray-900 dark:text-white break-words">
-                                {getDisplayMessage(event)}
-                              </div>
-                              {renderInlineDetails(event)}
                             </td>
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
                               <div className="text-sm text-gray-600 dark:text-gray-400">
@@ -1745,7 +1752,7 @@ function EventsPageContent() {
                       <div>
                         <Link
                           href={getDeviceHref(event)}
-                          className="font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors text-sm block"
+                          className="font-medium text-gray-900 dark:text-white hover:underline text-sm block"
                           onClick={(e) => e.stopPropagation()}
                         >
                           {event.deviceName || event.device}
@@ -1764,7 +1771,7 @@ function EventsPageContent() {
                     {/* Message */}
                     <div className="mb-3">
                       <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Message</div>
-                      <div className="text-sm text-gray-900 dark:text-white break-words">
+                      <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
                         {getDisplayMessage(event)}
                       </div>
                       {renderInlineDetails(event)}

--- a/app/installs/page.tsx
+++ b/app/installs/page.tsx
@@ -2387,9 +2387,9 @@ function InstallsPageContent() {
               <div className={`px-6 py-4 grid grid-cols-1 gap-6 ${
                 (() => {
                   const shown = [itemsWithErrors.length > 0, itemsWithWarnings.length > 0, itemsWithPending.length > 0, itemsWithSuccess.length > 0].filter(Boolean).length
-                  // Four across inside a max-w-7xl shell clips the Count
-                  // column, so four tables wrap to a 2x2 instead
-                  if (shown >= 4) return 'md:grid-cols-2'
+                  // One row of four; the tables are table-fixed so the item
+                  // name truncates instead of pushing Count out of the box
+                  if (shown >= 4) return 'md:grid-cols-2 lg:grid-cols-4'
                   if (shown === 3) return 'md:grid-cols-2 lg:grid-cols-3'
                   if (shown === 2) return 'lg:grid-cols-2'
                   return 'lg:grid-cols-1'
@@ -2432,7 +2432,7 @@ function InstallsPageContent() {
                         <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-5/6"></div>
                       </div>
                     ) : (
-                      <table className="w-full">
+                      <table className="w-full table-fixed">
                         <thead className="sticky top-0 bg-gray-50 dark:bg-gray-600 z-10">
                           <tr>
                             <th 
@@ -2452,7 +2452,7 @@ function InstallsPageContent() {
                               </div>
                             </th>
                             <th 
-                              className="px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
+                              className="w-20 px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
                               onClick={() => setErrorTableSort(prev => ({
                                 column: 'count',
                                 direction: prev.column === 'count' && prev.direction === 'desc' ? 'asc' : 'desc'
@@ -2543,7 +2543,7 @@ function InstallsPageContent() {
                         <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-5/6"></div>
                       </div>
                     ) : (
-                      <table className="w-full">
+                      <table className="w-full table-fixed">
                         <thead className="sticky top-0 bg-gray-50 dark:bg-gray-600 z-10">
                           <tr>
                             <th 
@@ -2563,7 +2563,7 @@ function InstallsPageContent() {
                               </div>
                             </th>
                             <th 
-                              className="px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
+                              className="w-20 px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
                               onClick={() => setWarningTableSort(prev => ({
                                 column: 'count',
                                 direction: prev.column === 'count' && prev.direction === 'desc' ? 'asc' : 'desc'
@@ -2654,7 +2654,7 @@ function InstallsPageContent() {
                         <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-5/6"></div>
                       </div>
                     ) : (
-                      <table className="w-full">
+                      <table className="w-full table-fixed">
                         <thead className="sticky top-0 bg-gray-50 dark:bg-gray-600 z-10">
                           <tr>
                             <th 
@@ -2674,7 +2674,7 @@ function InstallsPageContent() {
                               </div>
                             </th>
                             <th 
-                              className="px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
+                              className="w-20 px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
                               onClick={() => setPendingTableSort(prev => ({
                                 column: 'count',
                                 direction: prev.column === 'count' && prev.direction === 'desc' ? 'asc' : 'desc'
@@ -2767,13 +2767,13 @@ function InstallsPageContent() {
                         <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-5/6"></div>
                       </div>
                     ) : (
-                      <table className="w-full">
+                      <table className="w-full table-fixed">
                         <thead className="sticky top-0 bg-gray-50 dark:bg-gray-600 z-10">
                           <tr>
                             <th className="px-4 py-2 text-left text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider">
                               Item Name
                             </th>
-                            <th className="px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider">
+                            <th className="w-20 px-4 py-2 text-right text-xs font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wider">
                               Count
                             </th>
                           </tr>

--- a/app/installs/page.tsx
+++ b/app/installs/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { formatRelativeTime } from '@/src/lib/time'
 import { categorizeDevicesByInstallStatus, getDeviceInstallItems, aggregateStatusMessages, getItemMessage, getItemTimestamp, isErrorItem, isWarningItem, isPendingItem, isSuccessItem, matchesItemStatus, type ItemStatusFilter } from '@/src/hooks/useInstallsData'
+import { runLevelWarnings } from '@/src/lib/installs/status'
 import { calculateDeviceStatus } from '@/src/lib/data-processing'
 import { InstallErrorsWidget, InstallWarningsWidget, SelectedItemMessages } from '@/src/components/widgets/InstallMessages'
 import { CopyButton } from '@/src/components/ui/CopyButton'
@@ -190,7 +191,7 @@ function InstallsPageContent() {
   // Message rows cap their device list; this tracks the ones expanded in place
   const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set())
 
-  const { setTableContainerRef, effectiveFiltersExpanded, effectiveWidgetsExpanded } = useScrollCollapse(
+  const { setTableContainerRef, effectiveWidgetsExpanded } = useScrollCollapse(
     { filters: filtersExpanded, widgets: widgetsExpanded },
     { enabled: !loading && !filtersLoading }
   )
@@ -325,7 +326,7 @@ function InstallsPageContent() {
       setLoadingProgress({ current: 0, total: 0 })
       
       // Use a simple indeterminate progress while filters endpoint loads
-      let estimatedTotal = 100  // placeholder for progress bar
+      const estimatedTotal = 100  // placeholder for progress bar
       
       // Start fetching - we'll simulate progress with the actual device count
       let progress = 0
@@ -1264,14 +1265,18 @@ function InstallsPageContent() {
         })
       } else if (itemsStatusFilter === 'warnings') {
         relevantDevices = devicesWithWarnings.filter((device: any) => {
+          const searchLower = searchQuery.toLowerCase()
           const cimianItems = getDeviceInstallItems(device)
-          return cimianItems.some((item: any) => {
+          const itemMatch = cimianItems.some((item: any) => {
             const itemName = (item.itemName || item.name || '').toLowerCase()
             const lastWarning = (item.lastWarning || '').toLowerCase()
-            const searchLower = searchQuery.toLowerCase()
             // Match by item name OR by warning message
             return (itemName === searchLower || lastWarning.includes(searchLower)) && isWarningItem(item)
           })
+          if (itemMatch) return true
+          return runLevelWarnings(device).some(({ itemName, message }) =>
+            (itemName || '').toLowerCase() === searchLower || message.toLowerCase().includes(searchLower)
+          )
         })
       } else if (itemsStatusFilter === 'pending') {
         relevantDevices = devicesWithPending.filter((device: any) => {
@@ -1712,6 +1717,15 @@ function InstallsPageContent() {
           warningItems[itemName].devices.push(device.serialNumber || device.deviceId)
         }
       })
+      // Munki run-level warnings, attributed to the package they name
+      runLevelWarnings(device).forEach(({ itemName }) => {
+        if (!itemName) return
+        if (!warningItems[itemName]) {
+          warningItems[itemName] = { name: itemName, count: 0, devices: [] }
+        }
+        warningItems[itemName].count++
+        warningItems[itemName].devices.push(device.serialNumber || device.deviceId)
+      })
     })
     
     const items = Object.values(warningItems)
@@ -2086,9 +2100,9 @@ function InstallsPageContent() {
                   </div>
                 </div>
 
-                {/* Skeleton Widgets Content - 3 Tables Row */}
+                {/* Skeleton Widgets Content - Errors, Warnings, Pending, Installed in one row */}
                 <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-                  <div className="px-6 py-4 grid grid-cols-1 lg:grid-cols-3 gap-6">
+                  <div className="px-6 py-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                     {/* Skeleton Items with Errors Table */}
                     <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
                       <div className="flex items-center justify-between mb-4">
@@ -2140,6 +2154,25 @@ function InstallsPageContent() {
                         {[...Array(4)].map((_, i) => (
                           <div key={i} className="flex justify-between items-center py-1">
                             <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-28"></div>
+                            <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-8"></div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Skeleton Items Installed Table */}
+                    <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
+                      <div className="flex items-center justify-between mb-4">
+                        <div className="flex items-center gap-2">
+                          <div className="w-5 h-5 bg-green-200 dark:bg-green-900/50 rounded-full"></div>
+                          <div className="h-5 bg-gray-200 dark:bg-gray-600 rounded w-28"></div>
+                        </div>
+                        <div className="h-5 bg-green-100 dark:bg-green-900/30 rounded w-14"></div>
+                      </div>
+                      <div className="space-y-2">
+                        {[...Array(4)].map((_, i) => (
+                          <div key={i} className="flex justify-between items-center py-1">
+                            <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-24"></div>
                             <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-8"></div>
                           </div>
                         ))}
@@ -2355,8 +2388,7 @@ function InstallsPageContent() {
 
             {/* Widgets Accordion - Collapsible section for Items with Errors/Warnings/Pending and Config Widgets */}
             {isConfigReport && !isGeneratingReport && (
-              itemsWithErrors.length > 0 || itemsWithWarnings.length > 0 || itemsWithPending.length > 0 || itemsWithSuccess.length > 0 ||
-              (itemsStatusFilter === 'all' && configReportData.length > 0)
+              configReportData.length > 0
             ) && (
             <div className="border-b border-gray-200 dark:border-gray-700">
               {/* Widgets Accordion Header */}
@@ -2383,10 +2415,13 @@ function InstallsPageContent() {
               <CollapsibleSection expanded={effectiveWidgetsExpanded} maxHeight="60vh">
               <div className="bg-white dark:bg-gray-800">
             {/* Items Tables - Errors, Warnings, Pending (Above config widgets) - Only show in config report mode */}
-            {itemsStatusFilter === 'all' && (itemsWithErrors.length > 0 || itemsWithWarnings.length > 0 || itemsWithPending.length > 0 || itemsWithSuccess.length > 0) && !selectedMunkiVersion && !selectedCimianVersion && !selectedManifest && !selectedSoftwareRepo && (
+            {itemsStatusFilter === 'all' && configReportData.length > 0 && !selectedMunkiVersion && !selectedCimianVersion && !selectedManifest && !selectedSoftwareRepo && (
               <div className={`px-6 py-4 grid grid-cols-1 gap-6 ${
                 (() => {
-                  const shown = [itemsWithErrors.length > 0, itemsWithWarnings.length > 0, itemsWithPending.length > 0, itemsWithSuccess.length > 0].filter(Boolean).length
+                  // Errors and Warnings are the point of the page, so they always
+                  // have a box, even when empty; Pending and Installed only appear
+                  // when they have something to list
+                  const shown = [true, true, itemsWithPending.length > 0, itemsWithSuccess.length > 0].filter(Boolean).length
                   // One row of four; the tables are table-fixed so the item
                   // name truncates instead of pushing Count out of the box
                   if (shown >= 4) return 'md:grid-cols-2 lg:grid-cols-4'
@@ -2396,8 +2431,8 @@ function InstallsPageContent() {
                 })()
               }`}>
                 
-                {/* Items with Errors Table - Only show if has errors */}
-                {itemsWithErrors.length > 0 && (
+                {/* Items with Errors Table - always shown */}
+                {(
                 <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
                   <div 
                     className="flex items-center justify-between mb-4 cursor-pointer hover:opacity-80 transition-opacity"
@@ -2500,6 +2535,11 @@ function InstallsPageContent() {
                               </tr>
                             )})
                           }
+                                                  {itemsWithErrors.length === 0 && (
+                            <tr>
+                              <td colSpan={2} className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">No items with errors</td>
+                            </tr>
+                          )}
                         </tbody>
                       </table>
                     )}
@@ -2507,8 +2547,8 @@ function InstallsPageContent() {
                 </div>
                 )}
 
-                {/* Items with Warnings Table - Only show if has warnings */}
-                {itemsWithWarnings.length > 0 && (
+                {/* Items with Warnings Table - always shown */}
+                {(
                 <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 border border-gray-200 dark:border-gray-600">
                   <div 
                     className="flex items-center justify-between mb-4 cursor-pointer hover:opacity-80 transition-opacity"
@@ -2611,6 +2651,11 @@ function InstallsPageContent() {
                               </tr>
                             )})
                           }
+                                                  {itemsWithWarnings.length === 0 && (
+                            <tr>
+                              <td colSpan={2} className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">No items with warnings</td>
+                            </tr>
+                          )}
                         </tbody>
                       </table>
                     )}
@@ -3469,38 +3514,12 @@ function InstallsPageContent() {
             )
           })()}
 
-          {/* Installs report-builder accordion (page-specific) */}
-          {!filtersLoading && (
+          {/* Report-builder item picker (page-specific); the status filters that
+              used to live in this accordion sit beside the search bar now */}
+          {!filtersLoading && isGeneratingReport && (
             <div className="border-b border-gray-200 dark:border-gray-700">
-              {/* Accordion Header - Hide button when in generate report mode */}
-              {!isGeneratingReport && (
-              <button
-                onClick={() => setFiltersExpanded(!filtersExpanded)}
-                className="w-full px-6 py-3 flex items-center justify-between bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Installs
-                  </span>
-                  {(selectedInstalls.length > 0 || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedRooms.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0) && (
-                    <span className="px-2 py-0.5 text-xs rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                      {selectedInstalls.length + selectedUsages.length + selectedCatalogs.length + selectedRooms.length + selectedFleets.length + selectedAreas.length + selectedPlatforms.length} active
-                    </span>
-                  )}
-                </div>
-                <svg 
-                  className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${effectiveFiltersExpanded ? 'rotate-90' : 'rotate-180'}`} 
-                  fill="none" 
-                  stroke="currentColor" 
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
-              </button>
-              )}
-
               {/* Filter Clouds Section - Show when expanded OR in generate report mode */}
-              <CollapsibleSection expanded={effectiveFiltersExpanded || isGeneratingReport}>
+              <CollapsibleSection expanded={isGeneratingReport}>
             <div className={`px-6 py-4 bg-white dark:bg-gray-800 ${isGeneratingReport && !loading && installs.length === 0 && !hasGeneratedReport ? 'rounded-b-xl' : ''}`}>
               <div className="space-y-4">
 
@@ -3551,129 +3570,6 @@ function InstallsPageContent() {
                 </div>
                 )}
 
-                {/* Device Status and Install Status Filters - Only show after report is generated */}
-                {!isGeneratingReport && (installs.length > 0 || (isConfigReport && configReportData.length > 0)) && (
-                <div className="flex flex-col md:flex-row gap-8 pt-4">
-                  {/* Device Status Filter */}
-                  <div className="pb-2">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Device Status
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      <button
-                        onClick={() => setDeviceStatusFilter(deviceStatusFilter === 'active' ? 'all' : 'active')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          deviceStatusFilter === 'active'
-                            ? 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-200 dark:border-green-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <span className="w-2 h-2 rounded-full bg-green-500"></span>
-                        Active ({deviceStatusCounts.active})
-                      </button>
-                      <button
-                        onClick={() => setDeviceStatusFilter(deviceStatusFilter === 'stale' ? 'all' : 'stale')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          deviceStatusFilter === 'stale'
-                            ? 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <span className="w-2 h-2 rounded-full bg-yellow-500"></span>
-                        Stale ({deviceStatusCounts.stale})
-                      </button>
-                      <button
-                        onClick={() => setDeviceStatusFilter(deviceStatusFilter === 'missing' ? 'all' : 'missing')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          deviceStatusFilter === 'missing'
-                            ? 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-200 dark:border-red-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <span className="w-2 h-2 rounded-full bg-red-500"></span>
-                        Missing ({deviceStatusCounts.missing})
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Install Status Filter - Hide when items widget filter (errors/warnings/pending) is active */}
-                  {itemsStatusFilter === 'all' && (
-                  <div className="pb-2">
-                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Install Status
-                    </h3>
-                    <div className="flex flex-wrap gap-1">
-                      <button
-                        onClick={() => setInstallStatusFilter(installStatusFilter === 'installed' ? 'all' : 'installed')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          installStatusFilter === 'installed'
-                            ? 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900 dark:text-green-200 dark:border-green-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <svg className="w-3 h-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        Installed ({installStatusCounts.installed})
-                      </button>
-                      <button
-                        onClick={() => setInstallStatusFilter(installStatusFilter === 'pending' ? 'all' : 'pending')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          installStatusFilter === 'pending'
-                            ? 'bg-cyan-100 text-cyan-800 border-cyan-300 dark:bg-cyan-900 dark:text-cyan-200 dark:border-cyan-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <svg className="w-3 h-3 text-cyan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        Pending ({installStatusCounts.pending})
-                      </button>
-                      <button
-                        onClick={() => setInstallStatusFilter(installStatusFilter === 'warnings' ? 'all' : 'warnings')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          installStatusFilter === 'warnings'
-                            ? 'bg-amber-100 text-amber-800 border-amber-300 dark:bg-amber-900 dark:text-amber-200 dark:border-amber-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <svg className="w-3 h-3 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                        Warnings ({installStatusCounts.warnings})
-                      </button>
-                      <button
-                        onClick={() => setInstallStatusFilter(installStatusFilter === 'errors' ? 'all' : 'errors')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          installStatusFilter === 'errors'
-                            ? 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900 dark:text-red-200 dark:border-red-600'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <svg className="w-3 h-3 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        Errors ({installStatusCounts.errors})
-                      </button>
-                      <button
-                        onClick={() => setInstallStatusFilter(installStatusFilter === 'removed' ? 'all' : 'removed')}
-                        className={`px-3 py-1.5 text-xs rounded-full border transition-colors flex items-center gap-1.5 ${
-                          installStatusFilter === 'removed'
-                            ? 'bg-gray-200 text-gray-800 border-gray-400 dark:bg-gray-600 dark:text-gray-200 dark:border-gray-500'
-                            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-600 dark:text-gray-300 dark:border-gray-500 dark:hover:bg-gray-500'
-                        }`}
-                      >
-                        <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                        </svg>
-                        Removed ({installStatusCounts.removed})
-                      </button>
-                    </div>
-                  </div>
-                  )}
-                </div>
-                )}
-
               </div>
             </div>
           </CollapsibleSection>
@@ -3707,6 +3603,48 @@ function InstallsPageContent() {
                     </button>
                   )}
                 </div>
+                {/* Device and install status filters. A pill is coloured by what it
+                    means and goes solid when active, matching the status chips on
+                    the device Installs tab. */}
+                {(installs.length > 0 || (isConfigReport && configReportData.length > 0)) && (
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {([
+                      { value: 'active', label: 'Active', count: deviceStatusCounts.active, tone: 'neutral' },
+                      { value: 'stale', label: 'Stale', count: deviceStatusCounts.stale, tone: 'neutral' },
+                      { value: 'missing', label: 'Missing', count: deviceStatusCounts.missing, tone: 'neutral' },
+                    ] as const).map(pill => (
+                      <button
+                        key={pill.value}
+                        onClick={() => setDeviceStatusFilter(deviceStatusFilter === pill.value ? 'all' : pill.value)}
+                        aria-pressed={deviceStatusFilter === pill.value}
+                        className={statusPillClass(pill.tone, deviceStatusFilter === pill.value)}
+                      >
+                        {pill.label} - {pill.count}
+                      </button>
+                    ))}
+                    {itemsStatusFilter === 'all' && (
+                      <>
+                        <span className="w-px h-5 bg-gray-200 dark:bg-gray-700 mx-1" aria-hidden="true"></span>
+                        {([
+                          { value: 'errors', label: 'Errors', count: installStatusCounts.errors, tone: 'red' },
+                          { value: 'warnings', label: 'Warnings', count: installStatusCounts.warnings, tone: 'amber' },
+                          { value: 'pending', label: 'Pending', count: installStatusCounts.pending, tone: 'cyan' },
+                          { value: 'installed', label: 'Installed', count: installStatusCounts.installed, tone: 'green' },
+                          { value: 'removed', label: 'Removed', count: installStatusCounts.removed, tone: 'purple' },
+                        ] as const).map(pill => (
+                          <button
+                            key={pill.value}
+                            onClick={() => setInstallStatusFilter(installStatusFilter === pill.value ? 'all' : pill.value)}
+                            aria-pressed={installStatusFilter === pill.value}
+                            className={statusPillClass(pill.tone, installStatusFilter === pill.value)}
+                          >
+                            {pill.label} - {pill.count}
+                          </button>
+                        ))}
+                      </>
+                    )}
+                  </div>
+                )}
                 {/* Clear Filter(s) Button - Show when any filter is active */}
                 {(searchQuery || itemsStatusFilter !== 'all' || deviceStatusFilter !== 'all' || installStatusFilter !== 'all' || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0 || selectedRooms.length > 0 || selectedManifest || selectedSoftwareRepo || selectedMunkiVersion || selectedCimianVersion) && (
                   <button
@@ -4413,6 +4351,22 @@ function InstallsPageContent() {
       </div>
     </div>
   )
+}
+
+// Status filter pills. Install statuses take the same soft tones as the status
+// chips on the device Installs tab; device statuses stay neutral. Active is one
+// shade deeper plus a ring, never a solid fill.
+const STATUS_PILL_TONES = {
+  green: ['bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-900/60', 'bg-green-200 text-green-900 ring-1 ring-green-400 dark:bg-green-900/70 dark:text-green-100 dark:ring-green-600'],
+  amber: ['bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300 hover:bg-yellow-200 dark:hover:bg-yellow-900/60', 'bg-yellow-200 text-yellow-900 ring-1 ring-yellow-400 dark:bg-yellow-900/70 dark:text-yellow-100 dark:ring-yellow-600'],
+  red: ['bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-900/60', 'bg-red-200 text-red-900 ring-1 ring-red-400 dark:bg-red-900/70 dark:text-red-100 dark:ring-red-600'],
+  cyan: ['bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300 hover:bg-cyan-200 dark:hover:bg-cyan-900/60', 'bg-cyan-200 text-cyan-900 ring-1 ring-cyan-400 dark:bg-cyan-900/70 dark:text-cyan-100 dark:ring-cyan-600'],
+  purple: ['bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 hover:bg-purple-200 dark:hover:bg-purple-900/60', 'bg-purple-200 text-purple-900 ring-1 ring-purple-400 dark:bg-purple-900/70 dark:text-purple-100 dark:ring-purple-600'],
+  neutral: ['bg-white text-gray-700 border border-gray-300 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700', 'bg-gray-200 text-gray-900 border border-gray-400 dark:bg-gray-600 dark:text-white dark:border-gray-500'],
+} as const
+
+function statusPillClass(tone: keyof typeof STATUS_PILL_TONES, active: boolean): string {
+  return `px-3 py-1 text-sm font-medium rounded-full whitespace-nowrap transition-colors ${STATUS_PILL_TONES[tone][active ? 1 : 0]}`
 }
 
 export default function InstallsPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="format-detection" content="telephone=no" />
       </head>
-      <body className={`${inter.className} h-full antialiased bg-white dark:bg-black transition-colors duration-200`} suppressHydrationWarning>
+      <body className={`${inter.className} min-h-full antialiased bg-white dark:bg-black transition-colors duration-200`} suppressHydrationWarning>
         <script 
           dangerouslySetInnerHTML={{
             __html: `

--- a/src/components/DeviceEventsSimple.tsx
+++ b/src/components/DeviceEventsSimple.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { normalizeEventKind, severityToBadgeClasses } from '../lib/events/normalize';
 import { CopyButton } from './ui/CopyButton';
 import { LastRunSummary } from './LastRunSummary';
+import { EventDetails } from '../lib/modules/widgets/EventDetails';
 import { Search, X } from 'lucide-react';
 
 interface EventDto {
@@ -77,7 +78,8 @@ const formatTimestamp = (ts?: string): string => {
 }
 
 export default function DeviceEvents({ events }: { events: EventDto[] }) {
-  const [expanded, setExpanded] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const isOpen = (id: string) => expanded.has(id);
   const [fullPayloads, setFullPayloads] = useState<Record<string, unknown>>({});
   const [loadingPayloads, setLoadingPayloads] = useState<Set<string>>(new Set());
   const [payloadSearches, setPayloadSearches] = useState<Record<string, string>>({});
@@ -597,8 +599,8 @@ export default function DeviceEvents({ events }: { events: EventDto[] }) {
                 
                 <button 
                   onClick={() => {
-                    const isOpening = expanded !== ev.id;
-                    setExpanded(e => (e === ev.id ? null : ev.id));
+                    const isOpening = !isOpen(ev.id);
+                    setExpanded(prev => { const next = new Set(prev); if (next.has(ev.id)) next.delete(ev.id); else next.add(ev.id); return next; });
                     
                     // Auto-fetch full payload when opening, just like the main events page
                     if (isOpening) {
@@ -606,17 +608,17 @@ export default function DeviceEvents({ events }: { events: EventDto[] }) {
                     }
                   }}
                   className="flex items-center gap-1 px-3 py-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors flex-shrink-0"
-                  aria-expanded={expanded === ev.id}
+                  aria-expanded={isOpen(ev.id)}
                   aria-controls={`payload-${ev.id}`}
                 >
-                  {expanded === ev.id ? 'Hide' : 'Show'} Payload
+                  {isOpen(ev.id) ? 'Hide' : 'Show'} Payload
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={expanded === ev.id ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={isOpen(ev.id) ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} />
                   </svg>
                 </button>
               </header>
 
-              {expanded === ev.id && (
+              {isOpen(ev.id) && (
                 <div 
                   id={`payload-${ev.id}`}
                   className="mt-4 border-t border-gray-200 dark:border-gray-700 pt-4"
@@ -625,10 +627,13 @@ export default function DeviceEvents({ events }: { events: EventDto[] }) {
                   {fullPayloads[ev.id] && !loadingPayloads.has(ev.id) && (
                     <LastRunSummary payload={fullPayloads[ev.id]} />
                   )}
+                  <div className="mb-4">
+                    <EventDetails eventIds={bundledEventIds.length > 0 ? bundledEventIds : [String(ev.id)]} />
+                  </div>
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
                       <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-                        {fullPayloads[ev.id] ? 'Full Raw Payload' : 'Raw Payload (from events list)'}
+                        {fullPayloads[ev.id] ? 'Raw Payload' : 'Raw Payload (from events list)'}
                       </h4>
                       <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 font-mono">
                         #{ev.id}

--- a/src/components/DeviceEventsSimple.tsx
+++ b/src/components/DeviceEventsSimple.tsx
@@ -3,6 +3,7 @@ import { normalizeEventKind, severityToBadgeClasses } from '../lib/events/normal
 import { CopyButton } from './ui/CopyButton';
 import { LastRunSummary } from './LastRunSummary';
 import { EventDetails } from '../lib/modules/widgets/EventDetails';
+import { EventInlineLines } from '../lib/modules/widgets/EventInlineLines';
 import { Search, X } from 'lucide-react';
 
 interface EventDto {
@@ -587,9 +588,13 @@ export default function DeviceEvents({ events }: { events: EventDto[] }) {
                   </span>
                   
                   {/* Event Message - Hidden on mobile (sm and below) */}
-                  <span className="font-medium text-gray-900 dark:text-white truncate flex-1 min-w-0 hidden md:block">
-                    {getEventMessage(ev)}
-                  </span>
+                  <EventInlineLines
+                    eventId={String(ev.id)}
+                    kind={ev.kind || ''}
+                    summary={getEventMessage(ev)}
+                    isBundle={Boolean(ev.isBundle)}
+                    className="flex-1 min-w-0 hidden md:block font-medium"
+                  />
                   
                   {/* Timestamp */}
                   <span className="text-sm text-gray-500 dark:text-gray-400 flex-shrink-0">

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -1,0 +1,102 @@
+/**
+ * Outcome of the most recent managed-software run on a device.
+ *
+ * A run that never reached its manifest reports zero items, so the items
+ * table alone reads as "nothing assigned" when the truth is "the run failed".
+ * This card says which, and shows the run's messages: from the module when
+ * the client sent them, else from the device's latest error or warning event,
+ * because the stale-error sweep can blank the module strings.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
+
+interface InstallsRunStatusProps {
+  serialNumber?: string
+  installs: any
+}
+
+type Outcome = 'error' | 'warning' | null
+
+function splitMessages(raw: unknown): string[] {
+  if (typeof raw !== 'string') return []
+  return raw.split(/;|\n/).map(s => s.trim()).filter(s => s && !/^-{3,}$/.test(s) && !/^installer:(%|PHASE:|STATUS:)/i.test(s))
+}
+
+function runOutcome(installs: any): { outcome: Outcome; errors: string[]; warnings: string[] } {
+  const munki = installs?.munki
+  const cimian = installs?.cimian
+  if (munki) {
+    const errors = splitMessages(munki.errors)
+    const warnings = splitMessages(munki.warnings)
+    const status = String(munki.status || '').toLowerCase()
+    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || errors.length > 0
+    return { outcome: failed ? 'error' : (warnings.length > 0 || status === 'warning') ? 'warning' : null, errors, warnings }
+  }
+  if (cimian) {
+    const session = Array.isArray(cimian.sessions) ? cimian.sessions[0] : null
+    const status = String(session?.status || cimian.status || '').toLowerCase()
+    const failed = (session?.failures || 0) > 0 || (session?.packages_failed || 0) > 0 || status === 'failed' || status === 'error'
+    const warned = status === 'warning' || (session?.warnings || 0) > 0
+    return { outcome: failed ? 'error' : warned ? 'warning' : null, errors: [], warnings: [] }
+  }
+  return { outcome: null, errors: [], warnings: [] }
+}
+
+export function lastRunFailed(installs: any): boolean {
+  return runOutcome(installs).outcome === 'error'
+}
+
+export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumber, installs }) => {
+  const { outcome, errors, warnings } = runOutcome(installs)
+  const [eventLines, setEventLines] = useState<{ errors: InlineLine[]; warnings: InlineLine[] } | null>(null)
+
+  // No text on the module: read it from the device's latest matching event
+  useEffect(() => {
+    if (!outcome || !serialNumber || errors.length > 0 || warnings.length > 0) return
+    let cancelled = false
+    const type = outcome === 'error' ? 'error' : 'warning'
+    fetch(`/api/device/${encodeURIComponent(serialNumber)}/modules/events?limit=5&type=${type}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(async result => {
+        const events: any[] = result?.data || result?.events || []
+        const installsEvent = events.find(e => /munki|cimian|install/i.test(String(e.message || '')) || e.moduleId === 'installs' || e.module_id === 'installs') || events[0]
+        if (!installsEvent || cancelled) return
+        const payload = await fetchEventPayload(String(installsEvent.id))
+        if (cancelled) return
+        const extracted = extractInlineDetails(payload)
+        setEventLines({ errors: extracted.errors, warnings: extracted.warnings })
+      })
+      .catch(() => { /* the card still states the outcome without text */ })
+    return () => { cancelled = true }
+  }, [outcome, serialNumber, errors.length, warnings.length])
+
+  if (!outcome) return null
+
+  const errorLines: InlineLine[] = errors.length ? errors.map(text => ({ text, isMessage: true })) : (eventLines?.errors ?? [])
+  const warningLines: InlineLine[] = warnings.length ? warnings.map(text => ({ text, isMessage: true })) : (eventLines?.warnings ?? [])
+  const isError = outcome === 'error'
+
+  return (
+    <div className={`rounded-lg border p-4 ${isError ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20' : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'}`}>
+      <div className="flex items-center gap-2 mb-2">
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${isError ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'}`}>
+          {isError ? 'Last run failed' : 'Last run had warnings'}
+        </span>
+        {isError && (!installs?.munki?.items || installs.munki.items.length === 0) && (
+          <span className="text-sm text-gray-600 dark:text-gray-400">The run did not complete, so no items were reported.</span>
+        )}
+      </div>
+      {(errorLines.length > 0 || warningLines.length > 0) ? (
+        <div className="space-y-1">
+          {errorLines.map((line, i) => <div key={`e-${i}`} className={inlineLineClass(line, 'text-red-700 dark:text-red-300')}>{line.text}</div>)}
+          {warningLines.map((line, i) => <div key={`w-${i}`} className={inlineLineClass(line, 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>)}
+        </div>
+      ) : (
+        <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
+      )}
+    </div>
+  )
+}
+
+export default InstallsRunStatus

--- a/src/components/tables/ManagedInstallsTable.tsx
+++ b/src/components/tables/ManagedInstallsTable.tsx
@@ -26,9 +26,11 @@ interface ManagedInstallsTableProps {
   data: InstallsInfo;
   initialStatusFilter?: string[];
   initialSearchQuery?: string;
+  /** The last run failed; an empty list means "not reported", not "nothing assigned". */
+  runFailed?: boolean;
 }
 
-export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data, initialStatusFilter, initialSearchQuery }) => {
+export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data, initialStatusFilter, initialSearchQuery, runFailed = false }) => {
   const [statusFilter, setStatusFilter] = useState<Set<string>>(() => new Set(initialStatusFilter ?? []));
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery ?? '');
   const [expandedPackageIds, setExpandedPackageIds] = useState<Set<string>>(new Set());
@@ -547,16 +549,26 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                     <tr>
                       <td colSpan={5} className="px-6 py-16">
                         <div className="text-center">
-                          <div className="w-12 h-12 mx-auto mb-4 bg-emerald-100 dark:bg-emerald-900 rounded-full flex items-center justify-center">
-                            <svg className="w-6 h-6 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
+                          <div className={`w-12 h-12 mx-auto mb-4 rounded-full flex items-center justify-center ${runFailed ? 'bg-red-100 dark:bg-red-900' : 'bg-emerald-100 dark:bg-emerald-900'}`}>
+                            {runFailed ? (
+                              <svg className="w-6 h-6 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                              </svg>
+                            ) : (
+                              <svg className="w-6 h-6 text-emerald-600 dark:text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                              </svg>
+                            )}
                           </div>
                           <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-2">
-                            {data.systemName ? `${data.systemName.charAt(0).toUpperCase() + data.systemName.slice(1)} System Active` : 'Management System Active'}
+                            {runFailed
+                              ? 'Last run did not complete'
+                              : data.systemName ? `${data.systemName.charAt(0).toUpperCase() + data.systemName.slice(1)} System Active` : 'Management System Active'}
                           </h3>
                           <p className="text-sm text-gray-600 dark:text-gray-400">
-                            The managed installs system is configured and running, but no packages are currently assigned to this device.
+                            {runFailed
+                              ? 'No items were reported because the run failed before it could evaluate the manifest.'
+                              : 'The managed installs system is configured and running, but no packages are currently assigned to this device.'}
                           </p>
                           {data.config?.lastRun && (
                             <p className="text-xs text-gray-500 dark:text-gray-500 mt-2">

--- a/src/components/tables/ScheduledTasksTable.tsx
+++ b/src/components/tables/ScheduledTasksTable.tsx
@@ -5,6 +5,8 @@
 
 import React, { useState, useMemo, useRef, useEffect } from 'react'
 import { formatExactTime } from '../../lib/time'
+import { FilterPills } from '../ui/FilterPills'
+import { classifyTaskPath, type WindowsSource } from '../../lib/windows-source'
 
 export interface ScheduledTask {
   name: string
@@ -29,6 +31,7 @@ export const ScheduledTasksTable: React.FC<ScheduledTasksTableProps> = ({
 }) => {
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('all')
+  const [sourceFilter, setSourceFilter] = useState<'all' | WindowsSource>('all')
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -97,6 +100,10 @@ export const ScheduledTasksTable: React.FC<ScheduledTasksTableProps> = ({
       )
     }
     
+    if (sourceFilter !== 'all') {
+      filtered = filtered.filter(task => classifyTaskPath(task.path) === sourceFilter)
+    }
+
     if (statusFilter !== 'all') {
       filtered = filtered.filter(task => {
         if (statusFilter === 'enabled') return task.enabled
@@ -109,7 +116,16 @@ export const ScheduledTasksTable: React.FC<ScheduledTasksTableProps> = ({
     }
     
     return filtered
-  }, [scheduledTasks, search, statusFilter])
+  }, [scheduledTasks, search, statusFilter, sourceFilter])
+
+  const sourceOptions = useMemo(() => {
+    const builtIn = scheduledTasks.filter(task => classifyTaskPath(task.path) === 'windows').length
+    return [
+      { value: 'all' as const, label: 'All', count: scheduledTasks.length },
+      { value: 'windows' as const, label: 'Windows', count: builtIn },
+      { value: 'third-party' as const, label: 'Third-party', count: scheduledTasks.length - builtIn },
+    ]
+  }, [scheduledTasks])
 
   // Filter options with labels and counts
   const filterOptions = useMemo(() => {
@@ -214,7 +230,8 @@ export const ScheduledTasksTable: React.FC<ScheduledTasksTableProps> = ({
               Windows scheduled tasks and their execution status ({filteredTasks.length} of {scheduledTasks.length} tasks)
             </p>
           </div>
-          <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+            <FilterPills ariaLabel="Task source" options={sourceOptions} value={sourceFilter} onChange={setSourceFilter} />
             {/* Custom Filter Dropdown */}
             <div className="relative" ref={dropdownRef}>
               <button
@@ -349,10 +366,10 @@ export const ScheduledTasksTable: React.FC<ScheduledTasksTableProps> = ({
               ))}
             </tbody>
           </table>
-          {filteredTasks.length === 0 && search && (
+          {filteredTasks.length === 0 && (search || sourceFilter !== 'all' || statusFilter !== 'all') && (
             <div className="px-6 py-8 text-center">
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                No scheduled tasks found matching &quot;{search}&quot;
+                No scheduled tasks match the current filters
               </p>
             </div>
           )}

--- a/src/components/tabs/EventsTab.tsx
+++ b/src/components/tabs/EventsTab.tsx
@@ -24,23 +24,23 @@ const EVENT_FILTERS = [
 function getFilterStyles(key: string, isActive: boolean) {
   const baseColors: Record<string, { active: string; inactive: string }> = {
     success: {
-      active: 'bg-green-700 text-white border-green-800 shadow-md dark:bg-green-600 dark:border-green-700',
+      active: 'bg-green-200 text-green-900 border-green-400 ring-1 ring-green-400 dark:bg-green-900/70 dark:text-green-100 dark:border-green-600 dark:ring-green-600',
       inactive: 'bg-green-100 text-green-700 border-green-200 hover:bg-green-200 hover:border-green-300 dark:bg-green-900/40 dark:text-green-400 dark:border-green-800 dark:hover:bg-green-900/60'
     },
     warning: {
-      active: 'bg-yellow-600 text-white border-yellow-700 shadow-md dark:bg-yellow-500 dark:border-yellow-600',
+      active: 'bg-yellow-200 text-yellow-900 border-yellow-400 ring-1 ring-yellow-400 dark:bg-yellow-900/70 dark:text-yellow-100 dark:border-yellow-600 dark:ring-yellow-600',
       inactive: 'bg-yellow-100 text-yellow-700 border-yellow-200 hover:bg-yellow-200 hover:border-yellow-300 dark:bg-yellow-900/40 dark:text-yellow-400 dark:border-yellow-800 dark:hover:bg-yellow-900/60'
     },
     error: {
-      active: 'bg-red-700 text-white border-red-800 shadow-md dark:bg-red-600 dark:border-red-700',
+      active: 'bg-red-200 text-red-900 border-red-400 ring-1 ring-red-400 dark:bg-red-900/70 dark:text-red-100 dark:border-red-600 dark:ring-red-600',
       inactive: 'bg-red-100 text-red-700 border-red-200 hover:bg-red-200 hover:border-red-300 dark:bg-red-900/40 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-900/60'
     },
     info: {
-      active: 'bg-blue-700 text-white border-blue-800 shadow-md dark:bg-blue-600 dark:border-blue-700',
+      active: 'bg-blue-200 text-blue-900 border-blue-400 ring-1 ring-blue-400 dark:bg-blue-900/70 dark:text-blue-100 dark:border-blue-600 dark:ring-blue-600',
       inactive: 'bg-blue-100 text-blue-700 border-blue-200 hover:bg-blue-200 hover:border-blue-300 dark:bg-blue-900/40 dark:text-blue-400 dark:border-blue-800 dark:hover:bg-blue-900/60'
     },
     system: {
-      active: 'bg-purple-700 text-white border-purple-800 shadow-md dark:bg-purple-600 dark:border-purple-700',
+      active: 'bg-purple-200 text-purple-900 border-purple-400 ring-1 ring-purple-400 dark:bg-purple-900/70 dark:text-purple-100 dark:border-purple-600 dark:ring-purple-600',
       inactive: 'bg-purple-100 text-purple-700 border-purple-200 hover:bg-purple-200 hover:border-purple-300 dark:bg-purple-900/40 dark:text-purple-400 dark:border-purple-800 dark:hover:bg-purple-900/60'
     },
   }
@@ -252,7 +252,7 @@ export const EventsTab: React.FC<EventsTabProps> = ({ device, events, data }) =>
                 <Icon className="w-4 h-4" />
                 <span>{filter.label}</span>
                 {count > 0 && (
-                  <span className={`ml-1 px-1.5 py-0.5 text-xs font-semibold rounded-full ${isActive ? 'bg-white/30 text-white' : 'bg-white/50 dark:bg-black/20'}`}>
+                  <span className={`ml-1 px-1.5 py-0.5 text-xs font-semibold rounded-full ${isActive ? 'bg-white/60 dark:bg-black/30' : 'bg-white/50 dark:bg-black/20'}`}>
                     {count}
                   </span>
                 )}

--- a/src/components/tabs/InstallsTab.tsx
+++ b/src/components/tabs/InstallsTab.tsx
@@ -9,6 +9,7 @@ import { ManagedInstallsTable } from '../tables/ManagedInstallsTable'
 import { extractInstalls, type InstallsInfo } from '../../lib/data-processing/modules/installs'
 import { normalizeKeys } from '../../lib/utils/powershell-parser'
 import { DebugAccordion } from '../DebugAccordion'
+import { InstallsRunStatus, lastRunFailed } from '../InstallsRunStatus'
 
 interface InstallsTabProps {
   device: any
@@ -545,12 +546,16 @@ export const InstallsTab: React.FC<InstallsTabProps> = ({ device, data, initialF
       {/* Loading State */}
       {/* Removed simple loading state in favor of full page skeleton */}
 
+      {/* Outcome of the last run, above the items it did or did not produce */}
+      <InstallsRunStatus serialNumber={device?.serialNumber} installs={normalizedInstallsModule} />
+
       {/* Managed Installs with Configuration */}
       {processedInstallsData ? (
         <>
           <ManagedInstallsTable
             data={processedInstallsData}
             initialStatusFilter={initialFilter ? (Array.isArray(initialFilter) ? initialFilter : [initialFilter]) : undefined}
+            runFailed={lastRunFailed(normalizedInstallsModule)}
           />
           
           <DebugAccordion

--- a/src/components/tabs/SystemTab.tsx
+++ b/src/components/tabs/SystemTab.tsx
@@ -6,6 +6,8 @@
 
 import { formatRelativeTime, formatExactTime, formatBootTime, parseInstallTime } from '../../lib/time'
 import React, { useState, useMemo, useRef, useEffect } from 'react'
+import { FilterPills } from '../ui/FilterPills'
+import { classifyServicePath, type WindowsSource } from '../../lib/windows-source'
 import { extractSystem } from '../../lib/data-processing/modules/system'
 import { ScheduledTasksTable } from '../tables/ScheduledTasksTable'
 import { LaunchdTable } from '../tables/LaunchdTable'
@@ -156,6 +158,8 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
   
   // State for services search
   const [servicesSearch, setServicesSearch] = useState('')
+  const [servicesStatusFilter, setServicesStatusFilter] = useState<'all' | 'running' | 'stopped'>('all')
+  const [servicesSourceFilter, setServicesSourceFilter] = useState<'all' | WindowsSource>('all')
   // State for privileged helper tools search
   const [helperSearch, setHelperSearch] = useState('')
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -264,18 +268,46 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
     ? getMacOSMarketingName(osInfo?.version)
     : getWindowsMarketingName(osInfo?.displayVersion)
 
-  // Filter services based on search
+  const isServiceRunning = (service: any) => {
+    const status = (service.status || '').toLowerCase()
+    return status.includes('running') || status.includes('started')
+  }
+
+  const servicesStatusOptions = useMemo(() => {
+    const running = services.filter(isServiceRunning).length
+    return [
+      { value: 'all' as const, label: 'All', count: services.length },
+      { value: 'running' as const, label: 'Running', count: running },
+      { value: 'stopped' as const, label: 'Stopped', count: services.length - running },
+    ]
+  }, [services])
+
+  const servicesSourceOptions = useMemo(() => {
+    const builtIn = services.filter((s: any) => classifyServicePath(s.path) === 'windows').length
+    return [
+      { value: 'all' as const, label: 'All', count: services.length },
+      { value: 'windows' as const, label: 'Windows', count: builtIn },
+      { value: 'third-party' as const, label: 'Third-party', count: services.length - builtIn },
+    ]
+  }, [services])
+
+  // Filter services on status, source and search
   const filteredServices = useMemo(() => {
-    if (!servicesSearch.trim()) return services
-    
-    const searchLower = servicesSearch.toLowerCase()
-    return services.filter((service: any) => 
-      service.name?.toLowerCase().includes(searchLower) ||
-      service.displayName?.toLowerCase().includes(searchLower) ||
-      service.description?.toLowerCase().includes(searchLower) ||
-      service.status?.toLowerCase().includes(searchLower)
-    )
-  }, [services, servicesSearch])
+    const searchLower = servicesSearch.trim().toLowerCase()
+    return services.filter((service: any) => {
+      if (servicesStatusFilter === 'running' && !isServiceRunning(service)) return false
+      if (servicesStatusFilter === 'stopped' && isServiceRunning(service)) return false
+      if (servicesSourceFilter !== 'all' && classifyServicePath(service.path) !== servicesSourceFilter) return false
+      if (!searchLower) return true
+      return (
+        service.name?.toLowerCase().includes(searchLower) ||
+        service.displayName?.toLowerCase().includes(searchLower) ||
+        service.description?.toLowerCase().includes(searchLower) ||
+        service.path?.toLowerCase().includes(searchLower) ||
+        service.status?.toLowerCase().includes(searchLower)
+      )
+    })
+  }, [services, servicesSearch, servicesStatusFilter, servicesSourceFilter])
   
   return (
     <div className="space-y-6">
@@ -495,31 +527,33 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
               </div>
             </div>
           </div>
-          <div className="overflow-x-auto">
-            <table className="w-full">
+          {/* Fixed layout: every narrow column has a width, Update absorbs the
+              rest, so the table never grows past the card and never scrolls sideways */}
+          <div>
+            <table className="w-full table-fixed">
               <thead className="bg-gray-50 dark:bg-gray-900">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Update</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">KB</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Category</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Severity</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">CVEs</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Release Date</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Update</th>
+                  <th className="w-28 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">KB</th>
+                  <th className="w-40 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Category</th>
+                  <th className="w-24 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Severity</th>
+                  <th className="w-56 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">CVEs</th>
+                  <th className="w-32 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                  <th className="w-28 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Released</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {pendingWindowsUpdates.map((update, index) => (
-                  <tr key={update.kbNumber || index} className="hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <td className="px-6 py-4">
+                  <tr key={update.kbNumber || index} className="hover:bg-gray-50 dark:hover:bg-gray-700 align-top">
+                    <td className="px-4 py-3">
                       <div>
                         <div className="text-sm font-medium text-gray-900 dark:text-white">{update.title}</div>
                         {update.description && update.description !== update.title && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 max-w-md truncate">{update.description}</div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate" title={update.description}>{update.description}</div>
                         )}
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
+                    <td className="px-3 py-3 whitespace-nowrap">
                       {update.kbNumber ? (
                         <a
                           href={`https://support.microsoft.com/help/${update.kbNumber.replace('KB', '')}`}
@@ -533,12 +567,12 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                         <span className="text-sm text-gray-400">-</span>
                       )}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                    <td className="px-3 py-3">
+                      <span className="inline-block max-w-full truncate px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200" title={update.category || undefined}>
                         {update.category || 'Update'}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
+                    <td className="px-3 py-3 whitespace-nowrap">
                       {update.severity ? (
                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                           update.severity === 'Critical' ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
@@ -552,23 +586,23 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                         <span className="text-sm text-gray-400">-</span>
                       )}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-3 py-3">
                       {update.cves.length > 0 ? (
                         <div className="flex flex-wrap gap-1">
-                          {update.cves.slice(0, 3).map((cve) => (
+                          {update.cves.slice(0, 2).map((cve) => (
                             <a
                               key={cve}
                               href={`https://msrc.microsoft.com/update-guide/vulnerability/${cve}`}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/30 hover:underline"
+                              className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-mono text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/30 hover:underline"
                             >
                               {cve}
                             </a>
                           ))}
-                          {update.cves.length > 3 && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700" title={update.cves.slice(3).join(', ')}>
-                              +{update.cves.length - 3} more
+                          {update.cves.length > 2 && (
+                            <span className="inline-flex items-center whitespace-nowrap px-2 py-0.5 rounded text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700" title={update.cves.slice(2).join(', ')}>
+                              +{update.cves.length - 2} more
                             </span>
                           )}
                         </div>
@@ -576,8 +610,8 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                         <span className="text-sm text-gray-400">-</span>
                       )}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex gap-1">
+                    <td className="px-3 py-3">
+                      <div className="flex flex-wrap gap-1">
                         {update.isDownloaded ? (
                           <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
                             Downloaded
@@ -594,7 +628,7 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                         )}
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-white">
+                    <td className="px-3 py-3 whitespace-nowrap text-sm text-gray-900 dark:text-white tabular-nums">
                       {update.releaseDate ? new Date(update.releaseDate).toISOString().split('T')[0] : '-'}
                     </td>
                   </tr>
@@ -878,19 +912,23 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                   System services and their status ({filteredServices.length} of {services.length} services)
                 </p>
               </div>
-              <div className="relative">
-                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                  <svg className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                  </svg>
+              <div className="flex flex-wrap items-center gap-3">
+                <FilterPills ariaLabel="Service status" options={servicesStatusOptions} value={servicesStatusFilter} onChange={setServicesStatusFilter} />
+                <FilterPills ariaLabel="Service source" options={servicesSourceOptions} value={servicesSourceFilter} onChange={setServicesSourceFilter} />
+                <div className="relative">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <svg className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                  </div>
+                  <input
+                    type="text"
+                    className="block w-full sm:w-56 pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md leading-5 bg-white dark:bg-gray-700 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    placeholder="Search services..."
+                    value={servicesSearch}
+                    onChange={(e) => setServicesSearch(e.target.value)}
+                  />
                 </div>
-                <input
-                  type="text"
-                  className="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md leading-5 bg-white dark:bg-gray-700 placeholder-gray-500 dark:placeholder-gray-400 text-gray-900 dark:text-white focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                  placeholder="Search services..."
-                  value={servicesSearch}
-                  onChange={(e) => setServicesSearch(e.target.value)}
-                />
               </div>
             </div>
           </div>
@@ -899,12 +937,12 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
               ref={scrollContainerRef}
               className="max-h-96 overflow-auto overlay-scrollbar"
             >
-              <table className="w-full min-w-full">
+              <table className="w-full min-w-full table-fixed">
                 <thead className="bg-gray-50 dark:bg-gray-900 sticky top-0 z-10">
                   <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Service</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Start Type</th>
+                    <th className="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Service</th>
+                    <th className="w-28 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
+                    <th className="w-40 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Start Type</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
                   </tr>
                 </thead>
@@ -936,13 +974,16 @@ export const SystemTab: React.FC<SystemTabProps> = ({ device, data: _data }) => 
                         {service.startType || service.start_type || 'Unknown'}
                       </td>
                       <td className="px-6 py-4 text-sm text-gray-900 dark:text-white">
-                        {service.description || 'No description available'}
+                        <div className="truncate" title={service.description || undefined}>{service.description || 'No description available'}</div>
+                        {service.path && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate" title={service.path}>{service.path}</div>
+                        )}
                       </td>
                     </tr>
                   ))}
                 </tbody>
               </table>
-              {filteredServices.length === 0 && servicesSearch && (
+              {filteredServices.length === 0 && (servicesSearch || servicesStatusFilter !== 'all' || servicesSourceFilter !== 'all') && (
                 <div className="px-6 py-8 text-center">
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     No services found matching &quot;{servicesSearch}&quot;

--- a/src/components/ui/FilterPills.tsx
+++ b/src/components/ui/FilterPills.tsx
@@ -1,0 +1,47 @@
+/**
+ * Compact segmented filter: one pill per option with its count, one active at
+ * a time. Used above tables where a dropdown would hide the distribution.
+ */
+
+import React from 'react'
+
+export interface FilterPillOption<T extends string> {
+  value: T
+  label: string
+  count: number
+}
+
+interface FilterPillsProps<T extends string> {
+  options: FilterPillOption<T>[]
+  value: T
+  onChange: (value: T) => void
+  ariaLabel: string
+}
+
+export function FilterPills<T extends string>({ options, value, onChange, ariaLabel }: FilterPillsProps<T>) {
+  return (
+    <div role="group" aria-label={ariaLabel} className="inline-flex rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden">
+      {options.map((option) => {
+        const active = option.value === value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={active}
+            className={`px-3 py-1.5 text-xs font-medium whitespace-nowrap border-r last:border-r-0 border-gray-300 dark:border-gray-600 transition-colors ${
+              active
+                ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
+                : 'bg-white text-gray-700 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+            }`}
+          >
+            {option.label}
+            <span className={`ml-1.5 tabular-nums ${active ? 'opacity-70' : 'text-gray-500 dark:text-gray-400'}`}>{option.count}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default FilterPills

--- a/src/components/widgets/OSVersionPieWidget.tsx
+++ b/src/components/widgets/OSVersionPieWidget.tsx
@@ -7,6 +7,7 @@
 'use client'
 
 import React from 'react'
+import { useRouter } from 'next/navigation'
 import { OSVersionPieChart } from '../../lib/modules/graphs/OSVersionPieChart'
 
 interface Device {
@@ -42,6 +43,7 @@ interface OSVersionPieWidgetProps {
 }
 
 export const OSVersionPieWidget: React.FC<OSVersionPieWidgetProps> = ({ devices, loading, osType }) => {
+  const router = useRouter()
   const icon = osType === 'macOS' ? (
     <svg className="w-5 h-5 text-red-500 dark:text-red-300" fill="currentColor" viewBox="0 0 24 24">
       <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
@@ -72,6 +74,11 @@ export const OSVersionPieWidget: React.FC<OSVersionPieWidgetProps> = ({ devices,
           devices={devices as any}
           loading={loading}
           osType={osType}
+          onVersionSelect={(version, isDrillDown) => {
+            // A group click drills down inside the widget; a leaf opens the
+            // System report filtered to that exact version, same as /system does
+            if (!isDrillDown) router.push(`/system?osVersion=${encodeURIComponent(version)}`)
+          }}
         />
       </div>
     </div>

--- a/src/lib/data-processing/modules/system.ts
+++ b/src/lib/data-processing/modules/system.ts
@@ -269,7 +269,8 @@ export function extractSystem(deviceModules: any): SystemInfo {
         description: service.description || '',
         status: service.status || service.state || 'Unknown',
         startType: service.startType || service.start_type || '',
-        start_type: service.start_type || service.startType || ''
+        start_type: service.start_type || service.startType || '',
+        path: service.path || service.binaryPath || service.binary_path || ''
       }
     })
     

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -1,0 +1,129 @@
+/**
+ * Inline detail lines for an event row: what a run installed, warned about or
+ * failed on, straight from its payload. Shared by the fleet events feed, the
+ * dashboard Recent Events widget and the device Events tab so a row reads the
+ * same everywhere.
+ */
+
+// Payload keys that carry structure/metadata rather than an installed package.
+// Everything else with a string value in a success payload is a "name → version" pair.
+const RESERVED_PAYLOAD_KEYS = new Set([
+  'count', 'errors', 'warnings', 'error_items', 'warning_items', 'failed_items',
+  'error_messages', 'warning_messages', 'module_status', 'warning_count', 'error_count',
+  'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
+  'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
+  'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
+])
+
+// Extract human-readable detail lines from a loaded event payload so they can be
+// shown inline in the Message column without expanding the raw payload.
+// Handles the shapes ReportMate actually emits:
+//   Munki:   { errors: "a; b", warnings: "c; d" }         (semicolon-joined string)
+//   Cimian:  { warning_items: ["Name"], error_items: [] }  (array of names)
+//   Installs:{ failed_items: [{ displayName, error }] }    (array of objects)
+//   Generic: { error_messages: [...], warning_messages: [...] }
+//   Success: { "Managed Safari": "15.6.1", "ZoomPrefs": "14.1" }  (name → version)
+//   Cimian:  { items: [{ name: "Chrome", version: "151.0.7922.170" }] }  (array of objects)
+// A line is either a run message (sentence from the client) or an item
+// ("Name version"); the flag decides how the row renders it.
+export type InlineLine = { text: string; isMessage: boolean }
+export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[] } => {
+  const errors: InlineLine[] = []
+  const warnings: InlineLine[] = []
+  const successes: string[] = []
+  if (!payload || typeof payload !== 'object') return { errors, warnings, successes }
+  const p = payload as Record<string, any>
+
+  const pushString = (target: InlineLine[], val: unknown) => {
+    if (typeof val === 'string' && val.trim()) {
+      val.split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push({ text: s, isMessage: true }))
+    }
+  }
+  const pushItems = (target: InlineLine[], val: unknown) => {
+    if (!Array.isArray(val)) return
+    for (const item of val) {
+      if (typeof item === 'string') {
+        if (item.trim()) target.push({ text: item.trim(), isMessage: false })
+      } else if (item && typeof item === 'object') {
+        const name = item.displayName || item.name || ''
+        const version = item.version ? ` ${item.version}` : ''
+        const detail = item.error || item.warning || ''
+        const line = detail ? (name ? `${name}${version}: ${detail}` : detail) : `${name}${version}`
+        if (line) target.push({ text: line, isMessage: Boolean(detail) })
+      }
+    }
+  }
+
+  // The Windows installs collector sends its success items as an array of
+  // { name, version } objects rather than a flat map, and always includes them
+  // even when the summary message is a count. Read them so a multi-package run
+  // can still list what it installed.
+  if (Array.isArray(p.items)) {
+    for (const item of p.items) {
+      if (typeof item === 'string') {
+        if (item.trim()) successes.push(item.trim())
+      } else if (item && typeof item === 'object') {
+        const name = String(item.displayName || item.name || '').trim()
+        const version = String(item.version || '').trim()
+        if (name) successes.push(version ? `${name} ${version}` : name)
+      }
+    }
+  }
+
+  pushString(errors, p.errors)
+  pushString(warnings, p.warnings)
+  pushItems(errors, p.error_messages)
+  pushItems(warnings, p.warning_messages)
+  pushItems(errors, p.error_items)
+  pushItems(warnings, p.warning_items)
+  pushItems(errors, p.failed_items)
+
+  // Success payloads are a flat "package name → version" map — one line each.
+  for (const [key, value] of Object.entries(p)) {
+    if (RESERVED_PAYLOAD_KEYS.has(key)) continue
+    if (typeof value === 'string' && value.trim()) {
+      successes.push(`${key} ${value.trim()}`)
+    }
+  }
+
+  const dedupe = (lines: InlineLine[]) => {
+    const seen = new Set<string>()
+    return lines.filter(l => (seen.has(l.text) ? false : (seen.add(l.text), true)))
+  }
+  return {
+    errors: dedupe(errors),
+    warnings: dedupe(warnings),
+    successes: Array.from(new Set(successes)),
+  }
+}
+
+const payloadCache = new Map<string, unknown>()
+const inflight = new Map<string, Promise<unknown>>()
+
+/** Fetch one event's payload, once per session. */
+export async function fetchEventPayload(eventId: string): Promise<unknown> {
+  if (payloadCache.has(eventId)) return payloadCache.get(eventId)
+  const pending = inflight.get(eventId)
+  if (pending) return pending
+  const promise = fetch(`/api/events/${encodeURIComponent(eventId)}/payload`)
+    .then(async response => {
+      if (!response.ok) throw new Error(`Payload unavailable (${response.status})`)
+      const body = await response.json()
+      const payload = body?.payload ?? body
+      payloadCache.set(eventId, payload)
+      return payload
+    })
+    .finally(() => inflight.delete(eventId))
+  inflight.set(eventId, promise)
+  return promise
+}
+
+export function cachedEventPayload(eventId: string): unknown {
+  return payloadCache.get(eventId)
+}
+
+/** Run messages get a mono chip; a bare "Name version" item stays plain text. */
+export const inlineLineClass = (line: InlineLine, tone: string) =>
+  line.isMessage
+    ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${tone}`
+    : `text-sm break-words ${tone}`

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -13,6 +13,8 @@ const RESERVED_PAYLOAD_KEYS = new Set([
   'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
   'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
   'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
+  'recommendation', 'collection_type', 'collectionType', 'operating_system', 'display_version',
+  'version', 'uptime', 'previous_boot_time', 'current_boot_time',
 ])
 
 // Extract human-readable detail lines from a loaded event payload so they can be
@@ -78,10 +80,17 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
   pushItems(warnings, p.warning_items)
   pushItems(errors, p.failed_items)
 
+  // A client recommendation is a run message: the module is telling the
+  // operator something, not naming a package.
+  if (typeof p.recommendation === 'string' && p.recommendation.trim()) {
+    warnings.push({ text: p.recommendation.trim(), isMessage: true })
+  }
+
   // Success payloads are a flat "package name → version" map — one line each.
+  // Only a version-shaped value counts; other strings are context.
   for (const [key, value] of Object.entries(p)) {
-    if (RESERVED_PAYLOAD_KEYS.has(key)) continue
-    if (typeof value === 'string' && value.trim()) {
+    if (RESERVED_PAYLOAD_KEYS.has(key) || /count$/i.test(key)) continue
+    if (typeof value === 'string' && /^\d/.test(value.trim())) {
       successes.push(`${key} ${value.trim()}`)
     }
   }

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -47,7 +47,7 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
       } else if (item && typeof item === 'object') {
         const name = item.displayName || item.name || ''
         const version = item.version ? ` ${item.version}` : ''
-        const detail = item.error || item.warning || ''
+        const detail = item.error || item.warning || item.message || ''
         const line = detail ? (name ? `${name}${version}: ${detail}` : detail) : `${name}${version}`
         if (line) target.push({ text: line, isMessage: Boolean(detail) })
       }

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -103,7 +103,7 @@ function normalizeItem(raw: unknown): EventDetailItem | null {
   const name = String(rec.name ?? rec.displayName ?? rec.display_name ?? rec.item_name ?? '').trim()
   if (!name) return null
   const version = rec.version ?? rec.installedVersion ?? rec.installed_version
-  const detail = rec.error ?? rec.warning ?? rec.reason ?? rec.pending_reason
+  const detail = rec.error ?? rec.warning ?? rec.message ?? rec.reason ?? rec.pending_reason
   return {
     name,
     version: version ? String(version) : undefined,

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -158,7 +158,7 @@ export function summarizeEventPayload(payload: unknown): EventDetailSummary {
   for (const [key, tone] of [
     ['errors', 'error'], ['error_messages', 'error'],
     ['warnings', 'warning'], ['warning_messages', 'warning'],
-    ['recommendation', 'neutral'],
+    ['recommendation', 'warning'],
   ] as const) {
     const { kept, suppressed } = splitMessages(p[key])
     suppressedMessageCount += suppressed

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -61,6 +61,21 @@ const ITEM_GROUPS: Array<{ key: string; label: string; tone: EventDetailGroup['t
   { key: 'failed_items', label: 'Failed', tone: 'error' },
 ]
 
+// Keys that carry structure or context rather than a package. Anything else with a
+// string value in a Munki success payload is a "package name -> version" pair: the
+// Mac client sends "13 packages installed" as exactly that flat map, so without
+// this the accordion had nothing to list under the count.
+const RESERVED_KEYS = new Set([
+  'count', 'errors', 'warnings', 'error_items', 'warning_items', 'failed_items',
+  'error_messages', 'warning_messages', 'module_status', 'warning_count', 'error_count',
+  'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
+  'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
+  'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
+  'collection_type', 'collectionType', 'operating_system', 'display_version', 'version',
+  'uptime', 'recommendation', 'previous_boot_time', 'current_boot_time',
+  'previous_version', 'current_version', 'newlyInstalledItems', 'installed_items', 'removed_items',
+])
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
 
@@ -125,6 +140,17 @@ export function summarizeEventPayload(payload: unknown): EventDetailSummary {
     if (!Array.isArray(raw)) continue
     const items = raw.map(normalizeItem).filter((i): i is EventDetailItem => i !== null)
     if (items.length) groups.push({ key, label, tone, items })
+  }
+  const flatInstalled: EventDetailItem[] = []
+  for (const [key, value] of Object.entries(p)) {
+    if (RESERVED_KEYS.has(key) || typeof value !== 'string' || !value.trim()) continue
+    // A package pair is "Name": "version"; anything named like a counter
+    // (moduleCount) or whose value is not version-shaped is context, not a package
+    if (/count$/i.test(key) || !/^\d/.test(value.trim())) continue
+    flatInstalled.push({ name: key, version: value.trim() })
+  }
+  if (flatInstalled.length && !groups.some(g => g.key === 'installed_items')) {
+    groups.push({ key: 'installed_items', label: 'Installed', tone: 'success', items: flatInstalled })
   }
 
   const messages: EventDetailSummary['messages'] = []

--- a/src/lib/installs/status.ts
+++ b/src/lib/installs/status.ts
@@ -12,6 +12,41 @@
  * Get all install items from a device, checking both Cimian and Munki paths.
  * Cimian is preferred; falls back to Munki items if no Cimian data.
  */
+/**
+ * Munki reports a run's warnings as one semicolon/newline-joined string on the
+ * run, not on the item they concern ("Download of Excel failed: error -1005").
+ * The Warnings card reads that string; the Items with Warnings box read only
+ * items, so it stayed at zero on macOS. This attributes each run-level warning
+ * to its package by the name embedded in the text, so both agree.
+ */
+export interface RunLevelWarning {
+  message: string
+  itemName: string | null
+}
+
+const RUN_WARNING_ITEM_PATTERNS: RegExp[] = [
+  /^(?:Download|Install|Installation|Removal|Update) of (.+?) failed/i,
+  /Could not process item (\S+)/i,
+  /Will not attempt to remove (\S+)/i,
+  /^(\S+) (?:requires|is not|was not|could not)/i,
+]
+
+export function runLevelWarnings(device: any): RunLevelWarning[] {
+  const raw = device?.modules?.installs?.munki?.warnings
+  if (typeof raw !== 'string' || raw.trim() === '') return []
+  return raw
+    .split(/WARNING:|[\n\r]+/)
+    .map((w: string) => w.trim())
+    .filter(Boolean)
+    .map((message: string) => {
+      for (const pattern of RUN_WARNING_ITEM_PATTERNS) {
+        const match = message.match(pattern)
+        if (match) return { message, itemName: match[1].replace(/[.,:]+$/, '') }
+      }
+      return { message, itemName: null }
+    })
+}
+
 export function getDeviceInstallItems(device: any): any[] {
   const cimianItems = device?.modules?.installs?.cimian?.items
   if (cimianItems && cimianItems.length > 0) return cimianItems
@@ -40,7 +75,7 @@ export function categorizeDevicesByInstallStatus(devices: any[]) {
 
     const hasError = items.some(isErrorItem)
     // Warnings are issues that need attention - NOT pending changes
-    const hasWarning = items.some(isWarningItem)
+    const hasWarning = items.some(isWarningItem) || runLevelWarnings(device).length > 0
     // Pending are scheduled changes - installations, removals, updates
     const hasPending = items.some(isPendingItem)
     // Success is an install that actually completed in the most recent run
@@ -108,14 +143,26 @@ function hasText(value: any): boolean {
   return typeof value === 'string' && value.trim() !== ''
 }
 
+// Cimian leaves `currentStatus` at "Installed" for an item whose most recent
+// attempt raised a warning or failed, and records the outcome in
+// `lastAttemptStatus` instead (with no message text). Read it when the status
+// itself says nothing, or every Windows warning is invisible.
+function attemptCategory(item: any): ItemStatusCategory {
+  const attempt = (item?.lastAttemptStatus || '').toLowerCase()
+  if (!attempt) return null
+  if (attempt.includes('warn')) return 'warning'
+  if (attempt.includes('fail') || attempt.includes('error')) return 'error'
+  return null
+}
+
 export function isErrorItem(item: any): boolean {
-  const category = statusCategory(item)
+  const category = statusCategory(item) || attemptCategory(item)
   if (category) return category === 'error'
   return hasText(item?.lastError)
 }
 
 export function isWarningItem(item: any): boolean {
-  const category = statusCategory(item)
+  const category = statusCategory(item) || attemptCategory(item)
   if (category) return category === 'warning'
   return !hasText(item?.lastError) && hasText(item?.lastWarning)
 }
@@ -306,8 +353,12 @@ export function aggregateInstallWarnings(devices: any[]): AggregatedInstallMessa
     const deviceName = device.modules?.inventory?.deviceName || device.serialNumber || 'Unknown'
     const serialNumber = device.serialNumber || device.deviceId || 'Unknown'
     
-    // Cimian and Munki both attach the run's message to the item
+    // Cimian and Munki both attach the run's message to the item. Munki stamps a
+    // failed download with both lastError and lastWarning, so an item that is an
+    // error is skipped here or every failure is counted twice and the Warnings
+    // card disagrees with the Items with Warnings box.
     for (const item of getDeviceInstallItems(device)) {
+      if (isErrorItem(item)) continue
       if (item.lastWarning && item.lastWarning.trim() !== '') {
         const warningMsg = item.lastWarning.trim()
         const existing = warningMap.get(warningMsg)

--- a/src/lib/installs/status.ts
+++ b/src/lib/installs/status.ts
@@ -31,6 +31,15 @@ const RUN_WARNING_ITEM_PATTERNS: RegExp[] = [
   /^(\S+) (?:requires|is not|was not|could not)/i,
 ]
 
+/** The package a Munki run message is about, or null when it names none. */
+export function itemNameFromMessage(message: string): string | null {
+  for (const pattern of RUN_WARNING_ITEM_PATTERNS) {
+    const match = message.match(pattern)
+    if (match) return match[1].replace(/[.,:]+$/, '')
+  }
+  return null
+}
+
 export function runLevelWarnings(device: any): RunLevelWarning[] {
   const raw = device?.modules?.installs?.munki?.warnings
   if (typeof raw !== 'string' || raw.trim() === '') return []
@@ -38,13 +47,7 @@ export function runLevelWarnings(device: any): RunLevelWarning[] {
     .split(/WARNING:|[\n\r]+/)
     .map((w: string) => w.trim())
     .filter(Boolean)
-    .map((message: string) => {
-      for (const pattern of RUN_WARNING_ITEM_PATTERNS) {
-        const match = message.match(pattern)
-        if (match) return { message, itemName: match[1].replace(/[.,:]+$/, '') }
-      }
-      return { message, itemName: null }
-    })
+    .map((message: string) => ({ message, itemName: itemNameFromMessage(message) }))
 }
 
 export function getDeviceInstallItems(device: any): any[] {

--- a/src/lib/modules/widgets/EventDetails.tsx
+++ b/src/lib/modules/widgets/EventDetails.tsx
@@ -157,25 +157,33 @@ export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => 
         </div>
       ))}
 
-      {summary.messages.length > 0 && (
-        <div>
-          <SectionLabel count={summary.messages.length}>Messages</SectionLabel>
-          <ul className="space-y-1">
-            {summary.messages.map((message, index) => (
-              <li
-                key={index}
-                className={`text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[message.tone]}`}
-              >
-                {message.text}
-              </li>
-            ))}
-          </ul>
-          {summary.suppressedMessageCount > 0 && (
-            <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
-              {summary.suppressedMessageCount} installer progress {summary.suppressedMessageCount === 1 ? 'line' : 'lines'} hidden
-            </p>
-          )}
-        </div>
+      {/* Munki reports a run's problems as message text, Cimian as item names; both
+          render under the same Errors / Warnings labels so a row reads the same
+          whichever client produced it. */}
+      {(['error', 'warning', 'neutral'] as const).map(tone => {
+        const messages = summary.messages.filter(m => m.tone === tone)
+        if (messages.length === 0) return null
+        const label = tone === 'error' ? 'Errors' : tone === 'warning' ? 'Warnings' : 'Notes'
+        return (
+          <div key={tone}>
+            <SectionLabel count={messages.length}>{label}</SectionLabel>
+            <ul className="space-y-1">
+              {messages.map((message, index) => (
+                <li
+                  key={index}
+                  className={`text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[message.tone]}`}
+                >
+                  {message.text}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      })}
+      {summary.suppressedMessageCount > 0 && (
+        <p className="text-xs text-gray-400 dark:text-gray-500">
+          {summary.suppressedMessageCount} installer progress {summary.suppressedMessageCount === 1 ? 'line' : 'lines'} hidden
+        </p>
       )}
 
       {summary.context.length > 0 && (

--- a/src/lib/modules/widgets/EventDetails.tsx
+++ b/src/lib/modules/widgets/EventDetails.tsx
@@ -8,21 +8,10 @@
 
 import React, { useEffect, useState } from 'react'
 import { summarizeEventPayload, type EventDetailSummary } from '../../eventPayloadDetails'
+import { fetchEventPayload } from '../../eventInlineDetails'
 
 // Bundles are routine data-collection groupings; a handful of fetches covers them.
 const MAX_BUNDLE_FETCHES = 8
-
-const payloadCache = new Map<string, unknown>()
-
-async function fetchPayload(eventId: string): Promise<unknown> {
-  if (payloadCache.has(eventId)) return payloadCache.get(eventId)
-  const response = await fetch(`/api/events/${encodeURIComponent(eventId)}/payload`)
-  if (!response.ok) throw new Error(`Payload unavailable (${response.status})`)
-  const body = await response.json()
-  const payload = body?.payload ?? body
-  payloadCache.set(eventId, payload)
-  return payload
-}
 
 function mergeSummaries(summaries: EventDetailSummary[]): EventDetailSummary {
   const modules = new Set<string>()
@@ -92,7 +81,7 @@ export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => 
     setError(null)
     setSummary(null)
 
-    Promise.all(idKey.split(',').slice(0, MAX_BUNDLE_FETCHES).map(fetchPayload))
+    Promise.all(idKey.split(',').slice(0, MAX_BUNDLE_FETCHES).map(fetchEventPayload))
       .then(payloads => {
         if (cancelled) return
         setSummary(mergeSummaries(payloads.map(summarizeEventPayload)))

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -16,12 +16,14 @@ interface EventInlineLinesProps {
   isBundle?: boolean
   /** Fetch the payload for this row; false for rows far down a long list. */
   autoFetch?: boolean
+  /** Keep run messages (the mono chips) for the expanded view; list only items. */
+  itemsOnly?: boolean
   className?: string
 }
 
 const shouldFetch = (kind: string) => ['success', 'warning', 'error'].includes(kind.toLowerCase())
 
-export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kind, summary, isBundle = false, autoFetch = true, className = '' }) => {
+export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kind, summary, isBundle = false, autoFetch = true, itemsOnly = false, className = '' }) => {
   const [payload, setPayload] = useState<unknown>(() => cachedEventPayload(eventId))
   const [loading, setLoading] = useState(false)
 
@@ -36,7 +38,10 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
     return () => { cancelled = true }
   }, [eventId, kind, isBundle, autoFetch, payload])
 
-  const { errors, warnings, successes } = extractInlineDetails(payload)
+  const extracted = extractInlineDetails(payload)
+  const errors = itemsOnly ? extracted.errors.filter(l => !l.isMessage) : extracted.errors
+  const warnings = itemsOnly ? extracted.warnings.filter(l => !l.isMessage) : extracted.warnings
+  const successes = extracted.successes
   const hasDetails = errors.length > 0 || warnings.length > 0 || successes.length > 0
 
   if (!hasDetails) {

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -22,6 +22,14 @@ interface EventInlineLinesProps {
   className?: string
 }
 
+// The summary takes the kind's colour too, so a row reads the same whether it
+// lists items or a count
+const SUMMARY_TONE: Record<string, string> = {
+  success: 'text-green-700 dark:text-green-300',
+  warning: 'text-yellow-700 dark:text-yellow-300',
+  error: 'text-red-700 dark:text-red-300',
+}
+
 const shouldFetch = (kind: string) => ['success', 'warning', 'error'].includes(kind.toLowerCase())
 
 export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kind, summary, isBundle = false, autoFetch = true, itemsOnly = false, className = '' }) => {
@@ -60,7 +68,7 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
   if (!hasDetails) {
     return (
       <div className={className}>
-        <div className="text-sm text-gray-900 dark:text-white break-words">{summary}</div>
+        <div className={`text-sm break-words ${SUMMARY_TONE[kind.toLowerCase()] || 'text-gray-900 dark:text-white'}`}>{summary}</div>
         {loading && <div className="text-xs text-gray-400 dark:text-gray-500 mt-1 italic">Loading details…</div>}
       </div>
     )

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -1,0 +1,66 @@
+/**
+ * The message cell of an event row. Once the payload is in, the row shows the
+ * items themselves (in the kind's colour, run messages as mono chips) instead
+ * of a count like "4 warnings"; the summary text remains while loading or when
+ * the payload carries no items.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { extractInlineDetails, fetchEventPayload, cachedEventPayload, inlineLineClass } from '../../eventInlineDetails'
+
+interface EventInlineLinesProps {
+  eventId: string
+  kind: string
+  summary: string
+  /** Bundles are collection groupings; they keep their summary. */
+  isBundle?: boolean
+  /** Fetch the payload for this row; false for rows far down a long list. */
+  autoFetch?: boolean
+  className?: string
+}
+
+const shouldFetch = (kind: string) => ['success', 'warning', 'error'].includes(kind.toLowerCase())
+
+export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kind, summary, isBundle = false, autoFetch = true, className = '' }) => {
+  const [payload, setPayload] = useState<unknown>(() => cachedEventPayload(eventId))
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (isBundle || !autoFetch || !shouldFetch(kind) || payload !== undefined) return
+    let cancelled = false
+    setLoading(true)
+    fetchEventPayload(eventId)
+      .then(p => { if (!cancelled) setPayload(p) })
+      .catch(() => { if (!cancelled) setPayload(null) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [eventId, kind, isBundle, autoFetch, payload])
+
+  const { errors, warnings, successes } = extractInlineDetails(payload)
+  const hasDetails = errors.length > 0 || warnings.length > 0 || successes.length > 0
+
+  if (!hasDetails) {
+    return (
+      <div className={className}>
+        <div className="text-sm text-gray-900 dark:text-white break-words">{summary}</div>
+        {loading && <div className="text-xs text-gray-400 dark:text-gray-500 mt-1 italic">Loading details…</div>}
+      </div>
+    )
+  }
+
+  return (
+    <div className={`space-y-1 ${className}`}>
+      {errors.map((m, i) => (
+        <div key={`e-${i}`} className={inlineLineClass(m, 'text-red-700 dark:text-red-300')}>{m.text}</div>
+      ))}
+      {warnings.map((m, i) => (
+        <div key={`w-${i}`} className={inlineLineClass(m, 'text-yellow-700 dark:text-yellow-300')}>{m.text}</div>
+      ))}
+      {successes.map((m, i) => (
+        <div key={`s-${i}`} className="text-sm text-green-700 dark:text-green-300 break-words">{m}</div>
+      ))}
+    </div>
+  )
+}
+
+export default EventInlineLines

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -6,7 +6,8 @@
  */
 
 import React, { useEffect, useState } from 'react'
-import { extractInlineDetails, fetchEventPayload, cachedEventPayload, inlineLineClass } from '../../eventInlineDetails'
+import { extractInlineDetails, fetchEventPayload, cachedEventPayload, inlineLineClass, type InlineLine } from '../../eventInlineDetails'
+import { itemNameFromMessage } from '../../installs/status'
 
 interface EventInlineLinesProps {
   eventId: string
@@ -39,8 +40,20 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
   }, [eventId, kind, isBundle, autoFetch, payload])
 
   const extracted = extractInlineDetails(payload)
-  const errors = itemsOnly ? extracted.errors.filter(l => !l.isMessage) : extracted.errors
-  const warnings = itemsOnly ? extracted.warnings.filter(l => !l.isMessage) : extracted.warnings
+  // Items-only rows still list the package a run message is about
+  // ("Could not process item X" becomes "X"); messages naming nothing stay
+  // in the expanded view.
+  const toItems = (lines: InlineLine[]): InlineLine[] => {
+    const out: InlineLine[] = []
+    for (const line of lines) {
+      if (!line.isMessage) { out.push(line); continue }
+      const name = itemNameFromMessage(line.text)
+      if (name && !out.some(l => l.text === name)) out.push({ text: name, isMessage: false })
+    }
+    return out
+  }
+  const errors = itemsOnly ? toItems(extracted.errors) : extracted.errors
+  const warnings = itemsOnly ? toItems(extracted.warnings) : extracted.warnings
   const successes = extracted.successes
   const hasDetails = errors.length > 0 || warnings.length > 0 || successes.length > 0
 

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -9,6 +9,7 @@ import { formatRelativeTime } from '../../time'
 import { bundleEvents, formatPayloadPreview, type FleetEvent, type BundledEvent } from '../../eventBundling'
 import { SlidersHorizontal } from 'lucide-react'
 import { EventDetails } from './EventDetails'
+import { EventInlineLines } from './EventInlineLines'
 import { getEventModuleId, getEventDeviceHrefSuffix } from '../../eventLinks'
 
 interface RecentEventsTableProps {
@@ -208,6 +209,8 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
   // dashboard holds up to 1000 events in state, and mounting a row for every
   // one of them puts ~1000 <tr>s in a widget that shows a dozen at a time.
   const MAX_RENDERED_EVENTS = 250
+  // Payloads are fetched for the rows anyone will scroll to; the rest keep their summary
+  const AUTO_FETCH_ROWS = 60
   const filteredEvents = useMemo(() => {
     const visible = hiddenTypes.size === 0
       ? bundledEvents
@@ -579,7 +582,7 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                           </p>
                         </td>
                       </tr>
-                    ) : filteredEvents.map((bundledEvent: BundledEvent) => {
+                    ) : filteredEvents.map((bundledEvent: BundledEvent, index: number) => {
                       const isExpanded = expandedEvents.has(bundledEvent.id)
 
                       return (
@@ -618,14 +621,18 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                               </Link>
                             </td>
                             <td className="px-3 py-2.5 hidden md:table-cell">
-                              <div className="text-sm text-gray-900 dark:text-white truncate">
-                                {bundledEvent.message}
-                                {bundledEvent.isBundle && bundledEvent.bundledKinds.length > 1 && (
-                                  <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
-                                    ({bundledEvent.bundledKinds.join(', ')})
-                                  </span>
-                                )}
-                              </div>
+                              <EventInlineLines
+                                eventId={String(bundledEvent.id)}
+                                kind={bundledEvent.kind}
+                                summary={bundledEvent.message}
+                                isBundle={bundledEvent.isBundle}
+                                autoFetch={index < AUTO_FETCH_ROWS}
+                              />
+                              {bundledEvent.isBundle && bundledEvent.bundledKinds.length > 1 && (
+                                <span className="text-xs text-gray-500 dark:text-gray-400">
+                                  ({bundledEvent.bundledKinds.join(', ')})
+                                </span>
+                              )}
                             </td>
                             <td className="w-44 px-3 py-2.5">
                               <div className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -614,7 +614,7 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                             <td className="w-56 px-3 py-2.5">
                               <Link
                                 href={`/device/${encodeURIComponent(bundledEvent.device)}${getEventDeviceHrefSuffix(bundledEvent)}`}
-                                className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors block truncate"
+                                className="text-sm font-medium text-gray-900 dark:text-white hover:underline block truncate"
                                 onClick={(e) => e.stopPropagation()}
                               >
                                 {getDeviceName(bundledEvent, deviceNameMap)}
@@ -627,6 +627,7 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                 summary={bundledEvent.message}
                                 isBundle={bundledEvent.isBundle}
                                 autoFetch={index < AUTO_FETCH_ROWS}
+                                itemsOnly
                               />
                               {bundledEvent.isBundle && bundledEvent.bundledKinds.length > 1 && (
                                 <span className="text-xs text-gray-500 dark:text-gray-400">

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -190,10 +190,11 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
-  // Info is the firehose — routine data-collection chatter that drowns the events
-  // worth reacting to. It is hidden by default and opted into from the filter.
-  const DEFAULT_HIDDEN = useMemo(() => new Set<string>(['info']), [])
-  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set(['info']))
+  // Info is the firehose — routine data-collection chatter — and System is the
+  // reboot log; both drown the events worth reacting to, so both are hidden by
+  // default and opted into from the filter.
+  const DEFAULT_HIDDEN = useMemo(() => new Set<string>(['info', 'system']), [])
+  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set(['info', 'system']))
   // Only show filter as active when user has deviated from the default state
   const isFilterCustomized = hiddenTypes.size !== DEFAULT_HIDDEN.size ||
     [...hiddenTypes].some(t => !DEFAULT_HIDDEN.has(t))

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -465,11 +465,11 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                   <th className="w-20 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                     Type
                   </th>
-                  <th className="w-56 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                    Device
-                  </th>
                   <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider hidden md:table-cell">
                     Message
+                  </th>
+                  <th className="w-56 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                    Device
                   </th>
                   <th className="w-44 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                     Time
@@ -487,11 +487,11 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                           <div className="h-6 w-6 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
                         </div>
                       </td>
-                      <td className="w-56 px-3 py-2.5">
-                        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-32"></div>
-                      </td>
                       <td className="px-3 py-2.5 hidden md:table-cell">
                         <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-48"></div>
+                      </td>
+                      <td className="w-56 px-3 py-2.5">
+                        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-32"></div>
                       </td>
                       <td className="w-44 px-3 py-2.5">
                         <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-20"></div>
@@ -559,11 +559,11 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                     <th className="w-20 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Type
                     </th>
-                    <th className="w-56 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
-                      Device
-                    </th>
                     <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider hidden md:table-cell">
                       Message
+                    </th>
+                    <th className="w-56 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      Device
                     </th>
                     <th className="w-44 px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                       Time
@@ -611,15 +611,6 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                 {getStatusIcon(bundledEvent.kind)}
                               </div>
                             </td>
-                            <td className="w-56 px-3 py-2.5">
-                              <Link
-                                href={`/device/${encodeURIComponent(bundledEvent.device)}${getEventDeviceHrefSuffix(bundledEvent)}`}
-                                className="text-sm font-medium text-gray-900 dark:text-white hover:underline block truncate"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                {getDeviceName(bundledEvent, deviceNameMap)}
-                              </Link>
-                            </td>
                             <td className="px-3 py-2.5 hidden md:table-cell">
                               <EventInlineLines
                                 eventId={String(bundledEvent.id)}
@@ -629,6 +620,15 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                 autoFetch={index < AUTO_FETCH_ROWS}
                                 itemsOnly
                               />
+                            </td>
+                            <td className="w-56 px-3 py-2.5">
+                              <Link
+                                href={`/device/${encodeURIComponent(bundledEvent.device)}${getEventDeviceHrefSuffix(bundledEvent)}`}
+                                className="text-sm font-medium text-gray-900 dark:text-white hover:underline block truncate"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                {getDeviceName(bundledEvent, deviceNameMap)}
+                              </Link>
                             </td>
                             <td className="w-44 px-3 py-2.5">
                               <div className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -629,11 +629,6 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                 autoFetch={index < AUTO_FETCH_ROWS}
                                 itemsOnly
                               />
-                              {bundledEvent.isBundle && bundledEvent.bundledKinds.length > 1 && (
-                                <span className="text-xs text-gray-500 dark:text-gray-400">
-                                  ({bundledEvent.bundledKinds.join(', ')})
-                                </span>
-                              )}
                             </td>
                             <td className="w-44 px-3 py-2.5">
                               <div className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/lib/windows-source.ts
+++ b/src/lib/windows-source.ts
@@ -1,0 +1,39 @@
+/**
+ * Classify Windows services and scheduled tasks as built-in (shipped with the
+ * OS) or third-party, from the paths osquery reports. The client sends no
+ * vendor field, so the install location is the signal.
+ */
+
+export type WindowsSource = 'windows' | 'third-party'
+
+const OS_PATH_PREFIXES = [
+  '\\systemroot\\',
+  '%systemroot%',
+  '%windir%',
+  'system32\\',
+  '\\system32\\',
+]
+
+/**
+ * A service binary under the Windows directory is built-in, with one carve-out:
+ * DriverStore\FileRepository is where third-party driver packages are staged,
+ * so a driver living there belongs to its vendor even though it sits under
+ * C:\Windows.
+ */
+export function classifyServicePath(path: string | undefined | null): WindowsSource {
+  const p = (path || '').trim().toLowerCase().replace(/^"/, '')
+  if (!p) return 'windows'
+  if (p.includes('\\driverstore\\filerepository\\')) return 'third-party'
+  if (/^[a-z]:\\windows\\/.test(p)) return 'windows'
+  if (OS_PATH_PREFIXES.some(prefix => p.startsWith(prefix))) return 'windows'
+  return 'third-party'
+}
+
+/**
+ * Task Scheduler keeps everything Microsoft ships under \Microsoft\; anything
+ * at the root or in another folder was registered by an installer or a person.
+ */
+export function classifyTaskPath(path: string | undefined | null): WindowsSource {
+  const p = (path || '').trim().toLowerCase()
+  return p.startsWith('\\microsoft\\') ? 'windows' : 'third-party'
+}


### PR DESCRIPTION
Closes #72

Device page and Windows tables
- Header: sticky offset matches the 4rem app toolbar, so name/asset/serial/last-seen stay visible on scroll.
- Pending Windows Updates: fixed layout with widths on every narrow column; no horizontal scrolling.
- Windows Services: Running/Stopped and Windows/Third-party pills; binary path shown under the description. Scheduled Tasks gets the same source pills.
- Dashboard OS Versions widgets: a leaf click opens /system?osVersion=<version>.

Events (fleet feed, dashboard accordion, device Events tab)
- Structured details above the raw payload in every expanded row; several rows can be open at once.
- A flat name-to-version success payload lists as Installed.
- Inline row messages: run text in a mono chip, item lines plain; a single named item promotes its version into the summary line.
- Filter buttons: active state is a shade deeper with a ring, not solid.

Installs report
- Items with Errors and Items with Warnings always render, first; Pending and Installed follow when non-empty; skeleton matches, four across.
- Cimian records a warning or failure in lastAttemptStatus while currentStatus stays Installed; the shared predicates read it.
- Munki stamps a failed download with both lastError and lastWarning; the Warnings card skips error items so failures are not counted twice.
- Munki run-level warnings are attributed to the package they name.
- Device/install status filters sit beside the search bar as soft-toned pills; the Installs accordion is retired.

Devices table: long names truncate in the middle so the last three characters of a numbered name stay visible.

Also carries the rebased events-page change from #63.