### PR TITLE
Read Management Logs from the management module

### DIFF
--- a/src/components/tabs/ManagementLogsSection.tsx
+++ b/src/components/tabs/ManagementLogsSection.tsx
@@ -4,19 +4,22 @@
  * Collapsible card, one inner tab per management-tool log root the device
  * reported (Managed Installs, Managed Bootstrap, Managed Reports, ...), and a
  * log picker inside each tab because every tool writes more than one file.
- * The module summary is fetched once; a tool's tails are fetched the first
- * time its tab is opened. Tools the device is not reporting never appear, and
- * a device with no logs module at all renders nothing.
+ * The summary comes from the management module's logs section, already on
+ * the page; a tool's tails are fetched the first time its tab is opened.
+ * Tools the device is not reporting never appear, and a device whose
+ * management module has no logs section renders nothing.
  */
 
 'use client'
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { CopyButton } from '../ui/CopyButton'
-import { extractLogs, logProductName, normalizeLogRoot, type LogFileEntry, type LogRoot, type LogsInfo, type LogTail } from '../../lib/data-processing/modules/logs'
+import { logProductName, normalizeLogRoot, type LogFileEntry, type LogRoot, type LogsInfo, type LogTail } from '../../lib/data-processing/modules/logs'
 
 interface ManagementLogsSectionProps {
   serialNumber?: string
+  /** The management module's logs section, read by extractLogs; null hides the card */
+  logs: LogsInfo | null
 }
 
 type TailState =
@@ -143,8 +146,7 @@ function tailByFile(tails: LogTail[]): Map<string, LogTail> {
   return map
 }
 
-export const ManagementLogsSection: React.FC<ManagementLogsSectionProps> = ({ serialNumber }) => {
-  const [logs, setLogs] = useState<LogsInfo | null>(null)
+export const ManagementLogsSection: React.FC<ManagementLogsSectionProps> = ({ serialNumber, logs }) => {
   const [expanded, setExpanded] = useState(false)
   const [activeTool, setActiveTool] = useState<string | null>(null)
   const [tails, setTails] = useState<Record<string, TailState>>({})
@@ -155,33 +157,13 @@ export const ManagementLogsSection: React.FC<ManagementLogsSectionProps> = ({ se
   // keyed by tool, so a late response is never applied to the wrong tab.
   const requestedTails = useRef<Set<string>>(new Set())
 
-  // Load the module summary (tails already stripped by the API). A device that
-  // has not reported the module, or a failed fetch, leaves the section hidden.
+  // A new device (or a refreshed management module) resets the tool selection
+  // and the fetched tails.
   useEffect(() => {
-    let cancelled = false
-    setLogs(null)
     setTails({})
-    setActiveTool(null)
     requestedTails.current = new Set()
-    if (!serialNumber) return
-
-    fetch(`/api/device/${encodeURIComponent(serialNumber)}/modules/logs`)
-      .then(async (response) => {
-        if (cancelled || !response.ok) return
-        const result = await response.json()
-        if (cancelled) return
-        const info = result?.success && result.data ? extractLogs({ logs: result.data }) : null
-        if (info && info.roots.length > 0) {
-          setLogs(info)
-          setActiveTool(info.roots[0].tool)
-        }
-      })
-      .catch((error) => {
-        console.error('[MANAGEMENT LOGS] Failed to load logs module:', error)
-      })
-
-    return () => { cancelled = true }
-  }, [serialNumber])
+    setActiveTool(logs && logs.roots.length > 0 ? logs.roots[0].tool : null)
+  }, [serialNumber, logs])
 
   // Fetch a tool's tails the first time its tab is opened while expanded.
   useEffect(() => {

--- a/src/components/tabs/ManagementTab.tsx
+++ b/src/components/tabs/ManagementTab.tsx
@@ -11,6 +11,7 @@ import { Icons } from '../widgets/shared'
 import { convertPowerShellObjects } from '../../lib/utils/powershell-parser'
 import { CopyButton } from '../ui/CopyButton'
 import { ManagementLogsSection } from './ManagementLogsSection'
+import { extractLogs } from '../../lib/data-processing/modules/logs'
 
 // Helper to parse osquery boolean strings ("true", "false", "1", "0") to boolean
 function parseBool(value: any): boolean {
@@ -214,6 +215,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
   const managedPolicies = management.managed_policies || management.managedPolicies || []
   const adeConfiguration = management.ade_configuration || management.adeConfiguration || {}
   const deviceIdentifiers = management.device_identifiers || management.deviceIdentifiers || {}
+  const managementLogs = extractLogs({ management })
   
   // Toggle profile expansion
   const toggleProfile = (identifier: string) => {
@@ -1337,7 +1339,7 @@ export const ManagementTab: React.FC<ManagementTabProps> = ({ device }) => {
       </div>
 
       {/* Management tool logs - one inner tab per Managed logs root */}
-      <ManagementLogsSection serialNumber={(device as any)?.serialNumber} />
+      <ManagementLogsSection serialNumber={(device as any)?.serialNumber} logs={managementLogs} />
 
       {/* Configuration Profiles Section - macOS profiles and Windows policy branches alike */}
       {profileEntries.length > 0 && (

--- a/src/lib/data-processing/modules/logs.ts
+++ b/src/lib/data-processing/modules/logs.ts
@@ -1,12 +1,13 @@
 /**
- * Logs Module - Reader Only
+ * Management Logs - Reader Only
  *
  * Both clients survey the platform's management-tool log roots
  * (C:\ProgramData\Managed*\logs on Windows, /Library/Managed * /logs on macOS)
- * and report, per root, the file inventory, the latest session summary and a
- * capped tail of the primary log. The API strips the tails from the device and
- * module payloads; /api/device/[serial]/logs/[tool] serves one root with its
- * tails. This reader only normalises the shape.
+ * and report them as the `logs` section of the management module: per root,
+ * the file inventory, the latest session summary, error and warning counts and
+ * capped tails of the most relevant logs. The API strips the tails from the
+ * device, info and module payloads; /api/device/[serial]/logs/[tool] serves one
+ * root with its tails. This reader only normalises the shape.
  */
 
 export interface LogFileEntry {
@@ -133,11 +134,11 @@ export function normalizeLogRoot(raw: any): LogRoot | null {
 }
 
 /**
- * Read the logs module. Returns null when the device has never reported it,
- * which the UI renders as an empty state rather than inventing content.
+ * Read the management module's logs section. Returns null when the device has
+ * never reported it, which the UI renders by omitting the section entirely.
  */
 export function extractLogs(modules: any): LogsInfo | null {
-  const raw = modules?.logs
+  const raw = modules?.management?.logs
   if (!raw || typeof raw !== 'object') return null
   const roots = Array.isArray(raw.roots)
     ? raw.roots.map(normalizeLogRoot).filter((r: LogRoot | null): r is LogRoot => r !== null)


### PR DESCRIPTION
The log survey is a section of the management module (`management.logs`), not a module of its own. The Logs card now takes its summary from the management data already on the page (the API strips the tails there too) instead of fetching a `logs` module, and keeps fetching one tool's tails from `/api/device/[deviceId]/logs/[tool]` when a tab opens.