### PR TITLE
Render structured warning and error items like message rows on both platforms

### DIFF
--- a/app/events/ClientEventsPage.tsx
+++ b/app/events/ClientEventsPage.tsx
@@ -21,6 +21,14 @@ const VALID_EVENT_KINDS: ReadonlyArray<string> = ['system', 'info', 'error', 'wa
 // Helper function to get status icons matching the filter button style (no circles)
 const getStatusIcon = (kind: string) => {
   switch (kind.toLowerCase()) {
+    case 'removed':
+      return (
+        <div className="w-5 h-5 text-purple-500" title="Removed">
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+          </svg>
+        </div>
+      )
     case 'success':
       return (
         <div className="w-5 h-5 text-green-500" title="Success">
@@ -759,9 +767,16 @@ function EventsPageContent() {
   // A count summary takes its kind's colour, like the item lines it stands in for
   const summaryToneClass = (kind: string) => ({
     success: 'text-green-700 dark:text-green-300',
+    removed: 'text-purple-700 dark:text-purple-300',
     warning: 'text-yellow-700 dark:text-yellow-300',
     error: 'text-red-700 dark:text-red-300',
   } as Record<string, string>)[(kind || '').toLowerCase()] || 'text-gray-900 dark:text-white'
+
+  // Removals are successes rendered in the removed purple, matching the widget rows
+  const isRemovalEvent = (event: BundledEvent): boolean =>
+    (event.kind || '').toLowerCase() === 'success' &&
+    (extractInlineDetails(fullPayloads[event.id]).isRemoval || /\bremoved$/i.test(String(event.message || '').trim()))
+  const effectiveKind = (event: BundledEvent): string => (isRemovalEvent(event) ? 'removed' : event.kind)
 
   const getDisplayMessage = (event: BundledEvent): string | null =>
     inlineLines(event).hasDetails ? null : getEventMessage(event)
@@ -784,7 +799,7 @@ function EventsPageContent() {
           <div key={`w-${i}`} className={inlineLineClass(m, 'text-yellow-700 dark:text-yellow-300')}>{m.text}</div>
         ))}
         {successLines.map((m, i) => (
-          <div key={`s-${i}`} className="text-sm text-green-700 dark:text-green-300 break-words">{m}</div>
+          <div key={`s-${i}`} className={`text-sm break-words ${isRemovalEvent(event) ? 'text-purple-700 dark:text-purple-300' : 'text-green-700 dark:text-green-300'}`}>{m}</div>
         ))}
       </div>
     )
@@ -1105,7 +1120,7 @@ function EventsPageContent() {
                           >
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
                               <div className="flex items-center justify-center">
-                                {getStatusIcon(event.kind)}
+                                {getStatusIcon(effectiveKind(event))}
                               </div>
                             </td>
                             <td className="px-4 lg:px-6 py-4 whitespace-nowrap align-top">
@@ -1129,7 +1144,7 @@ function EventsPageContent() {
                               </div>
                             </td>
                             <td className="px-4 lg:px-6 py-4 align-top">
-                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                              <div className={`text-sm break-words ${summaryToneClass(effectiveKind(event))}`}>
                                 {getDisplayMessage(event)}
                               </div>
                               {renderInlineDetails(event)}
@@ -1486,7 +1501,7 @@ function EventsPageContent() {
                           >
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
                               <div className="flex items-center justify-center">
-                                {getStatusIcon(event.kind)}
+                                {getStatusIcon(effectiveKind(event))}
                               </div>
                             </td>
                             <td className="px-4 lg:px-6 py-3 whitespace-nowrap align-top">
@@ -1510,7 +1525,7 @@ function EventsPageContent() {
                               </div>
                             </td>
                             <td className="px-4 py-3 max-w-xs align-top">
-                              <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                              <div className={`text-sm break-words ${summaryToneClass(effectiveKind(event))}`}>
                                 {getDisplayMessage(event)}
                               </div>
                               {renderInlineDetails(event)}
@@ -1730,7 +1745,7 @@ function EventsPageContent() {
                     {/* Card Header */}
                     <div className="flex items-start justify-between mb-3">
                       <div className="flex items-center gap-2 flex-wrap">
-                        {getStatusIcon(event.kind)}
+                        {getStatusIcon(effectiveKind(event))}
                         <span 
                           className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 font-mono"
                           title={isBundleId(event.id) ? `Bundle: ${event.eventIds?.join(', ') || event.id}` : `#${event.id}`}
@@ -1765,7 +1780,7 @@ function EventsPageContent() {
                     {/* Message */}
                     <div className="mb-3">
                       <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Message</div>
-                      <div className={`text-sm break-words ${summaryToneClass(event.kind)}`}>
+                      <div className={`text-sm break-words ${summaryToneClass(effectiveKind(event))}`}>
                         {getDisplayMessage(event)}
                       </div>
                       {renderInlineDetails(event)}

--- a/app/installs/page.tsx
+++ b/app/installs/page.tsx
@@ -2449,13 +2449,13 @@ function InstallsPageContent() {
                     }}
                     title="Click to show all devices with errors"
                   >
-                    <h3 className={`text-lg font-medium flex items-center gap-2 ${itemsStatusFilter === 'errors' && !searchQuery ? 'text-red-700 dark:text-red-300' : 'text-gray-900 dark:text-white'}`}>
+                    <h3 className={`text-base font-medium flex items-center gap-2 whitespace-nowrap ${itemsStatusFilter === 'errors' && !searchQuery ? 'text-red-700 dark:text-red-300' : 'text-gray-900 dark:text-white'}`}>
                       <svg className="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       Items with Errors
                     </h3>
-                    <span className="text-sm font-semibold text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-2 py-0.5 rounded-full">
+                    <span className="text-xs font-semibold whitespace-nowrap text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30 px-2 py-0.5 rounded-full">
                       {itemsWithErrors.reduce((sum, item) => sum + item.count, 0)} total
                     </span>
                   </div>
@@ -2526,7 +2526,7 @@ function InstallsPageContent() {
                                   }
                                 }}
                               >
-                                <td className={`px-4 py-2 text-sm truncate max-w-[200px] ${isSelected ? 'text-red-700 dark:text-red-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
+                                <td className={`px-4 py-2 text-sm break-words ${isSelected ? 'text-red-700 dark:text-red-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
                                   {item.name}
                                 </td>
                                 <td className="px-4 py-2 text-sm text-right font-semibold text-red-600 dark:text-red-400">
@@ -2565,13 +2565,13 @@ function InstallsPageContent() {
                     }}
                     title="Click to show all devices with warnings"
                   >
-                    <h3 className={`text-lg font-medium flex items-center gap-2 ${itemsStatusFilter === 'warnings' && !searchQuery ? 'text-amber-700 dark:text-amber-300' : 'text-gray-900 dark:text-white'}`}>
+                    <h3 className={`text-base font-medium flex items-center gap-2 whitespace-nowrap ${itemsStatusFilter === 'warnings' && !searchQuery ? 'text-amber-700 dark:text-amber-300' : 'text-gray-900 dark:text-white'}`}>
                       <svg className="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                       </svg>
                       Items with Warnings
                     </h3>
-                    <span className="text-sm font-semibold text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 rounded-full">
+                    <span className="text-xs font-semibold whitespace-nowrap text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 rounded-full">
                       {itemsWithWarnings.reduce((sum, item) => sum + item.count, 0)} total
                     </span>
                   </div>
@@ -2642,7 +2642,7 @@ function InstallsPageContent() {
                                   }
                                 }}
                               >
-                                <td className={`px-4 py-2 text-sm truncate max-w-[200px] ${isSelected ? 'text-amber-700 dark:text-amber-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
+                                <td className={`px-4 py-2 text-sm break-words ${isSelected ? 'text-amber-700 dark:text-amber-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
                                   {item.name}
                                 </td>
                                 <td className="px-4 py-2 text-sm text-right font-semibold text-amber-600 dark:text-amber-400">
@@ -2681,13 +2681,13 @@ function InstallsPageContent() {
                     }}
                     title="Click to show all devices with pending updates"
                   >
-                    <h3 className={`text-lg font-medium flex items-center gap-2 ${itemsStatusFilter === 'pending' && !searchQuery ? 'text-cyan-700 dark:text-cyan-300' : 'text-gray-900 dark:text-white'}`}>
+                    <h3 className={`text-base font-medium flex items-center gap-2 whitespace-nowrap ${itemsStatusFilter === 'pending' && !searchQuery ? 'text-cyan-700 dark:text-cyan-300' : 'text-gray-900 dark:text-white'}`}>
                       <svg className="w-5 h-5 text-cyan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       Items with Pending
                     </h3>
-                    <span className="text-sm font-semibold text-cyan-600 dark:text-cyan-400 bg-cyan-100 dark:bg-cyan-900/30 px-2 py-0.5 rounded-full">
+                    <span className="text-xs font-semibold whitespace-nowrap text-cyan-600 dark:text-cyan-400 bg-cyan-100 dark:bg-cyan-900/30 px-2 py-0.5 rounded-full">
                       {itemsWithPending.reduce((sum, item) => sum + item.count, 0)} total
                     </span>
                   </div>
@@ -2758,7 +2758,7 @@ function InstallsPageContent() {
                                   }
                                 }}
                               >
-                                <td className={`px-4 py-2 text-sm truncate max-w-[200px] ${isSelected ? 'text-cyan-700 dark:text-cyan-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
+                                <td className={`px-4 py-2 text-sm break-words ${isSelected ? 'text-cyan-700 dark:text-cyan-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
                                   {item.name}
                                 </td>
                                 <td className="px-4 py-2 text-sm text-right font-semibold text-cyan-600 dark:text-cyan-400">
@@ -2794,13 +2794,13 @@ function InstallsPageContent() {
                     }}
                     title="Click to show all devices that completed an install in their most recent run"
                   >
-                    <h3 className={`text-lg font-medium flex items-center gap-2 ${itemsStatusFilter === 'success' && !searchQuery ? 'text-green-700 dark:text-green-300' : 'text-gray-900 dark:text-white'}`}>
+                    <h3 className={`text-base font-medium flex items-center gap-2 whitespace-nowrap ${itemsStatusFilter === 'success' && !searchQuery ? 'text-green-700 dark:text-green-300' : 'text-gray-900 dark:text-white'}`}>
                       <svg className="w-5 h-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       Items Installed
                     </h3>
-                    <span className="text-sm font-semibold text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30 px-2 py-0.5 rounded-full">
+                    <span className="text-xs font-semibold whitespace-nowrap text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-900/30 px-2 py-0.5 rounded-full">
                       {itemsWithSuccess.reduce((sum, item) => sum + item.count, 0)} total
                     </span>
                   </div>
@@ -2845,7 +2845,7 @@ function InstallsPageContent() {
                                   }
                                 }}
                               >
-                                <td className={`px-4 py-2 text-sm truncate max-w-[200px] ${isSelected ? 'text-green-700 dark:text-green-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
+                                <td className={`px-4 py-2 text-sm break-words ${isSelected ? 'text-green-700 dark:text-green-300 font-semibold' : 'text-gray-900 dark:text-white'}`} title={item.name}>
                                   {item.name}
                                 </td>
                                 <td className="px-4 py-2 text-sm text-right font-semibold text-green-600 dark:text-green-400">
@@ -3583,7 +3583,7 @@ function InstallsPageContent() {
                 <div className="relative flex-1 max-w-md">
                   <input
                     type="text"
-                    placeholder="Search installs, devices, versions..."
+                    placeholder="Search"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="w-full px-4 py-2 pl-10 pr-10 text-sm border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
@@ -3644,28 +3644,6 @@ function InstallsPageContent() {
                       </>
                     )}
                   </div>
-                )}
-                {/* Clear Filter(s) Button - Show when any filter is active */}
-                {(searchQuery || itemsStatusFilter !== 'all' || deviceStatusFilter !== 'all' || installStatusFilter !== 'all' || selectedUsages.length > 0 || selectedCatalogs.length > 0 || selectedFleets.length > 0 || selectedAreas.length > 0 || selectedPlatforms.length > 0 || selectedRooms.length > 0 || selectedManifest || selectedSoftwareRepo || selectedMunkiVersion || selectedCimianVersion) && (
-                  <button
-                    onClick={() => {
-                      setItemsStatusFilter('all')
-                      setDeviceStatusFilter('all')
-                      setInstallStatusFilter('all')
-                      setSearchQuery('')
-                      clearAllFilters()
-                      setSelectedManifest('')
-                      setSelectedSoftwareRepo('')
-                      setSelectedMunkiVersion('')
-                      setSelectedCimianVersion('')
-                    }}
-                    className="px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                    Clear Filter(s)
-                  </button>
                 )}
                 {/* New Report Button - Only show for generated reports when NO widget filters are active */}
                 {hasGeneratedReport && installs.length > 0 && !loading && itemsStatusFilter === 'all' && !selectedManifest && !selectedSoftwareRepo && !selectedMunkiVersion && !selectedCimianVersion && (

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -11,6 +11,7 @@
 import React, { useEffect, useState } from 'react'
 import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
 import { collectSystemProblems, type SystemProblem } from '../lib/installs/systemProblems'
+import { itemNameFromMessage } from '../lib/installs/status'
 import { formatRelativeTime } from '../lib/time'
 
 interface InstallsRunStatusProps {
@@ -69,7 +70,11 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
         const payload = await fetchEventPayload(String(installsEvent.id))
         if (cancelled) return
         const extracted = extractInlineDetails(payload)
-        setEventLines([...extracted.errors, ...extracted.warnings])
+        // The event carries everything the run said; keep only system-level
+        // lines here — item-attributable ones live on their items.
+        const systemOnly = (line: InlineLine) =>
+          !line.name && !/^installer:/i.test(line.text) && !/^-{3,}/.test(line.text) && itemNameFromMessage(line.text) === null
+        setEventLines([...extracted.errors, ...extracted.warnings].filter(systemOnly).slice(0, 10))
       })
       .catch(() => { /* the card still states the outcome without text */ })
     return () => { cancelled = true }
@@ -119,7 +124,11 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
             ))}
           </div>
         ) : (
-          <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {summary.latestFailed
+              ? 'The failure detail is on the item that failed, in the table below.'
+              : 'No message text was reported for this run.'}
+          </p>
         )
       )}
 

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -1,91 +1,63 @@
 /**
- * Outcome of the most recent managed-software run on a device.
+ * System-level outcome of recent managed-software runs on a device.
  *
- * A run that never reached its manifest reports zero items, so the items
- * table alone reads as "nothing assigned" when the truth is "the run failed".
- * This card says which, and shows the run's messages: from the module when
- * the client sent them, else from the device's latest error or warning event,
- * because the stale-error sweep can blank the module strings.
+ * Item problems live on their items in the table; this card carries only what
+ * no item can: manifest and catalog retrieval failures, preflight and
+ * postflight errors, a run that reported nothing at all. Problems are
+ * session-scoped — a later clean run demotes them to "earlier runs" rather
+ * than erasing them — and each line is stamped with the session it came from.
  */
 
 import React, { useEffect, useState } from 'react'
 import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
-import { itemNameFromMessage } from '../lib/installs/status'
+import { collectSystemProblems, type SystemProblem } from '../lib/installs/systemProblems'
 
 interface InstallsRunStatusProps {
   serialNumber?: string
   installs: any
 }
 
-type Outcome = 'error' | 'warning' | null
-
-function splitMessages(raw: unknown): string[] {
-  if (typeof raw !== 'string') return []
-  return raw.split(/;|\n/).map(s => s.trim()).filter(s => s && !/^-{3,}$/.test(s) && !/^installer:(%|PHASE:|STATUS:)/i.test(s))
-}
-
-function runOutcome(installs: any): { outcome: Outcome; errors: string[]; warnings: string[] } {
-  const munki = installs?.munki
-  const cimian = installs?.cimian
-  if (munki) {
-    // Newer clients send structured warningItems / errorItems ({name?, version?,
-    // message}); older ones the semicolon-joined strings. Show both the same way,
-    // with the item name leading when the problem names one.
-    const describe = (problem: any): string => {
-      const name = String(problem?.name || '').trim()
-      const version = String(problem?.version || '').trim()
-      const message = String(problem?.message || '').trim()
-      if (!name) return message
-      return message ? `${name}${version ? ` ${version}` : ''}: ${message}` : `${name}${version ? ` ${version}` : ''}`
-    }
-    // Only problems that name no item belong here; anything attributable —
-    // structured items with a name, "Download of X failed", installer output —
-    // lives on the item itself in the table below.
-    const nameless = (problem: any) => !String(problem?.name || '').trim()
-    const systemOnly = (message: string) => !/^installer:/i.test(message) && itemNameFromMessage(message) === null
-    const hasStructured = Array.isArray(munki.errorItems) || Array.isArray(munki.warningItems)
-    const errors = hasStructured
-      ? (munki.errorItems || []).filter(nameless).map(describe).filter(Boolean)
-      : splitMessages(munki.errors).filter(systemOnly)
-    const warnings = hasStructured
-      ? (munki.warningItems || []).filter(nameless).map(describe).filter(Boolean)
-      : splitMessages(munki.warnings).filter(systemOnly)
-    const anyErrors = hasStructured ? (munki.errorItems || []).length > 0 : splitMessages(munki.errors).length > 0
-    const status = String(munki.status || '').toLowerCase()
-    const sessionStatus = String(munki.lastSessionStatus || '').toLowerCase()
-    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || sessionStatus === 'failed' || anyErrors
-    const warned = warnings.length > 0 || status === 'warning' || sessionStatus === 'partial_failure'
-    const itemless = !Array.isArray(munki.items) || munki.items.length === 0
-    // With every problem attached to an item and items on the page, the card
-    // would only repeat the table; show it for system problems or an empty run.
-    if (errors.length === 0 && warnings.length === 0 && !(failed && itemless)) {
-      return { outcome: null, errors: [], warnings: [] }
-    }
-    return { outcome: failed ? 'error' : warned ? 'warning' : null, errors, warnings }
-  }
-  if (cimian) {
-    const session = Array.isArray(cimian.sessions) ? cimian.sessions[0] : null
-    const status = String(session?.status || cimian.status || '').toLowerCase()
-    const failed = (session?.failures || 0) > 0 || (session?.packages_failed || 0) > 0 || status === 'failed' || status === 'error'
-    const warned = status === 'warning' || (session?.warnings || 0) > 0
-    return { outcome: failed ? 'error' : warned ? 'warning' : null, errors: [], warnings: [] }
-  }
-  return { outcome: null, errors: [], warnings: [] }
-}
-
 export function lastRunFailed(installs: any): boolean {
-  return runOutcome(installs).outcome === 'error'
+  return collectSystemProblems(installs).latestFailed
+}
+
+const formatStamp = (problem: SystemProblem): string | null => {
+  if (problem.sessionId) return problem.sessionId
+  if (problem.time) {
+    const parsed = new Date(problem.time)
+    if (!Number.isNaN(parsed.getTime())) return parsed.toLocaleString()
+  }
+  return null
+}
+
+const ProblemLine: React.FC<{ problem: SystemProblem; stamped?: boolean }> = ({ problem, stamped = false }) => {
+  const tone = problem.tone === 'error' ? 'text-red-700 dark:text-red-300' : 'text-yellow-700 dark:text-yellow-300'
+  const stamp = stamped ? formatStamp(problem) : null
+  return (
+    <div>
+      <div className={inlineLineClass({ text: problem.message, isMessage: true }, tone)}>{problem.message}</div>
+      {stamp && <div className="mt-0.5 text-[11px] text-gray-400 dark:text-gray-500 font-mono">{stamp}</div>}
+    </div>
+  )
 }
 
 export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumber, installs }) => {
-  const { outcome, errors, warnings } = runOutcome(installs)
-  const [eventLines, setEventLines] = useState<{ errors: InlineLine[]; warnings: InlineLine[] } | null>(null)
+  const summary = collectSystemProblems(installs)
+  const [eventLines, setEventLines] = useState<InlineLine[] | null>(null)
 
-  // No text on the module: read it from the device's latest matching event
+  const currentTone: 'error' | 'warning' | null = summary.latestFailed || summary.current.some(p => p.tone === 'error')
+    ? 'error'
+    : summary.current.length > 0 ? 'warning' : null
+  const showCurrent = currentTone !== null
+  const showRecent = summary.recent.length > 0
+  const needsEventText = showCurrent && summary.current.length === 0
+
+  // A failed run with no module text (the stale-error sweep blanks it): read the
+  // device's latest matching event instead.
   useEffect(() => {
-    if (!outcome || !serialNumber || errors.length > 0 || warnings.length > 0) return
+    if (!needsEventText || !serialNumber) return
     let cancelled = false
-    const type = outcome === 'error' ? 'error' : 'warning'
+    const type = currentTone === 'error' ? 'error' : 'warning'
     fetch(`/api/device/${encodeURIComponent(serialNumber)}/modules/events?limit=5&type=${type}`)
       .then(r => (r.ok ? r.json() : null))
       .then(async result => {
@@ -95,35 +67,63 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
         const payload = await fetchEventPayload(String(installsEvent.id))
         if (cancelled) return
         const extracted = extractInlineDetails(payload)
-        setEventLines({ errors: extracted.errors, warnings: extracted.warnings })
+        setEventLines([...extracted.errors, ...extracted.warnings])
       })
       .catch(() => { /* the card still states the outcome without text */ })
     return () => { cancelled = true }
-  }, [outcome, serialNumber, errors.length, warnings.length])
+  }, [needsEventText, serialNumber, currentTone])
 
-  if (!outcome) return null
+  if (!showCurrent && !showRecent) return null
 
-  const errorLines: InlineLine[] = errors.length ? errors.map(text => ({ text, isMessage: true })) : (eventLines?.errors ?? [])
-  const warningLines: InlineLine[] = warnings.length ? warnings.map(text => ({ text, isMessage: true })) : (eventLines?.warnings ?? [])
-  const isError = outcome === 'error'
+  const isError = currentTone === 'error'
+  const chrome = showCurrent
+    ? isError
+      ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20'
+      : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'
+    : 'border-gray-200 bg-gray-50/60 dark:border-gray-700 dark:bg-gray-800/40'
+  const badge = showCurrent
+    ? isError
+      ? { text: 'Last run failed', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' }
+      : { text: 'Last run had warnings', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' }
+    : { text: 'Earlier runs had problems', className: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200' }
 
   return (
-    <div className={`rounded-lg border p-4 ${isError ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20' : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'}`}>
+    <div className={`rounded-lg border p-4 ${chrome}`}>
       <div className="flex items-center gap-2 mb-2">
-        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${isError ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'}`}>
-          {isError ? 'Last run failed' : 'Last run had warnings'}
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${badge.className}`}>
+          {badge.text}
         </span>
-        {isError && (!installs?.munki?.items || installs.munki.items.length === 0) && (
+        {showCurrent && isError && summary.latestItemless && (
           <span className="text-sm text-gray-600 dark:text-gray-400">The run did not complete, so no items were reported.</span>
         )}
+        {!showCurrent && showRecent && (
+          <span className="text-sm text-gray-600 dark:text-gray-400">The latest run was clean; these are from the last 24 hours.</span>
+        )}
       </div>
-      {(errorLines.length > 0 || warningLines.length > 0) ? (
-        <div className="space-y-1">
-          {errorLines.map((line, i) => <div key={`e-${i}`} className={inlineLineClass(line, 'text-red-700 dark:text-red-300')}>{line.text}</div>)}
-          {warningLines.map((line, i) => <div key={`w-${i}`} className={inlineLineClass(line, 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>)}
+
+      {showCurrent && (
+        summary.current.length > 0 ? (
+          <div className="space-y-1.5">
+            {summary.current.map((problem, i) => <ProblemLine key={`c-${i}`} problem={problem} />)}
+          </div>
+        ) : eventLines && eventLines.length > 0 ? (
+          <div className="space-y-1">
+            {eventLines.map((line, i) => (
+              <div key={`ev-${i}`} className={inlineLineClass(line, isError ? 'text-red-700 dark:text-red-300' : 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
+        )
+      )}
+
+      {showRecent && (
+        <div className={`space-y-1.5 ${showCurrent ? 'mt-3 pt-3 border-t border-gray-200/70 dark:border-gray-700/70' : ''}`}>
+          {showCurrent && (
+            <div className="text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Earlier runs, last 24 hours</div>
+          )}
+          {summary.recent.map((problem, i) => <ProblemLine key={`r-${i}`} problem={problem} stamped />)}
         </div>
-      ) : (
-        <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
       )}
     </div>
   )

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -27,11 +27,25 @@ function runOutcome(installs: any): { outcome: Outcome; errors: string[]; warnin
   const munki = installs?.munki
   const cimian = installs?.cimian
   if (munki) {
-    const errors = splitMessages(munki.errors)
-    const warnings = splitMessages(munki.warnings)
+    // Newer clients send structured warningItems / errorItems ({name?, version?,
+    // message}); older ones the semicolon-joined strings. Show both the same way,
+    // with the item name leading when the problem names one.
+    const describe = (problem: any): string => {
+      const name = String(problem?.name || '').trim()
+      const version = String(problem?.version || '').trim()
+      const message = String(problem?.message || '').trim()
+      if (!name) return message
+      return message ? `${name}${version ? ` ${version}` : ''}: ${message}` : `${name}${version ? ` ${version}` : ''}`
+    }
+    const structuredErrors = Array.isArray(munki.errorItems) ? munki.errorItems.map(describe).filter(Boolean) : []
+    const structuredWarnings = Array.isArray(munki.warningItems) ? munki.warningItems.map(describe).filter(Boolean) : []
+    const errors = structuredErrors.length ? structuredErrors : splitMessages(munki.errors)
+    const warnings = structuredWarnings.length ? structuredWarnings : splitMessages(munki.warnings)
     const status = String(munki.status || '').toLowerCase()
-    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || errors.length > 0
-    return { outcome: failed ? 'error' : (warnings.length > 0 || status === 'warning') ? 'warning' : null, errors, warnings }
+    const sessionStatus = String(munki.lastSessionStatus || '').toLowerCase()
+    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || sessionStatus === 'failed' || errors.length > 0
+    const warned = warnings.length > 0 || status === 'warning' || sessionStatus === 'partial_failure'
+    return { outcome: failed ? 'error' : warned ? 'warning' : null, errors, warnings }
   }
   if (cimian) {
     const session = Array.isArray(cimian.sessions) ? cimian.sessions[0] : null

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -10,6 +10,7 @@
 
 import React, { useEffect, useState } from 'react'
 import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
+import { itemNameFromMessage } from '../lib/installs/status'
 
 interface InstallsRunStatusProps {
   serialNumber?: string
@@ -37,14 +38,29 @@ function runOutcome(installs: any): { outcome: Outcome; errors: string[]; warnin
       if (!name) return message
       return message ? `${name}${version ? ` ${version}` : ''}: ${message}` : `${name}${version ? ` ${version}` : ''}`
     }
-    const structuredErrors = Array.isArray(munki.errorItems) ? munki.errorItems.map(describe).filter(Boolean) : []
-    const structuredWarnings = Array.isArray(munki.warningItems) ? munki.warningItems.map(describe).filter(Boolean) : []
-    const errors = structuredErrors.length ? structuredErrors : splitMessages(munki.errors)
-    const warnings = structuredWarnings.length ? structuredWarnings : splitMessages(munki.warnings)
+    // Only problems that name no item belong here; anything attributable —
+    // structured items with a name, "Download of X failed", installer output —
+    // lives on the item itself in the table below.
+    const nameless = (problem: any) => !String(problem?.name || '').trim()
+    const systemOnly = (message: string) => !/^installer:/i.test(message) && itemNameFromMessage(message) === null
+    const hasStructured = Array.isArray(munki.errorItems) || Array.isArray(munki.warningItems)
+    const errors = hasStructured
+      ? (munki.errorItems || []).filter(nameless).map(describe).filter(Boolean)
+      : splitMessages(munki.errors).filter(systemOnly)
+    const warnings = hasStructured
+      ? (munki.warningItems || []).filter(nameless).map(describe).filter(Boolean)
+      : splitMessages(munki.warnings).filter(systemOnly)
+    const anyErrors = hasStructured ? (munki.errorItems || []).length > 0 : splitMessages(munki.errors).length > 0
     const status = String(munki.status || '').toLowerCase()
     const sessionStatus = String(munki.lastSessionStatus || '').toLowerCase()
-    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || sessionStatus === 'failed' || errors.length > 0
+    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error' || sessionStatus === 'failed' || anyErrors
     const warned = warnings.length > 0 || status === 'warning' || sessionStatus === 'partial_failure'
+    const itemless = !Array.isArray(munki.items) || munki.items.length === 0
+    // With every problem attached to an item and items on the page, the card
+    // would only repeat the table; show it for system problems or an empty run.
+    if (errors.length === 0 && warnings.length === 0 && !(failed && itemless)) {
+      return { outcome: null, errors: [], warnings: [] }
+    }
     return { outcome: failed ? 'error' : warned ? 'warning' : null, errors, warnings }
   }
   if (cimian) {

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -87,8 +87,13 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
 
   if (!outcome) return null
 
-  const errorLines: InlineLine[] = errors.length ? errors.map(text => ({ text, isMessage: true })) : (eventLines?.errors ?? [])
-  const warningLines: InlineLine[] = warnings.length ? warnings.map(text => ({ text, isMessage: true })) : (eventLines?.warnings ?? [])
+  // When the module carries the run's messages, the Errors and Warnings section
+  // below the table renders them; repeating them here read as duplication. The
+  // card only prints text in the blank-module case, where it comes from the
+  // device's latest matching event instead.
+  const moduleHasMessages = errors.length > 0 || warnings.length > 0
+  const errorLines: InlineLine[] = moduleHasMessages ? [] : (eventLines?.errors ?? [])
+  const warningLines: InlineLine[] = moduleHasMessages ? [] : (eventLines?.warnings ?? [])
   const isError = outcome === 'error'
 
   return (
@@ -106,7 +111,7 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
           {errorLines.map((line, i) => <div key={`e-${i}`} className={inlineLineClass(line, 'text-red-700 dark:text-red-300')}>{line.text}</div>)}
           {warningLines.map((line, i) => <div key={`w-${i}`} className={inlineLineClass(line, 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>)}
         </div>
-      ) : (
+      ) : moduleHasMessages ? null : (
         <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
       )}
     </div>

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -25,7 +25,7 @@ export function lastRunFailed(installs: any): boolean {
 
 const CHIP: Record<'error' | 'warning', string> = {
   error: 'text-xs font-mono px-2.5 py-1.5 rounded bg-red-100/70 dark:bg-red-900/40 text-red-800 dark:text-red-200 break-words',
-  warning: 'text-xs font-mono px-2.5 py-1.5 rounded bg-yellow-100/70 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200 break-words',
+  warning: 'text-xs font-mono px-2.5 py-1.5 rounded bg-yellow-200/80 dark:bg-yellow-900/50 text-yellow-900 dark:text-yellow-200 break-words',
 }
 
 export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumber, installs }) => {
@@ -61,10 +61,10 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
   const isError = summary.failedWithoutItems || summary.problems.some(p => p.tone === 'error')
   const chrome = isError
     ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20'
-    : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'
+    : 'border-yellow-400 bg-yellow-100/80 dark:border-yellow-700 dark:bg-yellow-900/30'
   const badge = isError
     ? { text: 'Last run failed', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' }
-    : { text: 'Last run had warnings', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' }
+    : { text: 'Last run warnings', className: 'bg-yellow-200 text-yellow-900 dark:bg-yellow-900 dark:text-yellow-200' }
 
   const stampParts: string[] = []
   if (summary.sessionId) stampParts.push(summary.sessionId)

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -24,8 +24,8 @@ export function lastRunFailed(installs: any): boolean {
 }
 
 const CHIP: Record<'error' | 'warning', string> = {
-  error: 'text-xs font-mono px-2.5 py-1.5 rounded bg-red-100/70 dark:bg-red-900/40 text-red-800 dark:text-red-200 break-words',
-  warning: 'text-xs font-mono px-2.5 py-1.5 rounded bg-yellow-200/80 dark:bg-yellow-900/50 text-yellow-900 dark:text-yellow-200 break-words',
+  error: 'text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-800 text-red-700 dark:text-red-300 whitespace-pre-wrap break-words',
+  warning: 'text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-800 text-yellow-800 dark:text-yellow-300 whitespace-pre-wrap break-words',
 }
 
 export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumber, installs }) => {

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -1,15 +1,15 @@
 /**
- * System-level outcome of recent managed-software runs on a device.
+ * System-level problems from the device's managed-software runs.
  *
- * Item problems live on their items in the table; this card carries only what
- * no item can: manifest and catalog retrieval failures, preflight and
- * postflight errors, a run that reported nothing at all. Problems are
- * session-scoped — a later clean run demotes them to "earlier runs" rather
- * than erasing them — and each line is stamped with the session it came from.
+ * This box exists only for problems no item can carry: manifest and catalog
+ * retrieval failures, preflight and postflight errors, a failed run that
+ * reported no items. Anything attributable to an item lives on that item in
+ * the table and never appears here — when every problem has an item, there is
+ * no box at all.
  */
 
 import React, { useEffect, useState } from 'react'
-import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
+import { extractInlineDetails, fetchEventPayload, type InlineLine } from '../lib/eventInlineDetails'
 import { collectSystemProblems, type SystemProblem } from '../lib/installs/systemProblems'
 import { itemNameFromMessage } from '../lib/installs/status'
 import { formatRelativeTime } from '../lib/time'
@@ -20,48 +20,26 @@ interface InstallsRunStatusProps {
 }
 
 export function lastRunFailed(installs: any): boolean {
-  return collectSystemProblems(installs).latestFailed
+  return collectSystemProblems(installs).failedWithoutItems
 }
 
-const formatStamp = (problem: SystemProblem): string | null => {
-  const parts: string[] = []
-  if (problem.sessionId) parts.push(problem.sessionId)
-  if (problem.time) {
-    const parsed = new Date(problem.time)
-    if (!Number.isNaN(parsed.getTime())) parts.push(formatRelativeTime(problem.time))
-  }
-  return parts.length ? parts.join(' · ') : null
-}
-
-const ProblemLine: React.FC<{ problem: SystemProblem; stamped?: boolean }> = ({ problem, stamped = false }) => {
-  const tone = problem.tone === 'error' ? 'text-red-700 dark:text-red-300' : 'text-yellow-700 dark:text-yellow-300'
-  const stamp = stamped ? formatStamp(problem) : null
-  return (
-    <div>
-      <div className={inlineLineClass({ text: problem.message, isMessage: true }, tone)}>{problem.message}</div>
-      {stamp && <div className="mt-0.5 text-[11px] text-gray-400 dark:text-gray-500 font-mono">{stamp}</div>}
-    </div>
-  )
+const CHIP: Record<'error' | 'warning', string> = {
+  error: 'text-xs font-mono px-2.5 py-1.5 rounded bg-red-100/70 dark:bg-red-900/40 text-red-800 dark:text-red-200 break-words',
+  warning: 'text-xs font-mono px-2.5 py-1.5 rounded bg-yellow-100/70 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-200 break-words',
 }
 
 export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumber, installs }) => {
   const summary = collectSystemProblems(installs)
   const [eventLines, setEventLines] = useState<InlineLine[] | null>(null)
 
-  const currentTone: 'error' | 'warning' | null = summary.latestFailed || summary.current.some(p => p.tone === 'error')
-    ? 'error'
-    : summary.current.length > 0 ? 'warning' : null
-  const showCurrent = currentTone !== null
-  const showRecent = summary.recent.length > 0
-  const needsEventText = showCurrent && summary.current.length === 0
+  const needsEventText = summary.failedWithoutItems && summary.problems.length === 0
 
-  // A failed run with no module text (the stale-error sweep blanks it): read the
-  // device's latest matching event instead.
+  // A failed run that reported nothing: the module may carry no text either
+  // (the stale-error sweep blanks it), so read the latest matching event.
   useEffect(() => {
     if (!needsEventText || !serialNumber) return
     let cancelled = false
-    const type = currentTone === 'error' ? 'error' : 'warning'
-    fetch(`/api/device/${encodeURIComponent(serialNumber)}/modules/events?limit=5&type=${type}`)
+    fetch(`/api/device/${encodeURIComponent(serialNumber)}/modules/events?limit=5&type=error`)
       .then(r => (r.ok ? r.json() : null))
       .then(async result => {
         const events: any[] = result?.data || result?.events || []
@@ -70,29 +48,28 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
         const payload = await fetchEventPayload(String(installsEvent.id))
         if (cancelled) return
         const extracted = extractInlineDetails(payload)
-        // The event carries everything the run said; keep only system-level
-        // lines here — item-attributable ones live on their items.
         const systemOnly = (line: InlineLine) =>
           !line.name && !/^installer:/i.test(line.text) && !/^-{3,}/.test(line.text) && itemNameFromMessage(line.text) === null
         setEventLines([...extracted.errors, ...extracted.warnings].filter(systemOnly).slice(0, 10))
       })
-      .catch(() => { /* the card still states the outcome without text */ })
+      .catch(() => { /* the box still states the outcome without text */ })
     return () => { cancelled = true }
-  }, [needsEventText, serialNumber, currentTone])
+  }, [needsEventText, serialNumber])
 
-  if (!showCurrent && !showRecent) return null
+  if (summary.problems.length === 0 && !summary.failedWithoutItems) return null
 
-  const isError = currentTone === 'error'
-  const chrome = showCurrent
-    ? isError
-      ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20'
-      : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'
-    : 'border-gray-200 bg-gray-50/60 dark:border-gray-700 dark:bg-gray-800/40'
-  const badge = showCurrent
-    ? isError
-      ? { text: 'Last run failed', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' }
-      : { text: 'Last run had warnings', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' }
-    : { text: 'Earlier runs had problems', className: 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200' }
+  const isError = summary.failedWithoutItems || summary.problems.some(p => p.tone === 'error')
+  const chrome = isError
+    ? 'border-red-200 bg-red-50/60 dark:border-red-900 dark:bg-red-900/20'
+    : 'border-yellow-200 bg-yellow-50/60 dark:border-yellow-900 dark:bg-yellow-900/20'
+  const badge = isError
+    ? { text: 'Last run failed', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' }
+    : { text: 'Last run had warnings', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' }
+
+  const stampParts: string[] = []
+  if (summary.sessionId) stampParts.push(summary.sessionId)
+  if (summary.time && !Number.isNaN(new Date(summary.time).getTime())) stampParts.push(formatRelativeTime(summary.time))
+  const stamp = stampParts.join(' · ')
 
   return (
     <div className={`rounded-lg border p-4 ${chrome}`}>
@@ -100,46 +77,23 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${badge.className}`}>
           {badge.text}
         </span>
-        {showCurrent && isError && summary.latestItemless && (
+        {summary.failedWithoutItems && (
           <span className="text-sm text-gray-600 dark:text-gray-400">The run did not complete, so no items were reported.</span>
         )}
-        {!showCurrent && showRecent && (
-          <span className="text-sm text-gray-600 dark:text-gray-400">
-            {summary.latestSessionId
-              ? `The most recent run (${summary.latestSessionId}${summary.latestTime ? `, ${formatRelativeTime(summary.latestTime)}` : ''}) reported no problems; these came from earlier runs in the last 24 hours.`
-              : 'The most recent run reported no problems; these came from earlier runs in the last 24 hours.'}
-          </span>
-        )}
+        {stamp && <span className="ml-auto text-[11px] font-mono text-gray-400 dark:text-gray-500">{stamp}</span>}
       </div>
 
-      {showCurrent && (
-        summary.current.length > 0 ? (
-          <div className="space-y-1.5">
-            {summary.current.map((problem, i) => <ProblemLine key={`c-${i}`} problem={problem} />)}
-          </div>
-        ) : eventLines && eventLines.length > 0 ? (
-          <div className="space-y-1">
-            {eventLines.map((line, i) => (
-              <div key={`ev-${i}`} className={inlineLineClass(line, isError ? 'text-red-700 dark:text-red-300' : 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            {summary.latestFailed
-              ? 'The failure detail is on the item that failed, in the table below.'
-              : 'No message text was reported for this run.'}
-          </p>
-        )
-      )}
-
-      {showRecent && (
-        <div className={`space-y-1.5 ${showCurrent ? 'mt-3 pt-3 border-t border-gray-200/70 dark:border-gray-700/70' : ''}`}>
-          {showCurrent && (
-            <div className="text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500">Earlier runs, last 24 hours</div>
-          )}
-          {summary.recent.map((problem, i) => <ProblemLine key={`r-${i}`} problem={problem} stamped />)}
+      {summary.problems.length > 0 ? (
+        <div className="space-y-1.5">
+          {summary.problems.map((problem: SystemProblem, i: number) => (
+            <div key={`p-${i}`} className={CHIP[problem.tone]}>{problem.message}</div>
+          ))}
         </div>
-      )}
+      ) : eventLines && eventLines.length > 0 ? (
+        <div className="space-y-1.5">
+          {eventLines.map((line, i) => <div key={`ev-${i}`} className={CHIP.error}>{line.text}</div>)}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -11,6 +11,7 @@
 import React, { useEffect, useState } from 'react'
 import { extractInlineDetails, fetchEventPayload, inlineLineClass, type InlineLine } from '../lib/eventInlineDetails'
 import { collectSystemProblems, type SystemProblem } from '../lib/installs/systemProblems'
+import { formatRelativeTime } from '../lib/time'
 
 interface InstallsRunStatusProps {
   serialNumber?: string
@@ -22,12 +23,13 @@ export function lastRunFailed(installs: any): boolean {
 }
 
 const formatStamp = (problem: SystemProblem): string | null => {
-  if (problem.sessionId) return problem.sessionId
+  const parts: string[] = []
+  if (problem.sessionId) parts.push(problem.sessionId)
   if (problem.time) {
     const parsed = new Date(problem.time)
-    if (!Number.isNaN(parsed.getTime())) return parsed.toLocaleString()
+    if (!Number.isNaN(parsed.getTime())) parts.push(formatRelativeTime(problem.time))
   }
-  return null
+  return parts.length ? parts.join(' · ') : null
 }
 
 const ProblemLine: React.FC<{ problem: SystemProblem; stamped?: boolean }> = ({ problem, stamped = false }) => {
@@ -97,7 +99,11 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
           <span className="text-sm text-gray-600 dark:text-gray-400">The run did not complete, so no items were reported.</span>
         )}
         {!showCurrent && showRecent && (
-          <span className="text-sm text-gray-600 dark:text-gray-400">The latest run was clean; these are from the last 24 hours.</span>
+          <span className="text-sm text-gray-600 dark:text-gray-400">
+            {summary.latestSessionId
+              ? `The most recent run (${summary.latestSessionId}${summary.latestTime ? `, ${formatRelativeTime(summary.latestTime)}` : ''}) reported no problems; these came from earlier runs in the last 24 hours.`
+              : 'The most recent run reported no problems; these came from earlier runs in the last 24 hours.'}
+          </span>
         )}
       </div>
 

--- a/src/components/InstallsRunStatus.tsx
+++ b/src/components/InstallsRunStatus.tsx
@@ -87,13 +87,8 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
 
   if (!outcome) return null
 
-  // When the module carries the run's messages, the Errors and Warnings section
-  // below the table renders them; repeating them here read as duplication. The
-  // card only prints text in the blank-module case, where it comes from the
-  // device's latest matching event instead.
-  const moduleHasMessages = errors.length > 0 || warnings.length > 0
-  const errorLines: InlineLine[] = moduleHasMessages ? [] : (eventLines?.errors ?? [])
-  const warningLines: InlineLine[] = moduleHasMessages ? [] : (eventLines?.warnings ?? [])
+  const errorLines: InlineLine[] = errors.length ? errors.map(text => ({ text, isMessage: true })) : (eventLines?.errors ?? [])
+  const warningLines: InlineLine[] = warnings.length ? warnings.map(text => ({ text, isMessage: true })) : (eventLines?.warnings ?? [])
   const isError = outcome === 'error'
 
   return (
@@ -111,7 +106,7 @@ export const InstallsRunStatus: React.FC<InstallsRunStatusProps> = ({ serialNumb
           {errorLines.map((line, i) => <div key={`e-${i}`} className={inlineLineClass(line, 'text-red-700 dark:text-red-300')}>{line.text}</div>)}
           {warningLines.map((line, i) => <div key={`w-${i}`} className={inlineLineClass(line, 'text-yellow-700 dark:text-yellow-300')}>{line.text}</div>)}
         </div>
-      ) : moduleHasMessages ? null : (
+      ) : (
         <p className="text-xs text-gray-500 dark:text-gray-400">No message text was reported for this run.</p>
       )}
     </div>

--- a/src/components/tables/ManagedInstallsTable.tsx
+++ b/src/components/tables/ManagedInstallsTable.tsx
@@ -694,7 +694,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                                         )}
                                                       </button>
                                                     </div>
-                                                    <p className="text-sm text-red-700 dark:text-red-300">
+                                                    <p className="text-sm text-red-700 dark:text-red-300 whitespace-pre-wrap break-words">
                                                       {error.message}
                                                     </p>
                                                     {error.details && (
@@ -753,7 +753,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                                         )}
                                                       </button>
                                                     </div>
-                                                    <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                                                    <p className="text-sm text-yellow-700 dark:text-yellow-300 whitespace-pre-wrap break-words">
                                                       {warning.message}
                                                     </p>
                                                     {warning.details && (
@@ -928,7 +928,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                                 )}
                                               </button>
                                             </div>
-                                            <p className="text-sm text-red-700 dark:text-red-300">
+                                            <p className="text-sm text-red-700 dark:text-red-300 whitespace-pre-wrap break-words">
                                               {error.message}
                                             </p>
                                             {error.details && (
@@ -987,7 +987,7 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
                                                 )}
                                               </button>
                                             </div>
-                                            <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                                            <p className="text-sm text-yellow-700 dark:text-yellow-300 whitespace-pre-wrap break-words">
                                               {warning.message}
                                             </p>
                                             {warning.details && (

--- a/src/components/tables/ManagedInstallsTable.tsx
+++ b/src/components/tables/ManagedInstallsTable.tsx
@@ -293,63 +293,13 @@ export const ManagedInstallsTable: React.FC<ManagedInstallsTableProps> = ({ data
     : packages;
   const installedCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'installed').length;
   const pendingCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'pending').length;
-  const warningCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'warning').length + runLevelWarnings.length;
-  const errorCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'error').length + runLevelErrors.length;
+  const warningCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'warning').length;
+  const errorCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'error').length;
   const removedCount = contextPackages.filter((pkg: any) => pkg.status?.toLowerCase() === 'removed').length;
 
-  const hasRunLevelMessages = runLevelErrors.length > 0 || runLevelWarnings.length > 0;
 
   return (
     <div className="space-y-6">
-      {/* Run-level (Munki/Cimian system) errors and warnings — surfaces preflight
-          failures and other unattributable messages that aren't tied to a specific package. */}
-      {hasRunLevelMessages && hasPackages && (
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-              Errors and Warnings
-              <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
-                {runLevelErrors.length > 0 && `${runLevelErrors.length} error${runLevelErrors.length === 1 ? '' : 's'}`}
-                {runLevelErrors.length > 0 && runLevelWarnings.length > 0 && ', '}
-                {runLevelWarnings.length > 0 && `${runLevelWarnings.length} warning${runLevelWarnings.length === 1 ? '' : 's'}`}
-              </span>
-            </h3>
-          </div>
-          <div className="px-6 py-4 space-y-2">
-            {runLevelErrors.map((error, i) => (
-              <div
-                key={error.id || `run-error-${i}`}
-                className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded px-3 py-2"
-              >
-                <p className="text-sm text-red-800 dark:text-red-300 font-mono break-words">
-                  {error.message}
-                </p>
-                {error.timestamp && (
-                  <p className="text-xs text-red-500 dark:text-red-500 mt-1">
-                    {formatExactTime(error.timestamp)}
-                  </p>
-                )}
-              </div>
-            ))}
-            {runLevelWarnings.map((warning, i) => (
-              <div
-                key={warning.id || `run-warning-${i}`}
-                className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded px-3 py-2"
-              >
-                <p className="text-sm text-yellow-800 dark:text-yellow-300 font-mono break-words">
-                  {warning.message}
-                </p>
-                {warning.timestamp && (
-                  <p className="text-xs text-yellow-600 dark:text-yellow-500 mt-1">
-                    {formatExactTime(warning.timestamp)}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Full Width Packages Table */}
       <div className="space-y-4">
           {/* Packages Table */}

--- a/src/components/tabs/EventsTab.tsx
+++ b/src/components/tabs/EventsTab.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import DeviceEventsSimple from '../DeviceEventsSimple'
 import { bundleEvents, type FleetEvent } from '../../lib/eventBundling'
-import { CheckCircle2, XCircle, AlertTriangle, Info, Server } from 'lucide-react'
+import { CheckCircle2, AlertCircle, AlertTriangle, Info, Zap } from 'lucide-react'
 import { DebugAccordion } from '../DebugAccordion'
 
 const VALID_EVENT_KINDS: ReadonlyArray<string> = ['info', 'error', 'warning', 'success', 'system']
@@ -15,9 +15,9 @@ const VALID_EVENT_KINDS: ReadonlyArray<string> = ['info', 'error', 'warning', 's
 const EVENT_FILTERS = [
   { key: 'success', label: 'Success', icon: CheckCircle2, color: 'green' },
   { key: 'warning', label: 'Warnings', icon: AlertTriangle, color: 'yellow' },
-  { key: 'error', label: 'Errors', icon: XCircle, color: 'red' },
+  { key: 'error', label: 'Errors', icon: AlertCircle, color: 'red' },
+  { key: 'system', label: 'System', icon: Zap, color: 'purple' },
   { key: 'info', label: 'Info', icon: Info, color: 'blue' },
-  { key: 'system', label: 'System', icon: Server, color: 'purple' },
 ] as const
 
 // Get styling for filter buttons

--- a/src/lib/data-processing/modules/installs.ts
+++ b/src/lib/data-processing/modules/installs.ts
@@ -1,3 +1,4 @@
+import { splitLogText } from '../../logText'
 import { normalizeCimianTimestamp, isCimianSessionId } from '../../time'
 
 /**
@@ -870,9 +871,11 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
           }
         }
         
+        const cimianErrorText = splitLogText(item.lastError)
         packageInfo.errors?.push({
           id: `${item.id || item.name}-last-error`,
-          message: item.lastError,
+          message: cimianErrorText.message,
+          details: cimianErrorText.details,
           timestamp: errorTimestamp,
           code: item.hasInstallLoop ? 'INSTALL_LOOP' : 'ERROR',
           package: item.name || item.displayName,
@@ -904,9 +907,11 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
           }
         }
         
+        const cimianWarningText = splitLogText(item.lastWarning)
         packageInfo.warnings?.push({
           id: `${item.id || item.name}-last-warning`,
-          message: item.lastWarning,
+          message: cimianWarningText.message,
+          details: cimianWarningText.details,
           timestamp: warningTimestamp,
           code: item.hasInstallLoop ? 'INSTALL_LOOP' : 'WARNING',
           package: item.name || item.displayName,
@@ -1155,9 +1160,11 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
       
       if (lastError && lastError.trim()) {
         if (!pkg.errors) pkg.errors = []
+        const munkiErrorText = splitLogText(lastError)
         pkg.errors.push({
           id: `munki-item-error-${pkg.id}`,
-          message: lastError,
+          message: munkiErrorText.message,
+          details: munkiErrorText.details,
           timestamp: installs.munki.endTime || new Date().toISOString(),
           code: 'MUNKI_ERROR',
           package: pkg.name
@@ -1165,9 +1172,11 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
         pkg.status = 'Error'
       } else if (lastWarning && lastWarning.trim()) {
         if (!pkg.warnings) pkg.warnings = []
+        const munkiWarningText = splitLogText(lastWarning)
         pkg.warnings.push({
           id: `munki-item-warning-${pkg.id}`,
-          message: lastWarning,
+          message: munkiWarningText.message,
+          details: munkiWarningText.details,
           timestamp: installs.munki.endTime || new Date().toISOString(),
           code: 'MUNKI_WARNING',
           package: pkg.name

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -1,3 +1,4 @@
+import { cleanLogText } from './logText'
 /**
  * Inline detail lines for an event row: what a run installed, warned about or
  * failed on, straight from its payload. Shared by the fleet events feed, the
@@ -40,7 +41,7 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
 
   const pushString = (target: InlineLine[], val: unknown) => {
     if (typeof val === 'string' && val.trim()) {
-      val.split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push({ text: s, isMessage: true }))
+      cleanLogText(val).split(';').map(s => s.trim()).filter(Boolean).forEach(s => target.push({ text: s, isMessage: true }))
     }
   }
   const pushItems = (target: InlineLine[], val: unknown) => {
@@ -51,7 +52,7 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
       } else if (item && typeof item === 'object') {
         const name = String(item.displayName || item.name || '').trim()
         const version = String(item.version || '').trim()
-        const detail = String(item.error || item.warning || item.message || '').trim()
+        const detail = cleanLogText(item.error || item.warning || item.message)
         const line = detail ? (name ? `${name}${version ? ` ${version}` : ''}: ${detail}` : detail) : `${name}${version ? ` ${version}` : ''}`
         if (line) target.push({ text: line, isMessage: Boolean(detail), name: name || undefined, version: version || undefined, message: detail || undefined })
       }
@@ -141,5 +142,5 @@ export function cachedEventPayload(eventId: string): unknown {
 /** Run messages get a mono chip; a bare "Name version" item stays plain text. */
 export const inlineLineClass = (line: InlineLine, tone: string) =>
   line.isMessage
-    ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${tone}`
+    ? `text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 whitespace-pre-wrap break-words ${tone}`
     : `text-sm break-words ${tone}`

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -12,7 +12,7 @@ const RESERVED_PAYLOAD_KEYS = new Set([
   'error_messages', 'warning_messages', 'module_status', 'warning_count', 'error_count',
   'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
   'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
-  'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
+  'operational_warnings', 'operational_errors', 'session_installs', 'session_updates', 'session_removals',
   'recommendation', 'collection_type', 'collectionType', 'operating_system', 'display_version',
   'version', 'uptime', 'previous_boot_time', 'current_boot_time',
 ])
@@ -28,7 +28,7 @@ const RESERVED_PAYLOAD_KEYS = new Set([
 //   Cimian:  { items: [{ name: "Chrome", version: "151.0.7922.170" }] }  (array of objects)
 // A line is either a run message (sentence from the client) or an item
 // ("Name version"); the flag decides how the row renders it.
-export type InlineLine = { text: string; isMessage: boolean }
+export type InlineLine = { text: string; isMessage: boolean; name?: string; version?: string; message?: string }
 export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[] } => {
   const errors: InlineLine[] = []
   const warnings: InlineLine[] = []
@@ -47,11 +47,11 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
       if (typeof item === 'string') {
         if (item.trim()) target.push({ text: item.trim(), isMessage: false })
       } else if (item && typeof item === 'object') {
-        const name = item.displayName || item.name || ''
-        const version = item.version ? ` ${item.version}` : ''
-        const detail = item.error || item.warning || item.message || ''
-        const line = detail ? (name ? `${name}${version}: ${detail}` : detail) : `${name}${version}`
-        if (line) target.push({ text: line, isMessage: Boolean(detail) })
+        const name = String(item.displayName || item.name || '').trim()
+        const version = String(item.version || '').trim()
+        const detail = String(item.error || item.warning || item.message || '').trim()
+        const line = detail ? (name ? `${name}${version ? ` ${version}` : ''}: ${detail}` : detail) : `${name}${version ? ` ${version}` : ''}`
+        if (line) target.push({ text: line, isMessage: Boolean(detail), name: name || undefined, version: version || undefined, message: detail || undefined })
       }
     }
   }
@@ -79,6 +79,10 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
   pushItems(errors, p.error_items)
   pushItems(warnings, p.warning_items)
   pushItems(errors, p.failed_items)
+  // Problems the client could not attribute to an item (catalog, manifest,
+  // download failures) arrive as operational_* arrays of { message }.
+  pushItems(errors, p.operational_errors)
+  pushItems(warnings, p.operational_warnings)
 
   // A client recommendation is a run message: the module is telling the
   // operator something, not naming a package.

--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -29,12 +29,14 @@ const RESERVED_PAYLOAD_KEYS = new Set([
 // A line is either a run message (sentence from the client) or an item
 // ("Name version"); the flag decides how the row renders it.
 export type InlineLine = { text: string; isMessage: boolean; name?: string; version?: string; message?: string }
-export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[] } => {
+export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; warnings: InlineLine[]; successes: string[]; isRemoval: boolean } => {
   const errors: InlineLine[] = []
   const warnings: InlineLine[] = []
   const successes: string[] = []
-  if (!payload || typeof payload !== 'object') return { errors, warnings, successes }
+  if (!payload || typeof payload !== 'object') return { errors, warnings, successes, isRemoval: false }
   const p = payload as Record<string, any>
+  // A removal run is a success, but reads in the Removed colour rather than green.
+  const isRemoval = String(p.action || '').toLowerCase() === 'remove' || Array.isArray(p.removed_items)
 
   const pushString = (target: InlineLine[], val: unknown) => {
     if (typeof val === 'string' && val.trim()) {
@@ -107,6 +109,7 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
     errors: dedupe(errors),
     warnings: dedupe(warnings),
     successes: Array.from(new Set(successes)),
+    isRemoval,
   }
 }
 

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -70,7 +70,7 @@ const RESERVED_KEYS = new Set([
   'error_messages', 'warning_messages', 'module_status', 'warning_count', 'error_count',
   'run_type', 'session_id', 'modules', 'modules_processed', 'message', 'summary',
   'items', 'action', 'duration_seconds', 'item_warning_count', 'operational_warning_count',
-  'operational_warnings', 'session_installs', 'session_updates', 'session_removals',
+  'operational_warnings', 'operational_errors', 'session_installs', 'session_updates', 'session_removals',
   'collection_type', 'collectionType', 'operating_system', 'display_version', 'version',
   'uptime', 'recommendation', 'previous_boot_time', 'current_boot_time',
   'previous_version', 'current_version', 'newlyInstalledItems', 'installed_items', 'removed_items',
@@ -156,11 +156,14 @@ export function summarizeEventPayload(payload: unknown): EventDetailSummary {
   const messages: EventDetailSummary['messages'] = []
   let suppressedMessageCount = 0
   for (const [key, tone] of [
-    ['errors', 'error'], ['error_messages', 'error'],
-    ['warnings', 'warning'], ['warning_messages', 'warning'],
+    ['errors', 'error'], ['error_messages', 'error'], ['operational_errors', 'error'],
+    ['warnings', 'warning'], ['warning_messages', 'warning'], ['operational_warnings', 'warning'],
     ['recommendation', 'warning'],
   ] as const) {
-    const { kept, suppressed } = splitMessages(p[key])
+    const raw = p[key]
+    // operational_* entries are { message } objects; everything else is text.
+    const source = Array.isArray(raw) ? raw.map(v => (v && typeof v === 'object' ? String((v as Record<string, unknown>).message ?? '') : v)) : raw
+    const { kept, suppressed } = splitMessages(source)
     suppressedMessageCount += suppressed
     for (const text of kept) messages.push({ tone, text })
   }

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -1,3 +1,4 @@
+import { cleanLogText } from './logText'
 /**
  * Turn a raw event payload into the sections the Recent Events accordion renders.
  *
@@ -107,7 +108,7 @@ function normalizeItem(raw: unknown): EventDetailItem | null {
   return {
     name,
     version: version ? String(version) : undefined,
-    detail: detail ? String(detail) : undefined,
+    detail: detail ? cleanLogText(detail) : undefined,
   }
 }
 
@@ -165,7 +166,7 @@ export function summarizeEventPayload(payload: unknown): EventDetailSummary {
     const source = Array.isArray(raw) ? raw.map(v => (v && typeof v === 'object' ? String((v as Record<string, unknown>).message ?? '') : v)) : raw
     const { kept, suppressed } = splitMessages(source)
     suppressedMessageCount += suppressed
-    for (const text of kept) messages.push({ tone, text })
+    for (const text of kept) messages.push({ tone, text: cleanLogText(text) })
   }
 
   const context: EventDetailSummary['context'] = []

--- a/src/lib/installs/systemProblems.ts
+++ b/src/lib/installs/systemProblems.ts
@@ -1,3 +1,4 @@
+import { cleanLogText } from '../logText'
 /**
  * System-level problems from managed-software runs: messages the client could
  * not attribute to any item (manifest and catalog retrieval, preflight and
@@ -29,12 +30,12 @@ const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000
 const MAX_SESSIONS = 8
 
 const nameless = (problem: any) => !String(problem?.name || '').trim()
-const messageOf = (problem: any) => String(problem?.message || '').trim()
+const messageOf = (problem: any) => cleanLogText(problem?.message)
 
 /** Legacy flattened strings: keep only lines that name no item. */
 function systemLines(raw: unknown): string[] {
   if (typeof raw !== 'string') return []
-  return raw
+  return cleanLogText(raw)
     .split(/;|\n/)
     .map(s => s.trim())
     .filter(s => s && !/^-{3,}$/.test(s) && !/^installer:/i.test(s) && itemNameFromMessage(s) === null)

--- a/src/lib/installs/systemProblems.ts
+++ b/src/lib/installs/systemProblems.ts
@@ -1,0 +1,124 @@
+/**
+ * System-level problems from managed-software runs: messages the client could
+ * not attribute to any item (manifest and catalog retrieval, preflight and
+ * postflight failures, inventory errors). They are session-scoped facts — a
+ * later clean run supersedes them but does not erase that they happened — so
+ * they are read from the sessions history, not only the latest payload.
+ */
+
+import { itemNameFromMessage } from './status'
+
+export interface SystemProblem {
+  tone: 'error' | 'warning'
+  message: string
+  sessionId?: string
+  time?: string
+}
+
+export interface SystemProblemsSummary {
+  /** Problems from the most recent finished session. */
+  current: SystemProblem[]
+  /** Problems from earlier sessions inside the window, newest first. */
+  recent: SystemProblem[]
+  /** The most recent session failed outright (errors, or failed status). */
+  latestFailed: boolean
+  /** The most recent session reported no items at all. */
+  latestItemless: boolean
+}
+
+const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000
+const MAX_SESSIONS = 8
+
+const nameless = (problem: any) => !String(problem?.name || '').trim()
+const messageOf = (problem: any) => String(problem?.message || '').trim()
+
+/** Legacy flattened strings: keep only lines that name no item. */
+function systemLines(raw: unknown): string[] {
+  if (typeof raw !== 'string') return []
+  return raw
+    .split(/;|\n/)
+    .map(s => s.trim())
+    .filter(s => s && !/^-{3,}$/.test(s) && !/^installer:/i.test(s) && itemNameFromMessage(s) === null)
+}
+
+export function collectSystemProblems(installs: any): SystemProblemsSummary {
+  const munki = installs?.munki
+  const cimian = installs?.cimian
+  const empty: SystemProblemsSummary = { current: [], recent: [], latestFailed: false, latestItemless: false }
+
+  if (munki) {
+    const sessions: any[] = Array.isArray(munki.sessions) ? munki.sessions : []
+    if (sessions.length > 0) {
+      const cutoff = Date.now() - RECENT_WINDOW_MS
+      const summary: SystemProblemsSummary = {
+        current: [],
+        recent: [],
+        latestFailed: String(sessions[0]?.status || '').toLowerCase() === 'failed'
+          || (sessions[0]?.error_items || []).length > 0,
+        latestItemless: !Array.isArray(munki.items) || munki.items.length === 0,
+      }
+      sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
+        const time = String(session?.end_time || session?.start_time || '')
+        if (index > 0 && time && new Date(time).getTime() < cutoff) return
+        const sessionId = String(session?.session_id || '')
+        for (const [key, tone] of [['error_items', 'error'], ['warning_items', 'warning']] as const) {
+          for (const problem of (session?.[key] || []) as any[]) {
+            if (!nameless(problem)) continue
+            const message = messageOf(problem)
+            if (!message) continue
+            const target = index === 0 ? summary.current : summary.recent
+            if (!target.some(p => p.message === message) && !summary.current.some(p => p.message === message)) {
+              target.push({ tone, message, sessionId, time })
+            }
+          }
+        }
+      })
+      return summary
+    }
+    // Legacy payload: only the latest run's flattened strings exist.
+    const errors = systemLines(munki.errors)
+    const warnings = systemLines(munki.warnings)
+    const status = String(munki.status || '').toLowerCase()
+    return {
+      current: [
+        ...errors.map(message => ({ tone: 'error' as const, message })),
+        ...warnings.map(message => ({ tone: 'warning' as const, message })),
+      ],
+      recent: [],
+      latestFailed: munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error'
+        || String(munki.errors || '').trim() !== '',
+      latestItemless: !Array.isArray(munki.items) || munki.items.length === 0,
+    }
+  }
+
+  if (cimian) {
+    const sessions: any[] = Array.isArray(cimian.sessions) ? cimian.sessions : []
+    if (sessions.length === 0) return empty
+    const cutoff = Date.now() - RECENT_WINDOW_MS
+    const summary: SystemProblemsSummary = {
+      current: [],
+      recent: [],
+      latestFailed: ['failed', 'error'].includes(String(sessions[0]?.status || '').toLowerCase()),
+      latestItemless: !Array.isArray(cimian.items) || cimian.items.length === 0,
+    }
+    sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
+      const time = String(session?.end_time || session?.start_time || '')
+      if (index > 0 && time && new Date(time).getTime() < cutoff) return
+      const status = String(session?.status || '').toLowerCase()
+      if (!['failed', 'error'].includes(status)) return
+      // Cimian sessions carry counts rather than message text; the failed
+      // session itself is the system-level fact worth surfacing.
+      const failures = Number(session?.failures ?? session?.packages_failed ?? 0)
+      const message = failures > 0
+        ? `Run ${session?.session_id || ''} failed (${failures} failure${failures === 1 ? '' : 's'})`
+        : `Run ${session?.session_id || ''} failed`
+      const target = index === 0 ? summary.current : summary.recent
+      if (!target.some(p => p.message === message) && !summary.current.some(p => p.message === message)) {
+        target.push({ tone: 'error', message, sessionId: String(session?.session_id || ''), time })
+      }
+    })
+    return summary
+  }
+
+  return empty
+}

--- a/src/lib/installs/systemProblems.ts
+++ b/src/lib/installs/systemProblems.ts
@@ -54,15 +54,18 @@ export function collectSystemProblems(installs: any): SystemProblemsSummary {
         current: [],
         recent: [],
         latestFailed: String(sessions[0]?.status || '').toLowerCase() === 'failed'
-          || (sessions[0]?.error_items || []).length > 0,
+          || ((sessions[0]?.error_items ?? sessions[0]?.errorItems ?? []) as any[]).length > 0,
         latestItemless: !Array.isArray(munki.items) || munki.items.length === 0,
       }
       sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
-        const time = String(session?.end_time || session?.start_time || '')
+        // Sessions arrive snake_case from the client but may be camelCased by
+        // normalizeKeys before they reach here; accept either spelling.
+        const time = String(session?.end_time || session?.endTime || session?.start_time || session?.startTime || '')
         if (index > 0 && time && new Date(time).getTime() < cutoff) return
-        const sessionId = String(session?.session_id || '')
-        for (const [key, tone] of [['error_items', 'error'], ['warning_items', 'warning']] as const) {
-          for (const problem of (session?.[key] || []) as any[]) {
+        const sessionId = String(session?.session_id || session?.sessionId || '')
+        for (const [keys, tone] of [[['error_items', 'errorItems'], 'error'], [['warning_items', 'warningItems'], 'warning']] as const) {
+          const list = (session?.[keys[0]] ?? session?.[keys[1]] ?? []) as any[]
+          for (const problem of list) {
             if (!nameless(problem)) continue
             const message = messageOf(problem)
             if (!message) continue
@@ -102,19 +105,20 @@ export function collectSystemProblems(installs: any): SystemProblemsSummary {
       latestItemless: !Array.isArray(cimian.items) || cimian.items.length === 0,
     }
     sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
-      const time = String(session?.end_time || session?.start_time || '')
+      const time = String(session?.end_time || session?.endTime || session?.start_time || session?.startTime || '')
       if (index > 0 && time && new Date(time).getTime() < cutoff) return
       const status = String(session?.status || '').toLowerCase()
       if (!['failed', 'error'].includes(status)) return
       // Cimian sessions carry counts rather than message text; the failed
       // session itself is the system-level fact worth surfacing.
       const failures = Number(session?.failures ?? session?.packages_failed ?? 0)
+      const id = session?.session_id || session?.sessionId || ''
       const message = failures > 0
-        ? `Run ${session?.session_id || ''} failed (${failures} failure${failures === 1 ? '' : 's'})`
-        : `Run ${session?.session_id || ''} failed`
+        ? `Run ${id} failed (${failures} failure${failures === 1 ? '' : 's'})`
+        : `Run ${id} failed`
       const target = index === 0 ? summary.current : summary.recent
       if (!target.some(p => p.message === message) && !summary.current.some(p => p.message === message)) {
-        target.push({ tone: 'error', message, sessionId: String(session?.session_id || ''), time })
+        target.push({ tone: 'error', message, sessionId: String(id), time })
       }
     })
     return summary

--- a/src/lib/installs/systemProblems.ts
+++ b/src/lib/installs/systemProblems.ts
@@ -16,17 +16,13 @@ export interface SystemProblem {
 }
 
 export interface SystemProblemsSummary {
-  /** The most recent finished session, so the card can name it. */
-  latestSessionId?: string
-  latestTime?: string
-  /** Problems from the most recent finished session. */
-  current: SystemProblem[]
-  /** Problems from earlier sessions inside the window, newest first. */
-  recent: SystemProblem[]
-  /** The most recent session failed outright (errors, or failed status). */
-  latestFailed: boolean
-  /** The most recent session reported no items at all. */
-  latestItemless: boolean
+  /** System-level problems from the most recent run that had any. */
+  problems: SystemProblem[]
+  /** Session the problems came from. */
+  sessionId?: string
+  time?: string
+  /** The most recent session failed outright and reported no items at all. */
+  failedWithoutItems: boolean
 }
 
 const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000
@@ -47,88 +43,60 @@ function systemLines(raw: unknown): string[] {
 export function collectSystemProblems(installs: any): SystemProblemsSummary {
   const munki = installs?.munki
   const cimian = installs?.cimian
-  const empty: SystemProblemsSummary = { current: [], recent: [], latestFailed: false, latestItemless: false }
+  const empty: SystemProblemsSummary = { problems: [], failedWithoutItems: false }
 
   if (munki) {
     const sessions: any[] = Array.isArray(munki.sessions) ? munki.sessions : []
     if (sessions.length > 0) {
+      const itemless = !Array.isArray(munki.items) || munki.items.length === 0
+      const latestFailed = String(sessions[0]?.status || '').toLowerCase() === 'failed'
       const cutoff = Date.now() - RECENT_WINDOW_MS
-      const summary: SystemProblemsSummary = {
-        latestSessionId: String(sessions[0]?.session_id || sessions[0]?.sessionId || ''),
-        latestTime: String(sessions[0]?.end_time || sessions[0]?.endTime || sessions[0]?.start_time || sessions[0]?.startTime || ''),
-        current: [],
-        recent: [],
-        latestFailed: String(sessions[0]?.status || '').toLowerCase() === 'failed'
-          || ((sessions[0]?.error_items ?? sessions[0]?.errorItems ?? []) as any[]).length > 0,
-        latestItemless: !Array.isArray(munki.items) || munki.items.length === 0,
-      }
-      sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
-        // Sessions arrive snake_case from the client but may be camelCased by
-        // normalizeKeys before they reach here; accept either spelling.
+      // The most recent run that raised system-level problems is the one the
+      // box reports; runs older than the window have aged out.
+      for (const session of sessions.slice(0, MAX_SESSIONS)) {
         const time = String(session?.end_time || session?.endTime || session?.start_time || session?.startTime || '')
-        if (index > 0 && time && new Date(time).getTime() < cutoff) return
-        const sessionId = String(session?.session_id || session?.sessionId || '')
+        if (time && new Date(time).getTime() < cutoff) break
+        const problems: SystemProblem[] = []
         for (const [keys, tone] of [[['error_items', 'errorItems'], 'error'], [['warning_items', 'warningItems'], 'warning']] as const) {
-          const list = (session?.[keys[0]] ?? session?.[keys[1]] ?? []) as any[]
-          for (const problem of list) {
+          for (const problem of ((session?.[keys[0]] ?? session?.[keys[1]] ?? []) as any[])) {
             if (!nameless(problem)) continue
             const message = messageOf(problem)
-            if (!message) continue
-            const target = index === 0 ? summary.current : summary.recent
-            if (!target.some(p => p.message === message) && !summary.current.some(p => p.message === message)) {
-              target.push({ tone, message, sessionId, time })
-            }
+            if (message && !problems.some(p => p.message === message)) problems.push({ tone, message })
           }
         }
-      })
-      return summary
+        if (problems.length > 0) {
+          return {
+            problems,
+            sessionId: String(session?.session_id || session?.sessionId || ''),
+            time,
+            failedWithoutItems: latestFailed && itemless,
+          }
+        }
+      }
+      return { ...empty, failedWithoutItems: latestFailed && itemless }
     }
     // Legacy payload: only the latest run's flattened strings exist.
     const errors = systemLines(munki.errors)
     const warnings = systemLines(munki.warnings)
     const status = String(munki.status || '').toLowerCase()
+    const failed = munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error'
+      || String(munki.errors || '').trim() !== ''
+    const itemless = !Array.isArray(munki.items) || munki.items.length === 0
     return {
-      current: [
+      problems: [
         ...errors.map(message => ({ tone: 'error' as const, message })),
         ...warnings.map(message => ({ tone: 'warning' as const, message })),
       ],
-      recent: [],
-      latestFailed: munki.lastRunSuccess === false || munki.lastRunSuccess === 0 || status === 'error'
-        || String(munki.errors || '').trim() !== '',
-      latestItemless: !Array.isArray(munki.items) || munki.items.length === 0,
+      failedWithoutItems: failed && itemless,
     }
   }
 
   if (cimian) {
     const sessions: any[] = Array.isArray(cimian.sessions) ? cimian.sessions : []
     if (sessions.length === 0) return empty
-    const cutoff = Date.now() - RECENT_WINDOW_MS
-    const summary: SystemProblemsSummary = {
-      latestSessionId: String(sessions[0]?.session_id || sessions[0]?.sessionId || ''),
-      latestTime: String(sessions[0]?.end_time || sessions[0]?.endTime || sessions[0]?.start_time || sessions[0]?.startTime || ''),
-      current: [],
-      recent: [],
-      latestFailed: ['failed', 'error'].includes(String(sessions[0]?.status || '').toLowerCase()),
-      latestItemless: !Array.isArray(cimian.items) || cimian.items.length === 0,
-    }
-    sessions.slice(0, MAX_SESSIONS).forEach((session, index) => {
-      const time = String(session?.end_time || session?.endTime || session?.start_time || session?.startTime || '')
-      if (index > 0 && time && new Date(time).getTime() < cutoff) return
-      const status = String(session?.status || '').toLowerCase()
-      if (!['failed', 'error'].includes(status)) return
-      // Cimian sessions carry counts rather than message text; the failed
-      // session itself is the system-level fact worth surfacing.
-      const failures = Number(session?.failures ?? session?.packages_failed ?? 0)
-      const id = session?.session_id || session?.sessionId || ''
-      const message = failures > 0
-        ? `Run ${id} failed (${failures} failure${failures === 1 ? '' : 's'})`
-        : `Run ${id} failed`
-      const target = index === 0 ? summary.current : summary.recent
-      if (!target.some(p => p.message === message) && !summary.current.some(p => p.message === message)) {
-        target.push({ tone: 'error', message, sessionId: String(id), time })
-      }
-    })
-    return summary
+    const itemless = !Array.isArray(cimian.items) || cimian.items.length === 0
+    const latestFailed = ['failed', 'error'].includes(String(sessions[0]?.status || '').toLowerCase())
+    return { ...empty, failedWithoutItems: latestFailed && itemless }
   }
 
   return empty

--- a/src/lib/installs/systemProblems.ts
+++ b/src/lib/installs/systemProblems.ts
@@ -16,6 +16,9 @@ export interface SystemProblem {
 }
 
 export interface SystemProblemsSummary {
+  /** The most recent finished session, so the card can name it. */
+  latestSessionId?: string
+  latestTime?: string
   /** Problems from the most recent finished session. */
   current: SystemProblem[]
   /** Problems from earlier sessions inside the window, newest first. */
@@ -51,6 +54,8 @@ export function collectSystemProblems(installs: any): SystemProblemsSummary {
     if (sessions.length > 0) {
       const cutoff = Date.now() - RECENT_WINDOW_MS
       const summary: SystemProblemsSummary = {
+        latestSessionId: String(sessions[0]?.session_id || sessions[0]?.sessionId || ''),
+        latestTime: String(sessions[0]?.end_time || sessions[0]?.endTime || sessions[0]?.start_time || sessions[0]?.startTime || ''),
         current: [],
         recent: [],
         latestFailed: String(sessions[0]?.status || '').toLowerCase() === 'failed'
@@ -99,6 +104,8 @@ export function collectSystemProblems(installs: any): SystemProblemsSummary {
     if (sessions.length === 0) return empty
     const cutoff = Date.now() - RECENT_WINDOW_MS
     const summary: SystemProblemsSummary = {
+      latestSessionId: String(sessions[0]?.session_id || sessions[0]?.sessionId || ''),
+      latestTime: String(sessions[0]?.end_time || sessions[0]?.endTime || sessions[0]?.start_time || sessions[0]?.startTime || ''),
       current: [],
       recent: [],
       latestFailed: ['failed', 'error'].includes(String(sessions[0]?.status || '').toLowerCase()),

--- a/src/lib/logText.ts
+++ b/src/lib/logText.ts
@@ -1,0 +1,27 @@
+/**
+ * Managed-software log text arrives raw from installer output: ANSI colour
+ * escapes, Windows line endings, trailing whitespace, runs of blank lines.
+ * Every renderer reads it through here so the text is plain and line breaks
+ * survive into the page.
+ */
+
+const ANSI = /\u001b\[[0-9;]*[A-Za-z]|\u001b/g
+
+export function cleanLogText(raw: unknown): string {
+  return String(raw ?? '')
+    .replace(ANSI, '')
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/\s+$/, ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+/** The first line stands as the message; the remainder is the detail block. */
+export function splitLogText(raw: unknown): { message: string; details?: string } {
+  const text = cleanLogText(raw)
+  const nl = text.indexOf('\n')
+  if (nl === -1) return { message: text }
+  return { message: text.slice(0, nl).trim(), details: text.slice(nl + 1).trim() || undefined }
+}

--- a/src/lib/modules/graphs/PlatformDistributionChart.tsx
+++ b/src/lib/modules/graphs/PlatformDistributionChart.tsx
@@ -473,6 +473,10 @@ export const PlatformDistributionChart: React.FC<PlatformDistributionChartProps>
     const platform = platformStats[0]
     const displayName = platform.platform === 'macOS' ? 'Macintosh' : platform.platform
     const totalDevices = platform.count
+    // A bar either has a real usage value or it is not a bar; the unclassified
+    // remainder is a footnote, not a category.
+    const knownUsageStats = usageStats.filter(stats => stats.usage !== 'Unknown')
+    const unknownUsageCount = usageStats.filter(stats => stats.usage === 'Unknown').reduce((sum, stats) => sum + stats.count, 0)
 
     return (
       <div className="space-y-3">
@@ -484,10 +488,13 @@ export const PlatformDistributionChart: React.FC<PlatformDistributionChartProps>
           <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
             {displayName} — {totalDevices} {totalDevices === 1 ? 'device' : 'devices'} — by Usage
           </span>
+          {unknownUsageCount > 0 && (
+            <span className="ml-auto text-xs text-gray-400 dark:text-gray-500">{unknownUsageCount} unknown</span>
+          )}
         </div>
 
         {/* Usage cards */}
-        {usageStats.map(stats => {
+        {knownUsageStats.map(stats => {
           const isExpanded = expandedUsage === stats.usage
 
           return (

--- a/src/lib/modules/widgets/EventDetails.tsx
+++ b/src/lib/modules/widgets/EventDetails.tsx
@@ -138,7 +138,7 @@ export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => 
                   <span className="text-xs text-gray-500 dark:text-gray-400 font-mono shrink-0">{item.version}</span>
                 )}
                 {item.detail && (
-                  <span className={`basis-full ml-3.5 text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[group.tone]}`}>{item.detail}</span>
+                  <span className={`basis-full ml-3.5 text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 whitespace-pre-wrap break-words ${TONE_TEXT[group.tone]}`}>{item.detail}</span>
                 )}
               </li>
             ))}
@@ -160,7 +160,7 @@ export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => 
               {messages.map((message, index) => (
                 <li
                   key={index}
-                  className={`text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[message.tone]}`}
+                  className={`text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 whitespace-pre-wrap break-words ${TONE_TEXT[message.tone]}`}
                 >
                   {message.text}
                 </li>

--- a/src/lib/modules/widgets/EventDetails.tsx
+++ b/src/lib/modules/widgets/EventDetails.tsx
@@ -138,7 +138,7 @@ export const EventDetails: React.FC<{ eventIds: string[] }> = ({ eventIds }) => 
                   <span className="text-xs text-gray-500 dark:text-gray-400 font-mono shrink-0">{item.version}</span>
                 )}
                 {item.detail && (
-                  <span className="basis-full pl-3.5 text-xs text-gray-500 dark:text-gray-400 break-words">{item.detail}</span>
+                  <span className={`basis-full ml-3.5 text-xs font-mono px-2.5 py-1.5 rounded bg-gray-100 dark:bg-gray-900/50 break-words ${TONE_TEXT[group.tone]}`}>{item.detail}</span>
                 )}
               </li>
             ))}

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -48,14 +48,15 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
   }, [eventId, kind, isBundle, autoFetch, payload])
 
   const extracted = extractInlineDetails(payload)
-  // Items-only rows still list the package a run message is about
-  // ("Could not process item X" becomes "X"); messages naming nothing stay
-  // in the expanded view.
+  // Items-only rows list the package each problem is about. Structured items
+  // (warning_items / error_items / failed_items) carry the name outright; a
+  // legacy run message gives it up by pattern ("Could not process item X" →
+  // "X"). Messages naming nothing stay in the expanded view.
   const toItems = (lines: InlineLine[]): InlineLine[] => {
     const out: InlineLine[] = []
     for (const line of lines) {
       if (!line.isMessage) { out.push(line); continue }
-      const name = itemNameFromMessage(line.text)
+      const name = line.name || itemNameFromMessage(line.text)
       if (name && !out.some(l => l.text === name)) out.push({ text: name, isMessage: false })
     }
     return out

--- a/src/lib/modules/widgets/EventInlineLines.tsx
+++ b/src/lib/modules/widgets/EventInlineLines.tsx
@@ -57,7 +57,9 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
     for (const line of lines) {
       if (!line.isMessage) { out.push(line); continue }
       const name = line.name || itemNameFromMessage(line.text)
-      if (name && !out.some(l => l.text === name)) out.push({ text: name, isMessage: false })
+      if (!name) continue
+      const text = line.version ? `${name} ${line.version}` : name
+      if (!out.some(l => l.text === text)) out.push({ text, isMessage: false })
     }
     return out
   }
@@ -65,11 +67,15 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
   const warnings = itemsOnly ? toItems(extracted.warnings) : extracted.warnings
   const successes = extracted.successes
   const hasDetails = errors.length > 0 || warnings.length > 0 || successes.length > 0
+  // Removals read in the Removed colour, matching the status pill; the summary
+  // text says "removed" before the payload has even loaded.
+  const isRemoval = extracted.isRemoval || /\bremoved$/i.test(summary.trim())
+  const successTone = isRemoval ? 'text-purple-700 dark:text-purple-300' : 'text-green-700 dark:text-green-300'
 
   if (!hasDetails) {
     return (
       <div className={className}>
-        <div className={`text-sm break-words ${SUMMARY_TONE[kind.toLowerCase()] || 'text-gray-900 dark:text-white'}`}>{summary}</div>
+        <div className={`text-sm break-words ${kind.toLowerCase() === 'success' ? successTone : (SUMMARY_TONE[kind.toLowerCase()] || 'text-gray-900 dark:text-white')}`}>{summary}</div>
         {loading && <div className="text-xs text-gray-400 dark:text-gray-500 mt-1 italic">Loading details…</div>}
       </div>
     )
@@ -84,7 +90,7 @@ export const EventInlineLines: React.FC<EventInlineLinesProps> = ({ eventId, kin
         <div key={`w-${i}`} className={inlineLineClass(m, 'text-yellow-700 dark:text-yellow-300')}>{m.text}</div>
       ))}
       {successes.map((m, i) => (
-        <div key={`s-${i}`} className="text-sm text-green-700 dark:text-green-300 break-words">{m}</div>
+        <div key={`s-${i}`} className={`text-sm break-words ${successTone}`}>{m}</div>
       ))}
     </div>
   )

--- a/src/lib/modules/widgets/RecentEventsWidget.tsx
+++ b/src/lib/modules/widgets/RecentEventsWidget.tsx
@@ -127,7 +127,15 @@ const getDeviceName = (event: FleetEvent, deviceNameMap: Record<string, string>)
 // Helper function to get event status icon
 const getStatusIcon = (kind: string) => {
   switch (kind.toLowerCase()) {
-    case 'success':
+    case 'removed':
+      return (
+        <div className="w-6 h-6 bg-purple-400 rounded-full flex items-center justify-center" title="Removed">
+          <svg className="w-3.5 h-3.5 text-white" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+          </svg>
+        </div>
+      )
+case 'success':
       return (
         <div className="w-6 h-6 bg-green-400 rounded-full flex items-center justify-center" title="Success">
           <svg className="w-3.5 h-3.5 text-white" fill="currentColor" viewBox="0 0 20 20">
@@ -609,7 +617,7 @@ export const RecentEventsTable: React.FC<RecentEventsTableProps> = ({
                                 >
                                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                                 </svg>
-                                {getStatusIcon(bundledEvent.kind)}
+                                {getStatusIcon(bundledEvent.kind.toLowerCase() === 'success' && /\bremoved$/i.test(bundledEvent.message.trim()) ? 'removed' : bundledEvent.kind)}
                               </div>
                             </td>
                             <td className="px-3 py-2.5 hidden md:table-cell">


### PR DESCRIPTION
Closes #82

- Collapsed rows list the affected items by name from `warning_items` / `error_items` / `failed_items` (name, version, message objects), not only by pattern-matching a message string, so a row with structured items no longer collapses to `2 warnings`.
- Expanded rows show each item with its version and its message as a mono chip in the group's tone, the same look message-only rows already had.
- Run-level `operational_warnings` / `operational_errors` (problems the client could not attribute to an item) now render as messages inline and in the expanded view; they were dropped before.