### PR TITLE
Add read-only kiosk sessions for wall displays

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -34,6 +34,16 @@ const authOptions: NextAuthOptions = {
   },
   useSecureCookies: true,
   callbacks: {
+    // Carry the kiosk role from the JWT into the session so client code can
+    // hide controls a viewer cannot use.
+    async jwt({ token }) {
+      return token
+    },
+    async session({ session, token }) {
+      const role = (token as { role?: string }).role
+      if (role) (session as { role?: string }).role = role
+      return session
+    },
     async signIn() {
       // Always allow sign in - let NextAuth handle any issues
       return true

--- a/app/kiosk/route.ts
+++ b/app/kiosk/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { encode } from 'next-auth/jwt'
+import { matchKioskToken, KIOSK_ROLE, KIOSK_SESSION_DAYS } from '../../src/lib/kiosk/tokens'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /kiosk?token=<token>[&next=/events]
+ *
+ * Exchanges a kiosk token for a viewer session cookie and redirects to the
+ * requested read-only page. The cookie is the same NextAuth JWT the Entra
+ * flow issues, so the middleware and every page treat it as a signed-in
+ * session; the role claim is what narrows it.
+ */
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token')
+  const label = matchKioskToken(token)
+  if (!label) {
+    return NextResponse.json({ error: 'Unauthorized', details: 'Unknown kiosk token' }, { status: 401 })
+  }
+
+  const secret = process.env.NEXTAUTH_SECRET
+  if (!secret) {
+    return NextResponse.json({ error: 'Kiosk sessions are not configured' }, { status: 500 })
+  }
+
+  const maxAge = KIOSK_SESSION_DAYS * 24 * 60 * 60
+  const jwt = await encode({
+    secret,
+    maxAge,
+    token: {
+      name: `Kiosk ${label}`,
+      email: `${label}@kiosk.reportmate`,
+      role: KIOSK_ROLE,
+      kiosk: label,
+    },
+  })
+
+  const next = request.nextUrl.searchParams.get('next') || '/events'
+  const target = next.startsWith('/') && !next.startsWith('//') ? next : '/events'
+  const base = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin
+  const response = NextResponse.redirect(new URL(target, base))
+
+  const secure = process.env.NODE_ENV === 'production'
+  response.cookies.set({
+    name: secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
+    value: jwt,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure,
+    path: '/',
+    maxAge,
+  })
+  return response
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
+import { viewerMayRead, KIOSK_ROLE } from './src/lib/kiosk/tokens'
 
 // Define routes that should not trigger auto-redirect
 const publicRoutes = [
   '/api/auth',          // NextAuth authentication endpoints
+  '/kiosk',             // Kiosk token exchange (validates its own token)
   '/api/transmission',  // Device data transmission endpoint (client authentication via passphrase)
   '/api/healthz',       // Health check endpoint for Front Door
   '/api/health',        // Alternative health check endpoint
@@ -220,6 +222,18 @@ export default async function middleware(request: NextRequest) {
     })
     
     if (token) {
+      // A kiosk viewer holds a long-lived session that may only read: GET/HEAD
+      // on the report pages and their APIs. Anything else is refused outright
+      // rather than redirected, so a screen never lands on the sign-in page.
+      if ((token as { role?: string }).role === KIOSK_ROLE) {
+        const readMethod = request.method === 'GET' || request.method === 'HEAD'
+        if (!readMethod || !viewerMayRead(pathname)) {
+          if (pathname.startsWith('/api/')) {
+            return NextResponse.json({ error: 'Forbidden', details: 'Kiosk sessions are read-only' }, { status: 403 })
+          }
+          return NextResponse.redirect(new URL('/events', process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin))
+        }
+      }
       return NextResponse.next()
     }
 

--- a/src/lib/kiosk/tokens.ts
+++ b/src/lib/kiosk/tokens.ts
@@ -1,0 +1,58 @@
+/**
+ * Kiosk viewer sessions.
+ *
+ * A display that shows ReportMate all day should not hold a person's Entra
+ * session. KIOSK_TOKENS carries one opaque token per screen (comma-separated,
+ * sourced from Key Vault or Secrets Manager). Presenting a listed token to
+ * /kiosk mints a long-lived NextAuth JWT with role "viewer": read-only pages
+ * and read-only APIs, nothing else. Rotating the secret ends every session.
+ */
+
+import { timingSafeEqual } from 'crypto'
+
+export const KIOSK_ROLE = 'viewer'
+export const KIOSK_SESSION_DAYS = 365
+
+/** Parse KIOSK_TOKENS as "label:token" or bare "token" entries. */
+export function kioskTokens(): Array<{ label: string; token: string }> {
+  const raw = process.env.KIOSK_TOKENS || ''
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map((entry, i) => {
+      const sep = entry.indexOf(':')
+      return sep > 0
+        ? { label: entry.slice(0, sep), token: entry.slice(sep + 1) }
+        : { label: `kiosk-${i + 1}`, token: entry }
+    })
+    .filter(e => e.token.length >= 16)
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+
+/** The label of the kiosk a presented token belongs to, or null. */
+export function matchKioskToken(presented: string | null | undefined): string | null {
+  if (!presented) return null
+  for (const { label, token } of kioskTokens()) {
+    if (safeEqual(presented, token)) return label
+  }
+  return null
+}
+
+/**
+ * Routes a viewer may reach. Everything is read-only by construction: the
+ * middleware also refuses any method other than GET/HEAD for a viewer.
+ */
+const VIEWER_PAGE_PREFIXES = ['/dashboard', '/events', '/devices', '/device/', '/system', '/installs', '/applications', '/hardware', '/network', '/security', '/management', '/inventory', '/identity', '/peripherals', '/reports']
+const VIEWER_API_PREFIXES = ['/api/dashboard', '/api/events', '/api/device', '/api/device-names', '/api/stats', '/api/version', '/api/v1/devices', '/api/v1/device', '/api/v1/events', '/api/v1/installs', '/api/v1/identity', '/api/v1/system', '/api/v1/applications', '/api/v1/hardware', '/api/v1/network', '/api/v1/security', '/api/v1/management', '/api/v1/inventory', '/api/v1/peripherals']
+
+export function viewerMayRead(pathname: string): boolean {
+  if (pathname === '/' || pathname === '/kiosk') return true
+  if (pathname.startsWith('/api/')) return VIEWER_API_PREFIXES.some(p => pathname === p || pathname.startsWith(p + '/') || pathname.startsWith(p + '?'))
+  return VIEWER_PAGE_PREFIXES.some(p => pathname === p || pathname.startsWith(p.endsWith('/') ? p : p + '/'))
+}


### PR DESCRIPTION
Closes #74

- `GET /kiosk?token=<token>[&next=/events]` validates the token against `KIOSK_TOKENS` (constant-time) and sets the standard NextAuth session cookie with `role: viewer`, valid for a year.
- Middleware: a viewer may GET/HEAD the report pages and their read APIs; `/settings`, `/api/admin/*`, `/api/settings`, `/api/cache/*` and every non-GET request return 403 (pages redirect to `/events`), never the sign-in page.
- `KIOSK_TOKENS` empty or unset leaves the route returning 401 for everything.
- Verified against a production build: no cookie → sign-in redirect; bad token → 401; viewer → 200 on `/events` and `/api/dashboard`, 307 on `/settings`, 403 on `DELETE /api/admin/installs/clear-errors`, `POST /api/device`, `GET /api/settings`, `GET /api/cache/status`.

Infrastructure companions: reportmate/terraform-azurerm-reportmate#42 and reportmate/terraform-aws-reportmate#5 add the secret and the frontend env.