### PR TITLE
Show the MDM log root first and parse Intune log lines as events

### DIFF
--- a/src/components/tabs/ManagementLogsSection.tsx
+++ b/src/components/tabs/ManagementLogsSection.tsx
@@ -125,6 +125,46 @@ function parseJsonlLine(raw: string): JsonlEvent {
   }
 }
 
+/**
+ * MDM agent logs are structured lines rather than JSON. Two formats are
+ * recognised and shown as event rows like events.jsonl:
+ *   CMTrace (Intune Management Extension on Windows):
+ *     <![LOG[message]LOG]!><time="HH:mm:ss.fffffff" date="M-d-yyyy" component="X" context="" type="1|2|3" thread="n" file="">
+ *   Intune MDM daemon on the Mac:
+ *     yyyy-MM-dd HH:mm:ss:SSS | IntuneMDM-Daemon | I|W|E | thread | Logger | message
+ */
+const CMTRACE_PATTERN = /^<!\[LOG\[([\s\S]*?)\]LOG\]!><time="([^"]*)"\s+date="([^"]*)"\s+component="([^"]*)"(?:\s+context="[^"]*")?\s+type="(\d)"(?:\s+thread="([^"]*)")?(?:\s+file="[^"]*")?>\s*$/
+const INTUNE_DAEMON_PATTERN = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}):(\d{3}) \| ([^|]+?) \| ([IWE]) \| ([^|]*?) \| ([^|]*?) \| ([\s\S]*)$/
+
+const CMTRACE_LEVELS: Record<string, string> = { '1': 'INFO', '2': 'WARN', '3': 'ERROR' }
+const DAEMON_LEVELS: Record<string, string> = { I: 'INFO', W: 'WARN', E: 'ERROR' }
+
+function parseStructuredLine(raw: string): JsonlEvent {
+  const cm = CMTRACE_PATTERN.exec(raw)
+  if (cm) {
+    const [, message, time, date, component, type, thread] = cm
+    const [m, d, y] = date.split('-')
+    const iso = y && m && d ? `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T${time.replace(/[+-]\d+$/, '')}` : undefined
+    const parsed = { time, date, component, type, thread, message }
+    return { raw, parsed, timestamp: iso, level: CMTRACE_LEVELS[type] ?? type, eventType: component, message }
+  }
+  const dm = INTUNE_DAEMON_PATTERN.exec(raw)
+  if (dm) {
+    const [, stamp, millis, process, level, thread, logger, message] = dm
+    const parsed = { timestamp: `${stamp}.${millis}`, process: process.trim(), level, thread: thread.trim(), logger: logger.trim(), message }
+    return { raw, parsed, timestamp: `${stamp.replace(' ', 'T')}.${millis}`, level: DAEMON_LEVELS[level] ?? level, eventType: logger.trim(), message }
+  }
+  return { raw, parsed: null }
+}
+
+/** True when most of the sampled lines are CMTrace or Intune daemon records. */
+function isStructuredTail(lines: string[]): boolean {
+  const sample = lines.slice(0, 40)
+  if (sample.length === 0) return false
+  const hits = sample.filter(line => CMTRACE_PATTERN.test(line) || INTUNE_DAEMON_PATTERN.test(line)).length
+  return hits * 2 >= sample.length
+}
+
 function formatEventTime(value?: string): string {
   if (!value) return ''
   const date = new Date(value)
@@ -209,7 +249,13 @@ export const ManagementLogsSection: React.FC<ManagementLogsSectionProps> = ({ se
   }, [tailLines, filter])
   const isJsonl = Boolean(currentFile && currentFile.toLowerCase().endsWith('.jsonl'))
   const isJson = Boolean(currentFile && currentFile.toLowerCase().endsWith('.json'))
-  const visibleEvents = useMemo(() => (isJsonl ? visibleLines.map(parseJsonlLine) : []), [isJsonl, visibleLines])
+  const isStructured = useMemo(() => !isJsonl && !isJson && isStructuredTail(tailLines), [isJsonl, isJson, tailLines])
+  const showEvents = isJsonl || isStructured
+  const visibleEvents = useMemo(() => {
+    if (isJsonl) return visibleLines.map(parseJsonlLine)
+    if (isStructured) return visibleLines.map(parseStructuredLine)
+    return []
+  }, [isJsonl, isStructured, visibleLines])
   // A .json tail is one document (session.json, status.json); pretty-print it when it parses whole.
   const prettyJson = useMemo(() => {
     if (!isJson || tailLines.length === 0) return null
@@ -467,7 +513,7 @@ export const ManagementLogsSection: React.FC<ManagementLogsSectionProps> = ({ se
                     <div className="p-6 text-center text-sm text-gray-500 dark:text-gray-400">No log lines reported</div>
                   ) : prettyJson !== null && !filter.trim() ? (
                     <pre className="p-4 bg-gray-900 text-gray-100 text-xs font-mono overflow-x-auto max-h-[500px] overflow-y-auto whitespace-pre-wrap break-all">{prettyJson}</pre>
-                  ) : isJsonl ? (
+                  ) : showEvents ? (
                     <div className="max-h-[500px] overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700">
                       {visibleEvents.map((event, index) => {
                         if (!event.parsed) {

--- a/src/lib/data-processing/modules/logs.ts
+++ b/src/lib/data-processing/modules/logs.ts
@@ -147,8 +147,25 @@ export function extractLogs(modules: any): LogsInfo | null {
     platform: pick(raw, 'platform'),
     collectedAt: pick(raw, 'collectedAt', 'collected_at') ?? pick(raw, 'collectionTimestamp'),
     moduleVersion: pick(raw, 'moduleVersion', 'module_version'),
-    roots,
+    roots: orderLogRoots(roots),
   }
+}
+
+/**
+ * Tab order: the MDM root first, then the management tools in the order the
+ * client reported them, then the OS installer log last.
+ */
+export function orderLogRoots(roots: LogRoot[]): LogRoot[] {
+  const rank = (root: LogRoot): number => {
+    const tool = root.tool.toLowerCase()
+    if (tool === 'mdm') return 0
+    if (tool === 'installer') return 2
+    return 1
+  }
+  return roots
+    .map((root, index) => ({ root, index }))
+    .sort((a, b) => rank(a.root) - rank(b.root) || a.index - b.index)
+    .map(({ root }) => root)
 }
 
 /** "Managed Installs" -> "Installs"; falls back to the tool key in title case */
@@ -171,10 +188,14 @@ const PRODUCT_NAMES: Record<string, { mac: string; windows: string }> = {
   encryption: { mac: 'Crypt', windows: 'Crypt Escrow' },
   users: { mac: 'ManageUsers', windows: 'ManageUsers' },
   utilities: { mac: 'Utilities', windows: 'Utilities' },
+  installer: { mac: 'Installer', windows: 'Installer' },
 }
 
 export function logProductName(root: Pick<LogRoot, 'name' | 'tool'>, platform?: string): string {
-  const names = PRODUCT_NAMES[root.tool.toLowerCase()]
+  const tool = root.tool.toLowerCase()
+  // The MDM root is named after the agent the client found (Intune, Jamf, ...).
+  if (tool === 'mdm') return (root.name || '').trim() || 'MDM'
+  const names = PRODUCT_NAMES[tool]
   if (!names) return logRootLabel(root)
   const isWindows = (platform || '').toLowerCase().startsWith('win')
   return isWindows ? names.windows : names.mac


### PR DESCRIPTION
Both clients now report two roots outside the Managed directories: mdm (the MDM agent's logs, named after the agent found) and installer (the OS installer log). This orders the Logs card's tabs MDM first, then the management tools as reported, then Installer last, names the MDM tab after the root (Intune, Jamf, ...), and renders the two Intune line formats as event rows the way events.jsonl already is: CMTrace records from the Intune Management Extension on Windows (type 1/2/3 as INFO/WARN/ERROR, component as the event type) and the Mac daemon's pipe-separated records (I/W/E, logger as the event type). A tail is treated as structured when at least half of its first 40 lines match either format; anything else keeps the plain line view.