### PR TITLE
Show what a removal run removed, and stop calling it an install

### DIFF
--- a/src/lib/eventInlineDetails.ts
+++ b/src/lib/eventInlineDetails.ts
@@ -63,8 +63,11 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
   // { name, version } objects rather than a flat map, and always includes them
   // even when the summary message is a count. Read them so a multi-package run
   // can still list what it installed.
-  if (Array.isArray(p.items)) {
-    for (const item of p.items) {
+  // `removed_items` is the same shape; a removal run carries its packages there so
+  // the row can colour them as a removal rather than an install.
+  for (const list of [p.items, p.removed_items, p.installed_items]) {
+    if (!Array.isArray(list)) continue
+    for (const item of list) {
       if (typeof item === 'string') {
         if (item.trim()) successes.push(item.trim())
       } else if (item && typeof item === 'object') {
@@ -95,11 +98,17 @@ export const extractInlineDetails = (payload: unknown): { errors: InlineLine[]; 
 
   // Success payloads are a flat "package name → version" map — one line each.
   // Only a version-shaped value counts; other strings are context.
-  for (const [key, value] of Object.entries(p)) {
-    if (RESERVED_PAYLOAD_KEYS.has(key) || /count$/i.test(key)) continue
-    if (typeof value === 'string' && /^\d/.test(value.trim())) {
-      successes.push(`${key} ${value.trim()}`)
-    }
+  const flatPairs = Object.entries(p).filter(
+    ([key, value]) => !RESERVED_PAYLOAD_KEYS.has(key) && !/count$/i.test(key) && typeof value === 'string'
+  ) as Array<[string, string]>
+  // Munki reports no version for a removal, so its packages arrive as "Name": "".
+  // A blank value is only safe to read as a package when every pair is blank —
+  // otherwise it is a context field that happens to be empty.
+  const allBlank = flatPairs.length > 0 && flatPairs.every(([, value]) => value.trim() === '')
+  for (const [key, value] of flatPairs) {
+    const trimmed = value.trim()
+    if (trimmed === '') { if (allBlank) successes.push(key) }
+    else if (/^\d/.test(trimmed)) successes.push(`${key} ${trimmed}`)
   }
 
   const dedupe = (lines: InlineLine[]) => {

--- a/src/lib/eventPayloadDetails.test.ts
+++ b/src/lib/eventPayloadDetails.test.ts
@@ -29,6 +29,29 @@ describe('summarizeEventPayload', () => {
     expect(s.context).toContainEqual({ label: 'Duration', value: '1m 57s' })
   })
 
+  it('lists the packages a removal run names, and does not call them installs', () => {
+    // Munki reports no version for a removal, so its packages arrive as "Name": "".
+    const s = summarizeEventPayload({ FleetMate: '', MunkiReport: '' })
+    expect(s.groups.map(g => [g.label, g.tone])).toEqual([['Removed', 'neutral']])
+    expect(s.groups[0].items.map(i => i.name)).toEqual(['FleetMate', 'MunkiReport'])
+  })
+
+  it('lists removed_items under Removed', () => {
+    const s = summarizeEventPayload({
+      action: 'remove',
+      count: 2,
+      removed_items: [{ name: 'FleetMate', version: '2026.07.18.1820' }, { name: 'MunkiReport' }],
+    })
+    expect(s.groups.map(g => [g.label, g.tone])).toEqual([['Removed', 'neutral']])
+    expect(s.groups[0].items).toHaveLength(2)
+  })
+
+  it('still reads a flat install map, and ignores a blank field beside real versions', () => {
+    const s = summarizeEventPayload({ Teams: '26213.1006.5011.1671', BBEdit: '16.0.3', clientIdentifier: '' })
+    expect(s.groups.map(g => [g.label, g.tone])).toEqual([['Installed', 'success']])
+    expect(s.groups[0].items.map(i => i.name)).toEqual(['Teams', 'BBEdit'])
+  })
+
   it('separates failed and warning items by tone', () => {
     const s = summarizeEventPayload({
       failed_items: [{ name: 'RenderingManager', version: '2026.08.27.1706' }],

--- a/src/lib/eventPayloadDetails.ts
+++ b/src/lib/eventPayloadDetails.ts
@@ -142,16 +142,32 @@ export function summarizeEventPayload(payload: unknown): EventDetailSummary {
     const items = raw.map(normalizeItem).filter((i): i is EventDetailItem => i !== null)
     if (items.length) groups.push({ key, label, tone, items })
   }
-  const flatInstalled: EventDetailItem[] = []
-  for (const [key, value] of Object.entries(p)) {
-    if (RESERVED_KEYS.has(key) || typeof value !== 'string' || !value.trim()) continue
-    // A package pair is "Name": "version"; anything named like a counter
-    // (moduleCount) or whose value is not version-shaped is context, not a package
-    if (/count$/i.test(key) || !/^\d/.test(value.trim())) continue
-    flatInstalled.push({ name: key, version: value.trim() })
+  // Older clients send a run's packages as a flat "Name": "version" map rather than
+  // an array. Munki reports no version for a removal, so those pairs arrive blank —
+  // read a blank value as a package only when every pair is blank, otherwise it is
+  // a context field that happens to be empty.
+  const flatPairs = Object.entries(p).filter(
+    ([key, value]) => !RESERVED_KEYS.has(key) && !/count$/i.test(key) && typeof value === 'string'
+  ) as Array<[string, string]>
+  const allBlank = flatPairs.length > 0 && flatPairs.every(([, value]) => value.trim() === '')
+  const flatItems: EventDetailItem[] = []
+  for (const [key, value] of flatPairs) {
+    const version = value.trim()
+    if (version === '') { if (allBlank) flatItems.push({ name: key }) }
+    else if (/^\d/.test(version)) flatItems.push({ name: key, version })
   }
-  if (flatInstalled.length && !groups.some(g => g.key === 'installed_items')) {
-    groups.push({ key: 'installed_items', label: 'Installed', tone: 'success', items: flatInstalled })
+  // A payload that only names packages, with no version on any of them, is a removal:
+  // labelling it "Installed" in green is how "2 packages removed" came to read as
+  // an install. Anything else stays the install list it has always been.
+  const flatIsRemoval = allBlank || String(p.action ?? '').toLowerCase() === 'remove'
+  const flatKey = flatIsRemoval ? 'removed_items' : 'installed_items'
+  if (flatItems.length && !groups.some(g => g.key === flatKey)) {
+    groups.push({
+      key: flatKey,
+      label: flatIsRemoval ? 'Removed' : 'Installed',
+      tone: flatIsRemoval ? 'neutral' : 'success',
+      items: flatItems,
+    })
   }
 
   const messages: EventDetailSummary['messages'] = []


### PR DESCRIPTION
A Munki removal event arrives as a flat map of package names with empty values, because Munki reports no version for a removal. The flat-map reader required a version-shaped value, so both entries were dropped and "2 packages removed" expanded to "No further detail was reported for this event"; a removal that did carry versions was labelled **Installed** in green.

- Read a blank value as a package name, but only when every pair in the payload is blank, so a context field that happens to be empty is still ignored.
- Label a versionless or `action: "remove"` flat map as **Removed** in the neutral tone.
- Read `removed_items` and `installed_items` alongside `items` for the inline row lines.

This fixes the rendering for the clients already in the field. Paired with reportmate/reportmate-client-mac#88, which sends `removed_items` going forward, and emilycarru-its-infra/munki#36, which adds the uninstalled version.

Three tests added, exercised against the live payloads for events 11071758, 11071409 and 11071757. All 11 tests in `eventPayloadDetails.test.ts` pass; `eslint` clean. Note the repo's jest setup does not run as configured (`jest-environment-jsdom` and `jest-watch-typeahead` are not installed, and `moduleNameMapping` is a typo for `moduleNameMapper`) — pre-existing, not touched here.