### PR TITLE
Open a kiosk on the home page from Settings

### DIFF
--- a/app/kiosk/route.ts
+++ b/app/kiosk/route.ts
@@ -1,18 +1,34 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { matchKioskToken, issueKioskSession } from '../../src/lib/kiosk/tokens'
+import { safeKioskPath } from '../../src/lib/kiosk/role'
+import { getInternalApiHeaders } from '../../lib/api-auth'
 
 export const dynamic = 'force-dynamic'
+
+/** The kiosk home page from Settings; the events feed when it cannot be read. */
+async function kioskHomePath(): Promise<string> {
+  const apiBaseUrl = process.env.API_BASE_URL
+  if (!apiBaseUrl) return '/events'
+  try {
+    const response = await fetch(`${apiBaseUrl}/api/v1/settings`, { headers: getInternalApiHeaders(), cache: 'no-store' })
+    if (!response.ok) return '/events'
+    const data = await response.json()
+    return safeKioskPath(data?.value?.kiosk?.homePath)
+  } catch {
+    return '/events'
+  }
+}
 
 /**
  * GET /kiosk?token=<token>[&next=/events]
  *
  * Exchanges a kiosk token for a viewer session cookie and redirects to the
- * requested read-only page. The cookie is the same NextAuth JWT the Entra
- * flow issues, so the middleware and every page treat it as a signed-in
- * session; the role claim is what narrows it. The token itself is pinned in
- * a second cookie so the middleware can renew the session after NextAuth
- * shortens it to the app's session lifetime.
+ * display's home page (Settings → Kiosk Displays, or an explicit `next`). The
+ * cookie is the same NextAuth JWT the Entra flow issues, so the middleware and
+ * every page treat it as a signed-in session; the role claim is what narrows
+ * it. The token itself is pinned in a second cookie so the middleware can
+ * renew the session after NextAuth shortens it to the app's session lifetime.
  */
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token')
@@ -26,8 +42,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Kiosk sessions are not configured' }, { status: 500 })
   }
 
-  const next = request.nextUrl.searchParams.get('next') || '/events'
-  const target = next.startsWith('/') && !next.startsWith('//') ? next : '/events'
+  const next = request.nextUrl.searchParams.get('next')
+  const target = next ? safeKioskPath(next) : await kioskHomePath()
   const base = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_SITE_URL || request.nextUrl.origin
   const response = NextResponse.redirect(new URL(target, base))
 


### PR DESCRIPTION
`/kiosk` redirected to a hardcoded `/events` unless the URL carried `next=`. The kiosk home page is now a setting (Settings → Kiosk Displays), so the exchange reads it from the settings document and opens the display there; an explicit `next=` still wins, and both go through `safeKioskPath`, so only a same-origin path is ever used. When the settings cannot be read the feed remains the fallback.

Refs #74