### PR TITLE
Give Munki items held by the loop guard the INSTALL_LOOP code

### DIFF
--- a/src/lib/data-processing/modules/installs.ts
+++ b/src/lib/data-processing/modules/installs.ts
@@ -1166,7 +1166,7 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
           message: munkiErrorText.message,
           details: munkiErrorText.details,
           timestamp: installs.munki.endTime || new Date().toISOString(),
-          code: 'MUNKI_ERROR',
+          code: (pkg as any).hasInstallLoop ? 'INSTALL_LOOP' : 'MUNKI_ERROR',
           package: pkg.name
         })
         pkg.status = 'Error'
@@ -1178,7 +1178,7 @@ export function extractInstalls(deviceModules: any): InstallsInfo {
           message: munkiWarningText.message,
           details: munkiWarningText.details,
           timestamp: installs.munki.endTime || new Date().toISOString(),
-          code: 'MUNKI_WARNING',
+          code: (pkg as any).hasInstallLoop ? 'INSTALL_LOOP' : 'MUNKI_WARNING',
           package: pkg.name
         })
         if (pkg.status !== 'Error') pkg.status = 'Warning'


### PR DESCRIPTION
The Mac client now sends hasInstallLoop for Munki items the install-loop guard is holding; the Munki per-item warning and error paths stamp INSTALL_LOOP for them, matching the Windows path.

Closes #88