### PR TITLE
Show the inventory install count under active devices instead of the usage footprint

### DIFF
--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -68,6 +68,11 @@ interface UtilizationApp {
   userCount: number
   activeDeviceCount?: number
   activeUserCount?: number
+  // Devices whose applications inventory lists the app, folded by the same
+  // alias rules as the usage row. This is the install figure; deviceCount
+  // is not (it bottoms out at the last baseline reset and, on macOS, only
+  // sees GUI sessions).
+  installedDeviceCount?: number
   lastUsed: string | null
   firstUsed: string | null
   devices: string[]
@@ -2202,7 +2207,7 @@ function ApplicationsPageContent() {
                         app.totalHours.toFixed(1),
                         app.launchCount,
                         app.activeDeviceCount ?? '',
-                        app.deviceCount,
+                        app.installedDeviceCount ?? '',
                         app.activeUserCount ?? '',
                         app.userCount,
                         app.lastUsed || '',
@@ -3338,9 +3343,9 @@ function ApplicationsPageContent() {
                             <div className={`text-sm ${(app.activeDeviceCount ?? 0) > 0 ? 'text-gray-900 dark:text-white' : 'text-gray-400 dark:text-gray-500'}`}>
                               {app.activeDeviceCount ?? app.deviceCount}
                             </div>
-                            {app.activeDeviceCount != null && app.activeDeviceCount !== app.deviceCount && (
-                              <div className="text-xs text-gray-500 dark:text-gray-400" title="Devices with any usage row, including background-only process time">
-                                {app.deviceCount} installed
+                            {app.installedDeviceCount != null && (
+                              <div className="text-xs text-gray-500 dark:text-gray-400" title="Devices whose applications inventory lists this app">
+                                {app.installedDeviceCount} installed
                               </div>
                             )}
                           </td>


### PR DESCRIPTION
The secondary line under Active Devices on the utilization table read "{deviceCount} installed", but deviceCount is the set of devices with a usage row in the window, not an install count. It bottoms out at the last baseline reset and on macOS only sees GUI sessions, so Chrome showed 105 installed the day after a reset against 847 in the inventory.

Renders the API's new installedDeviceCount (reportmate-api branch of the same name) there and in the CSV's Devices Installed column. deviceCount stays on the type for the sort and the widget aggregate. Until the API change is deployed the field is absent and the secondary line simply does not render.

tsc: no new errors at the changed lines; the four existing page.tsx errors (1165, 3929, 3930, 3985) predate this.