### PR TITLE
Renew kiosk sessions from a pinned kiosk cookie

### DIFF
--- a/app/kiosk/route.ts
+++ b/app/kiosk/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import { encode } from 'next-auth/jwt'
-import { matchKioskToken, KIOSK_ROLE, KIOSK_SESSION_DAYS } from '../../src/lib/kiosk/tokens'
+import { matchKioskToken, issueKioskSession } from '../../src/lib/kiosk/tokens'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,12 +10,14 @@ export const dynamic = 'force-dynamic'
  * Exchanges a kiosk token for a viewer session cookie and redirects to the
  * requested read-only page. The cookie is the same NextAuth JWT the Entra
  * flow issues, so the middleware and every page treat it as a signed-in
- * session; the role claim is what narrows it.
+ * session; the role claim is what narrows it. The token itself is pinned in
+ * a second cookie so the middleware can renew the session after NextAuth
+ * shortens it to the app's session lifetime.
  */
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token')
   const label = matchKioskToken(token)
-  if (!label) {
+  if (!label || !token) {
     return NextResponse.json({ error: 'Unauthorized', details: 'Unknown kiosk token' }, { status: 401 })
   }
 
@@ -25,32 +26,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Kiosk sessions are not configured' }, { status: 500 })
   }
 
-  const maxAge = KIOSK_SESSION_DAYS * 24 * 60 * 60
-  const jwt = await encode({
-    secret,
-    maxAge,
-    token: {
-      name: `Kiosk ${label}`,
-      email: `${label}@kiosk.reportmate`,
-      role: KIOSK_ROLE,
-      kiosk: label,
-    },
-  })
-
   const next = request.nextUrl.searchParams.get('next') || '/events'
   const target = next.startsWith('/') && !next.startsWith('//') ? next : '/events'
   const base = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin
   const response = NextResponse.redirect(new URL(target, base))
 
-  const secure = process.env.NODE_ENV === 'production'
-  response.cookies.set({
-    name: secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
-    value: jwt,
-    httpOnly: true,
-    sameSite: 'lax',
-    secure,
-    path: '/',
-    maxAge,
-  })
+  await issueKioskSession(response, { label, token, secret, secure: process.env.NODE_ENV === 'production' })
   return response
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
-import { viewerMayRead, KIOSK_ROLE } from './src/lib/kiosk/tokens'
+import { viewerMayRead, matchKioskToken, issueKioskSession, kioskCookieName, KIOSK_ROLE } from './src/lib/kiosk/tokens'
 
 // Define routes that should not trigger auto-redirect
 const publicRoutes = [
@@ -235,6 +235,26 @@ export default async function middleware(request: NextRequest) {
         }
       }
       return NextResponse.next()
+    }
+
+    // No live session, but a kiosk cookie: NextAuth re-issues session JWTs
+    // with its 24h maxAge, so a wall display's session lapses daily. While
+    // the pinned token is still listed, mint a fresh viewer session in place
+    // and carry on, under the same read-only rules.
+    const secure = process.env.NODE_ENV === 'production'
+    const kioskToken = request.cookies.get(kioskCookieName(secure))?.value
+    const kioskLabel = matchKioskToken(kioskToken)
+    if (kioskLabel && kioskToken && process.env.NEXTAUTH_SECRET) {
+      const readMethod = request.method === 'GET' || request.method === 'HEAD'
+      if (!readMethod || !viewerMayRead(pathname)) {
+        if (pathname.startsWith('/api/')) {
+          return NextResponse.json({ error: 'Forbidden', details: 'Kiosk sessions are read-only' }, { status: 403 })
+        }
+        return NextResponse.redirect(new URL('/events', process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin))
+      }
+      const response = NextResponse.next()
+      await issueKioskSession(response, { label: kioskLabel, token: kioskToken, secret: process.env.NEXTAUTH_SECRET, secure })
+      return response
     }
 
     // API routes answer with JSON 401 rather than an HTML redirect: fetch()

--- a/src/lib/kiosk/tokens.ts
+++ b/src/lib/kiosk/tokens.ts
@@ -4,14 +4,27 @@
  * A display that shows ReportMate all day should not hold a person's Entra
  * session. KIOSK_TOKENS carries one opaque token per screen (comma-separated,
  * sourced from Key Vault or Secrets Manager). Presenting a listed token to
- * /kiosk mints a long-lived NextAuth JWT with role "viewer": read-only pages
- * and read-only APIs, nothing else. Rotating the secret ends every session.
+ * /kiosk mints a NextAuth JWT with role "viewer": read-only pages and
+ * read-only APIs, nothing else. Rotating the secret ends every session.
+ *
+ * NextAuth's own session endpoint re-issues every session JWT with the app's
+ * session.maxAge (24 hours), so the long expiry stamped at /kiosk does not
+ * survive the first session fetch. The kiosk token is therefore pinned in a
+ * second, long-lived cookie, and the middleware mints a fresh viewer session
+ * from it whenever the session JWT has lapsed — a screen never lands on the
+ * sign-in page while its token is still listed.
  */
 
-import { timingSafeEqual } from 'crypto'
+import { encode } from 'next-auth/jwt'
+import type { NextResponse } from 'next/server'
 
 export const KIOSK_ROLE = 'viewer'
 export const KIOSK_SESSION_DAYS = 365
+
+export const sessionCookieName = (secure: boolean) =>
+  secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+export const kioskCookieName = (secure: boolean) =>
+  secure ? '__Secure-reportmate-kiosk' : 'reportmate-kiosk'
 
 /** Parse KIOSK_TOKENS as "label:token" or bare "token" entries. */
 export function kioskTokens(): Array<{ label: string; token: string }> {
@@ -29,10 +42,14 @@ export function kioskTokens(): Array<{ label: string; token: string }> {
     .filter(e => e.token.length >= 16)
 }
 
+/** Constant-time comparison that also runs in the edge middleware runtime. */
 function safeEqual(a: string, b: string): boolean {
-  const ab = Buffer.from(a)
-  const bb = Buffer.from(b)
-  return ab.length === bb.length && timingSafeEqual(ab, bb)
+  const ab = new TextEncoder().encode(a)
+  const bb = new TextEncoder().encode(b)
+  if (ab.length !== bb.length) return false
+  let diff = 0
+  for (let i = 0; i < ab.length; i++) diff |= ab[i] ^ bb[i]
+  return diff === 0
 }
 
 /** The label of the kiosk a presented token belongs to, or null. */
@@ -42,6 +59,30 @@ export function matchKioskToken(presented: string | null | undefined): string | 
     if (safeEqual(presented, token)) return label
   }
   return null
+}
+
+/**
+ * Set the viewer session for a kiosk on a response, with the kiosk token
+ * pinned beside it so the session can be re-minted after NextAuth shortens it.
+ */
+export async function issueKioskSession(
+  response: NextResponse,
+  opts: { label: string; token: string; secret: string; secure: boolean },
+): Promise<void> {
+  const maxAge = KIOSK_SESSION_DAYS * 24 * 60 * 60
+  const jwt = await encode({
+    secret: opts.secret,
+    maxAge,
+    token: {
+      name: `Kiosk ${opts.label}`,
+      email: `${opts.label}@kiosk.reportmate`,
+      role: KIOSK_ROLE,
+      kiosk: opts.label,
+    },
+  })
+  const base = { httpOnly: true, sameSite: 'lax' as const, secure: opts.secure, path: '/', maxAge }
+  response.cookies.set({ name: sessionCookieName(opts.secure), value: jwt, ...base })
+  response.cookies.set({ name: kioskCookieName(opts.secure), value: opts.token, ...base })
 }
 
 /**


### PR DESCRIPTION
NextAuth's session endpoint re-issues every session JWT with the app's 24h `session.maxAge`, so the 365-day expiry stamped by `/kiosk` did not survive the first session fetch: a wall display landed on the Entra sign-in page about a day after launch.

`/kiosk` now pins the kiosk token in a second long-lived cookie beside the session. When the middleware finds no live session but a pinned token that is still listed in `KIOSK_TOKENS`, it mints a fresh viewer session in place and continues under the same read-only rules (GET/HEAD on viewer pages and APIs; 403 for writes, redirect to `/events` for other pages). Rotating `KIOSK_TOKENS` still ends every kiosk session.

The token comparison no longer depends on Node's `crypto` so it runs in the edge middleware runtime.

Verified against a production build: exchange sets both cookies; a request with only the kiosk cookie gets 200 plus a renewed session; a bogus kiosk cookie redirects to sign-in; a write with the kiosk cookie gets 403; a non-viewer page redirects to `/events`.

Refs #74